### PR TITLE
Network from Lattice

### DIFF
--- a/pysal/network/floyd-warshall and repeat-dijkstra.ipynb
+++ b/pysal/network/floyd-warshall and repeat-dijkstra.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import pysal as ps\n",
+    "import fw\n",
+    "import time\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "N = ps.network.network.Network(ps.examples.get_path('geodanet/streets.shp'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here I'll just illustrate the floyd warshall algorithm's usage. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3.38626980782\n"
+     ]
+    }
+   ],
+   "source": [
+    "tfw = time.time()\n",
+    "dfw, pfw = fw.floyd_warshall(N)\n",
+    "tfw = time.time() - tfw\n",
+    "print tfw"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This implementation uses the standard 3-nested for loop structure. It requires a network object, and can take an alternate edge cost dictionary as a keyword. In addition, it can handle directed graphs with a boolean keyword. \n",
+    "\n",
+    "It returns two dicts of dicts, each with outer keys of the origins and inner keys of the destinations. \n",
+    "\n",
+    "`dfw` is the distance dictionary, containing all distances from nodes to nodes. The distance from a node to itself is zero by default. \n",
+    "\n",
+    "`pfw` is the precedence or path dictionary containing all distances from nodes to nodes. This contains the steps to take from start to destination. So, if you have a path $A \\rightarrow B \\rightarrow E \\rightarrow D \\rightarrow C$, the list would be $[B, E, D, C]$, as it's four steps from $A$ to $C$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.16067194939\n"
+     ]
+    }
+   ],
+   "source": [
+    "trd = time.time()\n",
+    "N.node_distance_matrix()\n",
+    "trd = time.time() - trd\n",
+    "print trd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Floyd-Warshall is slow wrt. repeat dijkstra here. It's got a triple `for` loop through the nodes. But, if `streets.shp` were denser, $V >> N$, it might win out. Do we have a dense network to test that out on?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "np.testing.assert_allclose(N.alldistances[0][0], dfw[0].values())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "for idx in N.alldistances:\n",
+    "    np.testing.assert_allclose(N.alldistances[idx][0], dfw[idx].values())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "But, distances are the same. Predecessor networks are harder to compare due to the behavior I mentioned in [#576](https://github.com/pysal/pysal/issues/576). "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 72,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "starts_rd = []\n",
+    "nostarts_rd = []\n",
+    "\n",
+    "starts_fw = []\n",
+    "nostarts_fw = []\n",
+    "for start in N.alldistances:\n",
+    "    for dest, path in N.alldistances[idx][1].iteritems():\n",
+    "        if start == dest:\n",
+    "            pass\n",
+    "        elif path[-1] != start:\n",
+    "            nostarts_rd.append((start,dest))\n",
+    "        else:\n",
+    "            starts_rd.append((start,dest))\n",
+    "for start in pfw.keys():\n",
+    "    for dest,path in pfw[start].iteritems():\n",
+    "        if start == dest:\n",
+    "            pass\n",
+    "        elif path[0] != start:\n",
+    "            nostarts_fw.append((start,dest))\n",
+    "        else: \n",
+    "            starts_fw.append((start,dest))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 73,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "38534 167\n",
+      "52670 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "print len(noends_rd), len(ends_rd)\n",
+    "print len(noends_fw), len(ends_fw)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So, all of the floyd-warshall paths end with the destination node, but some of the repeat dijkstra paths are inconsistent. Sometimes they're the same and both leave out the starting node:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[3, 23, 22, 20, 19, 170, 2]\n",
+      "[3, 23, 22, 20, 19, 170, 2]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print N.alldistances[0][1][3]\n",
+    "print pfw[0][3][::-1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And sometimes they're different, and dijkstra includes the starting node:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[217, 79, 216, 63, 62, 174, 20, 228, 116, 119, 229]\n",
+      "[217, 79, 216, 63, 62, 174, 20, 228, 116, 119]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print N.alldistances[229][1][217]\n",
+    "print pfw[229][217][::-1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "I can't tell why though. 167 that end in the "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/pysal/network/fw-and-rd.ipynb
+++ b/pysal/network/fw-and-rd.ipynb
@@ -1,0 +1,256 @@
+{
+ "metadata": {
+  "name": "",
+  "signature": "sha256:8b52f827a2925a9285cec8ea299b649abc0379c6dc1b8e64461377fe911c4660"
+ },
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "import pysal as ps\n",
+      "import fw\n",
+      "import time\n",
+      "import numpy as np"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 4
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "N = ps.network.network.Network(ps.examples.get_path('geodanet/streets.shp'))"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 5
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Here I'll just illustrate the floyd warshall algorithm's usage. "
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "tfw = time.time()\n",
+      "dfw, pfw = fw.floyd_warshall(N)\n",
+      "tfw = time.time() - tfw\n",
+      "print tfw"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "2.90875315666\n"
+       ]
+      }
+     ],
+     "prompt_number": 6
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "This implementation uses the standard 3-nested for loop structure. It requires a network object, and can take an alternate edge cost dictionary as a keyword. In addition, it can handle directed graphs with a boolean keyword. \n",
+      "\n",
+      "It returns two dicts of dicts, each with outer keys of the origins and inner keys of the destinations. \n",
+      "\n",
+      "`dfw` is the distance dictionary, containing all distances from nodes to nodes. The distance from a node to itself is zero by default. \n",
+      "\n",
+      "`pfw` is the precedence or path dictionary containing all distances from nodes to nodes. This contains the steps to take from start to destination. So, if you have a path $A \\rightarrow B \\rightarrow E \\rightarrow D \\rightarrow C$, the list would be $[B, E, D, C]$, as it's four steps from $A$ to $C$."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "trd = time.time()\n",
+      "N.node_distance_matrix()\n",
+      "trd = time.time() - trd\n",
+      "print trd"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "1.0536608696\n"
+       ]
+      }
+     ],
+     "prompt_number": 7
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Floyd-Warshall is slow wrt. repeat dijkstra here. It's got a triple `for` loop through the nodes. But, if `streets.shp` were denser, $V >> N$, it might win out. Do we have a dense network to test that out on?"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "np.testing.assert_allclose(N.alldistances[0][0], dfw[0].values())"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 8
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "for idx in N.alldistances:\n",
+      "    np.testing.assert_allclose(N.alldistances[idx][0], dfw[idx].values())"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 9
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "But, distances are the same. Predecessor networks are harder to compare due to the behavior I mentioned in [#576](https://github.com/pysal/pysal/issues/576). "
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "starts_rd = []\n",
+      "nostarts_rd = []\n",
+      "\n",
+      "starts_fw = []\n",
+      "nostarts_fw = []\n",
+      "for start in N.alldistances:\n",
+      "    for dest, path in N.alldistances[idx][1].iteritems():\n",
+      "        if start == dest:\n",
+      "            pass\n",
+      "        elif path[-1] != start:\n",
+      "            nostarts_rd.append((start,dest))\n",
+      "        else:\n",
+      "            starts_rd.append((start,dest))\n",
+      "for start in pfw.keys():\n",
+      "    for dest,path in pfw[start].iteritems():\n",
+      "        if start == dest:\n",
+      "            pass\n",
+      "        elif path[0] != start:\n",
+      "            nostarts_fw.append((start,dest))\n",
+      "        else: \n",
+      "            starts_fw.append((start,dest))"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 10
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "print len(nostarts_rd), len(starts_rd)\n",
+      "print len(nostarts_fw), len(starts_fw)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "39445 172\n",
+        "52670 0\n"
+       ]
+      }
+     ],
+     "prompt_number": 13
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "So, all of the floyd-warshall paths end with the destination node, but some of the repeat dijkstra paths are inconsistent. Sometimes they're the same and both leave out the starting node:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "print N.alldistances[0][1][3]\n",
+      "print pfw[0][3][::-1]"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "[3, 23, 22, 20, 19, 170, 2]\n",
+        "[3, 23, 22, 20, 19, 170, 2]\n"
+       ]
+      }
+     ],
+     "prompt_number": 14
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "And sometimes they're different, and dijkstra includes the starting node:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "print N.alldistances[229][1][217]\n",
+      "print pfw[229][217][::-1]"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "[217, 79, 216, 63, 62, 174, 20, 228, 116, 119, 229]\n",
+        "[217, 79, 216, 63, 62, 174, 20, 228, 116, 119]\n"
+       ]
+      }
+     ],
+     "prompt_number": 15
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "I can't tell why though. 167 that end in the destination node... that's not the total number of nodes. I'm wondering if it's something wonky related to the leftovers from inserting and removing nodes from the candidate list."
+     ]
+    }
+   ],
+   "metadata": {}
+  }
+ ]
+}

