### PR TITLE
Dict to unique value mapper

### DIFF
--- a/pysal/contrib/viz/mapping.py
+++ b/pysal/contrib/viz/mapping.py
@@ -389,7 +389,7 @@ def base_choropleth_classless(map_obj, values, cmap='Greys' ):
         map_obj.set_array(values)
     return map_obj
 
-def base_choropleth_unique(map_obj, values,  clrs='hot_r'):
+def base_choropleth_unique(map_obj, values,  cmap='hot_r'):
     '''
     Set coloring based on unique values from a map object
     ...

--- a/pysal/contrib/viz/mapping.py
+++ b/pysal/contrib/viz/mapping.py
@@ -389,7 +389,7 @@ def base_choropleth_classless(map_obj, values, cmap='Greys' ):
         map_obj.set_array(values)
     return map_obj
 
-def base_choropleth_unique(map_obj, values,  cmap='hot_r'):
+def base_choropleth_unique(map_obj, values,  clrs='hot_r'):
     '''
     Set coloring based on unique values from a map object
     ...
@@ -401,8 +401,11 @@ def base_choropleth_unique(map_obj, values,  cmap='hot_r'):
                       Output from map_X_shp
     values          : array
                       Numpy array with values to map
-    cmap            : str
-                      Matplotlib coloring scheme
+    clrs            : dict/str
+                      [Optional. Default='hot_r'] Dictionary mapping {value:
+                      color}. Alternatively, a string can be passed specifying
+                      the Matplotlib coloring scheme for a random assignment
+                      of {value: color}
 
     Returns
     -------
@@ -412,11 +415,16 @@ def base_choropleth_unique(map_obj, values,  cmap='hot_r'):
                       unique value coloring
 
     '''
-    uvals = np.unique(values)
-    colormap = getattr(plt.cm, cmap)
-    colors = [colormap(i) for i in np.linspace(0, 0.9, len(uvals))]
-    colors = np.random.permutation(colors)
-    colormatch = {val: col for val, col in zip(uvals, colors)}
+    if type(clrs) == str:
+        uvals = np.unique(values)
+        colormap = getattr(plt.cm, clrs)
+        colors = [colormap(i) for i in np.linspace(0, 0.9, len(uvals))]
+        colors = np.random.permutation(colors)
+        colormatch = {val: col for val, col in zip(uvals, colors)}
+    elif type(clrs) == dict:
+        colormatch = clrs
+    else:
+        raise Exception("`clrs` can only take a str or a dict")
 
     if isinstance(map_obj, mpl.collections.PolyCollection):
         pvalues = _expand_values(values, map_obj.shp2dbf_row)

--- a/pysal/contrib/viz/mapping.py
+++ b/pysal/contrib/viz/mapping.py
@@ -401,7 +401,7 @@ def base_choropleth_unique(map_obj, values,  clrs='hot_r'):
                       Output from map_X_shp
     values          : array
                       Numpy array with values to map
-    clrs            : dict/str
+    cmap            : dict/str
                       [Optional. Default='hot_r'] Dictionary mapping {value:
                       color}. Alternatively, a string can be passed specifying
                       the Matplotlib coloring scheme for a random assignment
@@ -415,16 +415,16 @@ def base_choropleth_unique(map_obj, values,  clrs='hot_r'):
                       unique value coloring
 
     '''
-    if type(clrs) == str:
+    if type(cmap) == str:
         uvals = np.unique(values)
-        colormap = getattr(plt.cm, clrs)
+        colormap = getattr(plt.cm, cmap)
         colors = [colormap(i) for i in np.linspace(0, 0.9, len(uvals))]
         colors = np.random.permutation(colors)
         colormatch = {val: col for val, col in zip(uvals, colors)}
-    elif type(clrs) == dict:
-        colormatch = clrs
+    elif type(cmap) == dict:
+        colormatch = cmap
     else:
-        raise Exception("`clrs` can only take a str or a dict")
+        raise Exception("`cmap` can only take a str or a dict")
 
     if isinstance(map_obj, mpl.collections.PolyCollection):
         pvalues = _expand_values(values, map_obj.shp2dbf_row)


### PR DESCRIPTION
Adding the option to pass a dictionary to explicitly assign colors to unique value mapper. This doesn't break previous API (as it stays as the default) but makes it possible to assign specific colors to unique value choropleths. Technically, it's all it's needed for easy and straightforward LISA mapping.