### PR TITLE
ENH: Move Geary's C calculations to Cython.

### DIFF
--- a/pysal/esda/fast_geary.pyx
+++ b/pysal/esda/fast_geary.pyx
@@ -1,0 +1,36 @@
+"""
+cython -a fast_geary.pyx
+gcc -shared -fPIC -O2 -Wall -fno-strict-aliasing -o fast_geary.so fast_geary.c -I/usr/include/python2.7 -I/usr/local/lib/python2.7/dist-packages/numpy/core/include/
+"""
+
+
+cimport cython
+from numpy import zeros
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.cdivision(True)
+def compute_geary_c(double[:] y, id_order, neighbor_offsets, weights, int n,
+                    double den):
+    cdef int i
+    cdef int j
+    cdef int ii
+    cdef int neighbor_j
+    cdef double wij
+    cdef int n_ids = len(id_order)
+    cdef int nobs = y.shape[0]
+    cdef double ys = 0.0
+    cdef double[:] y2 = zeros(nobs)
+    for ii in range(nobs):
+        y2[ii] = y[ii]**2
+
+    for i in range(n_ids):
+        i0 = id_order[i]
+        neighbors = neighbor_offsets[i0]
+        wijs = weights[i0]
+        for j in range(len(wijs)):
+            wij = wijs[j]
+            neighbor_j = neighbors[j]
+            ys = ys + wij * (y2[i] - 2 * y[i] * y[neighbor_j] + y2[neighbor_j])
+    a = (n - 1) * ys
+    return a / den

--- a/pysal/esda/geary.py
+++ b/pysal/esda/geary.py
@@ -5,6 +5,7 @@ __author__ = "Sergio J. Rey <srey@asu.edu> "
 
 import numpy as np
 import scipy.stats as stats
+from .fast_geary import compute_geary_c
 
 __all__ = ['Geary']
 
@@ -147,15 +148,6 @@ class Geary:
         self.seC_norm = vc_norm ** (0.5)
 
     def __calc(self, y):
-        ys = np.zeros(y.shape)
-        y2 = y ** 2
-        for i, i0 in enumerate(self.w.id_order):
-            neighbors = self.w.neighbor_offsets[i0]
-            wijs = self.w.weights[i0]
-            z = zip(neighbors, wijs)
-            ys[i] = sum([wij * (y2[i] - 2 * y[i] * y[j] + y2[j])
-                         for j, wij in z])
-        a = (self.n - 1) * sum(ys)
-        return a / self.den
-
-
+        return compute_geary_c(y.squeeze().astype(float), self.w.id_order,
+                               self.w.neighbor_offsets, self.w.weights,
+                               self.n, self.den)

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,13 @@ try:
 except ImportError:
     from distutils.core import setup
 
+from distutils.extension import Extension
+
+try:
+    from Cython.Distutils import build_ext
+except ImportError:
+    raise ImportError("Cython must be installed to build from source.")
+
 import sys
 import shutil
 import os
@@ -13,7 +20,7 @@ if sys.version_info[0] < 3:
 else:
     import builtins
 
-from pysal.version import version as dversion
+#from pysal.version import version as dversion
 
 with open('README.txt') as file:
     long_description = file.read()
@@ -84,7 +91,7 @@ def setup_package():
 
     setup(
         name='PySAL',
-        version=dversion,
+        version=VERSION,
         description="A library of spatial analysis functions.",
         long_description=long_description,
         maintainer="PySAL Developers",
@@ -110,7 +117,10 @@ def setup_package():
         ],
         packages=find_packages(exclude=["*.network", "*.network.*", "network.*", "network"]),
         package_data={'pysal': list(example_data_files)},
-        requires=['scipy']
+        requires=['scipy'],
+        cmdclass = {'build_ext' : build_ext},
+        ext_modules = [Extension('pysal.esda.fast_geary',
+                                 ['pysal/esda/fast_geary.pyx'])],
     )
 
 


### PR DESCRIPTION
Work in progress. Don't merge yet, and I'm in no particular hurry.

Is there any interest for moving some calculations to Cython? It does complicate the build process a bit, but once it's started you can roll other bottlenecks into it as well.

I benchmarked this on the test suite data for Geary and on a small-ish 100-400 observation problem I'm working on now. The former got a 25x speed-up the latter got around a 11x speed-up. Depending on the "usual" size assumptions, things can be optimized more in the Cython code. Usually handle small lists vs. medium-size and large lists/arrays a little differently because of overhead.

If there's interest, I can make the build a little more robust sometime this week. I.e., no checking in to git of .c files, they'd be generated at build time. That means to build from Github you need Cython. The .c files woud be included in source distributions, so that means a C compiler becomes necessary.

I'm generating nightly binary builds for windows of statsmodels, and could probably add pysal easily enough if this is a concern.