--- a/pysal/network/fw.py
+++ b/pysal/network/fw.py
@@ -2,9 +2,36 @@ from collections import defaultdict
 import pysal as ps
 import numpy as np
 
-ntw = ps.network.network.Network(ps.examples.get_path('geodanet/streets.shp'))
-
 def floyd_warshall(ntw, cost = None, directed = False):
+    """
+    Uses Floyd & Warshall's algorithm in O(n^3) time using O(nm) initialization
+    and O(n^2) space. 
+
+    Parameters
+    ----------
+    ntw : pysal network object
+    cost : dict
+           key is tuple of start,end nodes of the edge
+           value is the cost of traversing the arc
+           if not set, defaults to the self.edge_lengths value of ntw
+    directed : bool
+               True if the network is directed
+               False if the network is not directed
+               default is False, meaning the edges are added both forwards and
+               backwards, i.e. (2,3) contains edges (2,3) and (3,2). 
+
+    Returns
+    -------
+    dist: dict of dicts
+          outer dictinoary key is the node id at the start of the path (start)
+          inner dictionary key is the node id at the end of the path (dest)
+          inner dictionary value is the distance from outer key to inner key
+
+    pred: dict of dicts
+          outer dictionary key is the node id at the start of the path (start)
+          inner dictionary key is the node id at the end of the path (dest)
+          inner dictionary value lists steps from start ending at dest
+    """
     dist = defaultdict(lambda : defaultdict(lambda : np.inf)) #defaultdict requires callable
     pred = defaultdict(dict)
     

