### PR TITLE
ENH: handle the case of an ergodic distribution where one state has 0 probability

### DIFF
--- a/pysal/spatial_dynamics/ergodic.py
+++ b/pysal/spatial_dynamics/ergodic.py
@@ -118,7 +118,9 @@ def fmpt(P):
     I = np.identity(k)
     Z = la.inv(I - P + A)
     E = np.ones_like(Z)
-    D = np.diag(1. / np.diag(A))
+    A_diag = np.diag(A)
+    A_diag = A_diag + (A_diag==0)
+    D = np.diag(1. / A_diag)
     Zdg = np.diag(np.diag(Z))
     M = (I - Z + E * Zdg) * D
     return M


### PR DESCRIPTION
This is in reference to https://groups.google.com/forum/#!topic/openspace-list/wj0A3_VhLrU

Numpy would issue a warning of divide by zero. This occurs in cases where the chain is irregular resulting in the  estimated "ergodic" distribution with k states is such that one or more of the states has a 0 probability. Since the chain is irregular it does not have an ergodic distribution.

This pr handles the divide by zero case.
