### PR TITLE
Handle case where a region has a 0 share.

### DIFF
--- a/pysal/inequality/theil.py
+++ b/pysal/inequality/theil.py
@@ -118,6 +118,7 @@ class TheilD:
         ng.shape = (ng.size,)  # ensure ng is 1-d
         n = y.shape[0]
         # between group inequality
+        sg = sg + (sg==0) # handle case when a partition has 0 for sum
         bg = np.multiply(sg, np.log(mm(np.diag(n * 1. / ng), sg))).sum(axis=0)
         self.T = T
         self.bg = bg


### PR DESCRIPTION
When running permutations it is possible for a region to have all zeros for the attribute in question (if the original data has zeros) and if this happened we were taking the log of 0. So this handles that case.