--- a/pysal/network/fw.py
+++ b/pysal/network/fw.py
@@ -1,0 +1,38 @@
+from collections import defaultdict
+import pysal as ps
+import numpy as np
+
+ntw = ps.network.network.Network(ps.examples.get_path('geodanet/streets.shp'))
+
+def floyd_warshall(ntw, cost = None, directed = False):
+    dist = defaultdict(lambda : defaultdict(lambda : np.inf)) #defaultdict requires callable
+    pred = defaultdict(dict)
+    
+    if not cost:
+        cost = ntw.edge_lengths
+
+    #populate initial predecessor and distance dictionaries
+    for node,neighbors in ntw.adjacencylist.iteritems():
+        for neighbor in neighbors:
+            if (node,neighbor) in cost.keys():
+                dist[node][neighbor] = cost[(node,neighbor)]
+                pred[neighbor][node] = [node] #forward: node -> neighb
+                if not directed:
+                    pred[node][neighbor] = [neighbor] #backward: neighb -> node 
+            elif (neighbor,node) in cost.keys():
+                dist[node][neighbor] = cost[(neighbor, node)]
+                pred[node][neighbor] = [neighbor] #forward: neighb -> node
+                if not directed:
+                    pred[neighbor][node] = [node] #backward: node -> neighb
+        dist[node][node] = 0
+        pred[node][node] = []
+#    return dist, pred
+
+    #update precedence and distance using intermediate paths
+    for inter in ntw.node_list:
+        for start in ntw.node_list:
+            for dest in ntw.node_list:
+                if dist[start][dest] > dist[start][inter] + dist[inter][dest]:
+                    dist[start][dest] = dist[start][inter] + dist[inter][dest]
+                    pred[start][dest] = pred[start][inter] + pred[inter][dest]
+    return dist, pred

