### PR TITLE
Updates for coveralls

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,8 @@
+[run]
+omit = 
+    __init__.py
+    */contrib/*
+    */test/*
 [report]
 omit = 
     __init__.py 

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,5 @@
-[run]
-branch = True
-omit = __init__.py pysal/contrib/* */test/*
+[report]
+omit = 
+    __init__.py 
+    */contrib/* 
+    */test/*


### PR DESCRIPTION
This PR is trying to modify the coverage report returned via travis to omit __init__ and */contrib/* files.  I will manually verify the omission is working and comment when ready for review and merge.