### PR TITLE
handle ties in knnW in doctest

### DIFF
--- a/pysal/weights/Distance.py
+++ b/pysal/weights/Distance.py
@@ -70,7 +70,11 @@ def knnW(data, k=2, p=2, ids=None, pct_unique=0.25):
     >>> set([1,5,6]) == set(wnn3e.neighbors[0])
     True
     >>> wnn3m=knnW(data,p=1,k=3)
-    >>> set([1,2,5]) == set(wnn3m.neighbors[0])
+    >>> a = set([1,5,2])
+    >>> b = set([1,5,6])
+    >>> c = set([1,5,10])
+    >>> w0n = set(wnn3m.neighbors[0])
+    >>> a==w0n or b==w0n or c==w0n
     True
 
     ids


### PR DESCRIPTION
For the Manhattan metric on a regular latice with k=3 there are three possible solutions for a corner cell. This pr allows for random breaking of the ties. Working on a different branch exploring cKDTree made this apparent so I think we should change it here to make the readers aware of the possible non-uniqueness of the solutions returned. This will also ease a move to cKDTree later on.