--- a/pysal/network/network.py
+++ b/pysal/network/network.py
@@ -17,22 +17,23 @@ __all__ = ["Network", "PointPattern", "NetworkG", "NetworkK", "NetworkF"  ]
 class Network:
 
     """
-    Spatially constrained network representation and analytical functionality.
+    Spatially constrained network representation with analytical functionality.
 
     Parameters
     -----------
     in_shp : string
-             A topoligically correct input shapefile
+             A topologically correct input shapefile
 
     Attributes
     ----------
     in_shp : string
              input shapefile name
+    
+    adjacencylist : dict
+                    key is the id of the node
+                    value is a list containing nodes adjacent to key
 
-    adjacencylist : list
-                    of lists storing node adjacency
-
-    nodes : dict
+nodes : dict
             key are tuple of node coords and value is the node ID
 
     edge_lengths : dict

--- a/pysal/network/ntw_from_w.py
+++ b/pysal/network/ntw_from_w.py
@@ -1,0 +1,61 @@
+import numpy as np
+import operator as op
+
+def ntw_from_w(path, W = None):
+    """
+    Construction of the dual network from a lattice shapefile
+    
+    Parameters
+    ----------
+    
+    path : string
+           path to shapefile 
+    
+    Returns
+    -------
+    ntw : network
+          a pysal.network.network.Network object
+    """
+
+    ntw = ps.network.network.Network()
+
+    #read shapefile stuff
+    ntw.in_shp = shp
+    shp = ps.open(shp)
+    
+    if 'rook' in W:
+        W = ps.rook_from_shapefile
+    elif not W or 'queen' in W:
+        W = ps.rook_from_shapefile
+  
+    #set node_list and edges using the weights
+    ed = set()
+    ntw.node_list = []
+    for poly,neighbs in W.neighbors.iteritems():
+        tl = [(p, n) for p,n in zip([poly]*len(neighbs), neighbs) ]
+        ed.update(tl)
+        ntw.node_list.append(poly) #add key to the node_list
+    ed = list(ed)
+    ed.sort(key=op.itemgetter(0)) #sort on first element of tup
+    ntw.edges = ed
+    
+    #set nodes and node_coords if shp exists
+    #there's some index problems here:
+    #weights usu. 0-index but shps usu. 1-index
+    #so, for now, any call against shps will decrement index
+
+    ntw.nodes = {poly.centroid: poly.id-1 for poly in shp}
+
+    ntw.node_coords = {poly.id-1: poly.centroid for poly in shp}#invert!
+    
+    ntw.edge_lengths = {edge: np.linalg.norm((ntw.node_coords[edge[0]],\
+        ntw.node_coords[edge[1]])) for edge in ntw.edges}
+
+    #no pp's
+    ntw.pointpatterns = None
+
+    #this is just weights
+    ntw.adjacencylist = W.neighbors
+    
+    ntw.extractgraph()   
+    return ntw

--- a/pysal/network/ntw_from_w.py
+++ b/pysal/network/ntw_from_w.py
@@ -24,9 +24,9 @@ def ntw_from_w(path, W = None):
     shp = ps.open(shp)
     
     if 'rook' in W:
-        W = ps.rook_from_shapefile
+        W = ps.rook_from_shapefile(path)
     elif not W or 'queen' in W:
-        W = ps.rook_from_shapefile
+        W = ps.queen_from_shapefile(path)
   
     #set node_list and edges using the weights
     ed = set()


### PR DESCRIPTION
Adds a function, `ntw_from_w` that constructs a `pysal.network,network.Network()` object from a lattice shapefile, using some spatial weights matrix. This allows us to port lattices into networks to solve problems with network structure like flow, assignment, or partition.

Currently, this arbitrarily assigns the centroids of the polygon to their dual network node.

This works best with contiguity weights, as the distances are computed from centroids to other centroids. I'd be curious on perspectives on how to change the edge distances given non-binary weights or using Luc's new spherical geometry code. Currently, this uses `numpy.linalg.norm`, so it's an easy swap. 







