### PR TITLE
stubbed in minimal tests

### DIFF
--- a/pysal/network/tests/test_network.py
+++ b/pysal/network/tests/test_network.py
@@ -1,0 +1,36 @@
+import pysal as ps
+import unittest
+
+class TestNetwork(unittest.TestCase):
+
+    def setUp(self):
+        self.ntw = ps.Network(ps.examples.get_path('geodanet/streets.shp'))
+
+    def tearDown(self):
+        pass
+
+    def test_extract_network(self):
+        self.assertEqual(len(self.ntw.edges), 303)
+        self.assertEqual(len(self.ntw.nodes), 230)
+
+        edgelengths = self.ntw.edge_lengths.values()
+        self.assertAlmostEqual(sum(edgelengths), 104414.0920159, places=5)
+
+
+        self.assertIn(0,self.ntw.adjacencylist[1])
+        self.assertIn(0, self.ntw.adjacencylist[2])
+        self.assertNotIn(0, self.ntw.adjacencylist[3])
+
+    def test_contiguity_weights(self):
+        w = self.ntw.contiguityweights(graph=False)
+
+        self.assertEqual(w.n, 303)
+        self.assertEqual(w.histogram,
+                         [(2, 35), (3, 89), (4, 105), (5, 61), (6, 13)])
+
+    def test_contiguity_weights_graph(self):
+        w = self.ntw.contiguityweights(graph=True)
+
+        self.assertEqual(w.n, 179)
+        self.assertEqual(w.histogram,
+                         [(2, 2), (3, 2), (4, 45), (5, 82), (6, 48)])


### PR DESCRIPTION
To run these independently

```bash
$ cd pysal/pysal/network
$ nosetests
```

When you have a chunk done, you can run

```bash
$ cd pysal/pysal/network
$ nosetests --with-coverage --cover-package=pysal
```

This assumes that you have the coverage tools installed locally (they are pip installable).  This will generate a bunch of output (alphabetical).  Focus on:

```bash
pysal.network                            1      0   100%
pysal.network.analysis                 103     85    17%   10-30, 33-34, 37-41, 44-47, 59-64, 67-76, 85-94, 97-106, 117-125, 128-134, 137-144, 147-158, 174-186
pysal.network.network                  496    344    31%   271, 278, 286, 297-309, 336-337, 364-366, 389-484, 509-522, 528-538, 568-600, 616-620, 623-631, 654-728, 747-814, 853, 896, 938, 965-1041, 1060-1061, 1065-1068, 1104-1134, 1148-1152, 1157-1160, 1162-1163
pysal.network.util                      97     84    13%   13-30, 50-57, 61-75, 79-83, 102-126, 130-138, 141-158
```

Then line numbers are the uncovered lines.