### PR TITLE
Replacing 0 by min value in choropleths

### DIFF
--- a/pysal/contrib/viz/mapping.py
+++ b/pysal/contrib/viz/mapping.py
@@ -489,7 +489,7 @@ def base_choropleth_classif(map_obj, values, classification='quantiles', \
     cmap = cm.get_cmap(cmap, k+1)
     map_obj.set_cmap(cmap)
 
-    boundaries.insert(0,0)
+    boundaries.insert(0, values.min())
     norm = clrs.BoundaryNorm(boundaries, cmap.N)
     map_obj.set_norm(norm)
 


### PR DESCRIPTION
Replacing 0 by min value in the series to be inserted in the boundaries of classified choropleths. This fixes a small bug when creating choropleths of series with negative values.

[I should have created a small branch for the PR, sorry, I didn't realize until too late. It's a very small thing nevertheless]
