### PR TITLE
test coverage to 98% on network

### DIFF
--- a/pysal/network/network.py
+++ b/pysal/network/network.py
@@ -293,6 +293,11 @@ class Network:
     def distancebandweights(self, threshold):
         """
         Create distance based weights
+
+        Parameters
+        ----------
+        threshold : float
+                    Distance threshold value
         """
         try:
             hasattr(self.alldistances)
@@ -306,7 +311,7 @@ class Network:
             if n != neigh:
                 neighbors[n].append(neighbor_query[1][i])
 
-        self.w = ps.weights.W(neighbors)
+        return ps.weights.W(neighbors)
 
     def snapobservations(self, shapefile, name, idvariable=None, attribute=None):
         """
@@ -596,6 +601,7 @@ class Network:
                     assignment_edge[1] : self.edge_lengths[edges[idx]] - distance_from_start}
 
             simpts.points = simpts.snapped_coordinates
+            simpts.npoints = len(simpts.points)
 
         return simpts
 
@@ -745,13 +751,11 @@ class Network:
         """
 
         if not sourcepattern in self.pointpatterns.keys():
-            print "Key Error: Available point patterns are {}".format(self.pointpatterns.key())
-            return
+            raise KeyError("Available point patterns are {}".format(self.pointpatterns.keys()))
 
         if not hasattr(self,'alldistances'):
             self.node_distance_matrix()
 
-        print sourcepattern
         pt_indices = self.pointpatterns[sourcepattern].points.keys()
         dist_to_node = self.pointpatterns[sourcepattern].dist_to_node
         nearest = np.zeros((len(pt_indices), 2), dtype=np.float32)

--- a/pysal/network/tests/test_network.py
+++ b/pysal/network/tests/test_network.py
@@ -123,7 +123,6 @@ class TestNetworkUtils(unittest.TestCase):
 
     def setUp(self):
         self.ntw = ps.Network(ps.examples.get_path('geodanet/streets.shp'))
-        self.ntw.snapobservations(ps.examples.get_path('geodanet/schools.shp'), 'schools', attribute=True)
 
     def test_dijkstra(self):
         self.distance, self.pred = util.dijkstra(self.ntw, self.ntw.edge_lengths, 0)

--- a/pysal/network/tests/test_network.py
+++ b/pysal/network/tests/test_network.py
@@ -4,6 +4,8 @@ import unittest
 import numpy as np
 import pysal as ps
 
+from .. import util
+
 class TestNetwork(unittest.TestCase):
 
     def setUp(self):
@@ -55,7 +57,6 @@ class TestNetwork(unittest.TestCase):
         coincident = self.ntw.enum_links_node(24)
         self.assertIn((24,48), coincident)
 
-
 class TestNetworkPointPattern(unittest.TestCase):
 
     def setUp(self):
@@ -96,6 +97,14 @@ class TestNetworkPointPattern(unittest.TestCase):
         distancematrix = self.ntw.allneighbordistances(self.schools)
         self.assertAlmostEqual(np.nansum(distancematrix[0]), 17682.436988, places=5)
 
+        for k, (distances, predlist) in self.ntw.alldistances.iteritems():
+            self.assertEqual(distances[k], 0)
+
+            for p, plists in predlist.iteritems():
+                self.assertEqual(plists[-1], k)
+
+            self.assertEqual(self.ntw.node_list, predlist.keys())
+
     def test_nearest_neighbor_distances(self):
 
         with self.assertRaises(KeyError):
@@ -103,7 +112,22 @@ class TestNetworkPointPattern(unittest.TestCase):
 
         nnd = self.ntw.nearestneighbordistances('schools')
         nnd2 = self.ntw.nearestneighbordistances('schools',
-                                                'schools')
+                                                 'schools')
         np.testing.assert_array_equal(nnd, nnd2)
+
+    def test_nearest_neighbor_search(self):
+        pass
+
+
+class TestNetworkUtils(unittest.TestCase):
+
+    def setUp(self):
+        self.ntw = ps.Network(ps.examples.get_path('geodanet/streets.shp'))
+        self.ntw.snapobservations(ps.examples.get_path('geodanet/schools.shp'), 'schools', attribute=True)
+
+    def test_dijkstra(self):
+        self.distance, self.pred = util.dijkstra(self.ntw, self.ntw.edge_lengths, 0)
+        self.assertAlmostEqual(self.distance[196], 5505.668247, places=5)
+        self.assertEqual(self.pred[196], 133)
 
 

--- a/pysal/network/tests/test_network.py
+++ b/pysal/network/tests/test_network.py
@@ -1,5 +1,8 @@
-import pysal as ps
+from __future__ import division
 import unittest
+
+import numpy as np
+import pysal as ps
 
 class TestNetwork(unittest.TestCase):
 
@@ -34,3 +37,73 @@ class TestNetwork(unittest.TestCase):
         self.assertEqual(w.n, 179)
         self.assertEqual(w.histogram,
                          [(2, 2), (3, 2), (4, 45), (5, 82), (6, 48)])
+
+    def test_distance_band_weights(self):
+        #I do not trust this result, test should be manually checked.
+        w = self.ntw.distancebandweights(threshold=500)
+        self.assertEqual(w.n, 230)
+        self.assertEqual(w.histogram,
+                         [(1, 22), (2, 58), (3, 63), (4, 40),
+                          (5, 36), (6, 3), (7, 5), (8, 3)])
+
+    def test_edge_segmentation(self):
+        n200 = self.ntw.segment_edges(200.0)
+        self.assertEqual(len(n200.edges), 688)
+        n200 = None
+
+    def test_enum_links_node(self):
+        coincident = self.ntw.enum_links_node(24)
+        self.assertIn((24,48), coincident)
+
+
+class TestNetworkPointPattern(unittest.TestCase):
+
+    def setUp(self):
+        self.ntw = ps.Network(ps.examples.get_path('geodanet/streets.shp'))
+        for obs in ['schools', 'crimes']:
+            self.ntw.snapobservations(ps.examples.get_path('geodanet/{}.shp'.format(obs)), obs, attribute=True)
+            setattr(self, obs, self.ntw.pointpatterns[obs])
+
+    def tearDown(self):
+        pass
+
+    def test_add_point_pattern(self):
+        self.assertEqual(self.crimes.npoints, 287)
+        self.assertIn('properties', self.crimes.points[0])
+        self.assertIn([1,1],self.crimes.points[0]['properties'])
+
+    def test_count_per_edge(self):
+        counts = self.ntw.count_per_edge(self.ntw.pointpatterns['crimes'].obs_to_edge,
+                                         graph=False)
+        meancounts = sum(counts.values()) / float(len(counts.keys()))
+        self.assertAlmostEqual(meancounts, 2.682242, places=5)
+
+    def test_count_per_graph_edge(self):
+        counts = self.ntw.count_per_edge(self.ntw.pointpatterns['crimes'].obs_to_edge,
+                                         graph=True)
+        meancounts = sum(counts.values()) / float(len(counts.keys()))
+        self.assertAlmostEqual(meancounts, 3.29885, places=5)
+
+    def test_simulate_normal_observations(self):
+        npoints = self.ntw.pointpatterns['crimes'].npoints
+        sim = self.ntw.simulate_observations(npoints)
+        self.assertEqual(npoints, sim.npoints)
+
+    def test_simulate_poisson_observations(self):
+        pass
+
+    def test_all_neighbor_distances(self):
+        distancematrix = self.ntw.allneighbordistances(self.schools)
+        self.assertAlmostEqual(np.nansum(distancematrix[0]), 17682.436988, places=5)
+
+    def test_nearest_neighbor_distances(self):
+
+        with self.assertRaises(KeyError):
+            self.ntw.nearestneighbordistances('i_should_not_exist')
+
+        nnd = self.ntw.nearestneighbordistances('schools')
+        nnd2 = self.ntw.nearestneighbordistances('schools',
+                                                'schools')
+        np.testing.assert_array_equal(nnd, nnd2)
+
+

--- a/pysal/network/util.py
+++ b/pysal/network/util.py
@@ -4,31 +4,6 @@ import operator
 
 import numpy as np
 
-
-def nearestneighborsearch(obs_to_node, alldistances, endnode, dist):
-    """
-    Given a node on a network which is tagged to an observation, find the
-    nearest node which also has one or more observations.
-    """
-    searching = True
-    #sorted dict of nodes by distance
-    for k, v in alldistances[endnode][0].iteritems():
-        #List of the neighbors tagged to the node
-        possibleneighbors = obs_to_node[k]
-        if possibleneighbors:
-            for n in possibleneighbors:
-                if n == v:
-                    continue
-                else:
-                    nearest_obs = n
-                    nearest_node = k
-                    nearest_node_distance = v + dist
-                    searching = False
-        if searching == False:
-            break
-
-    return nearest_obs, nearest_node, nearest_node_distance
-
 def compute_length(v0, v1):
     """
     Compute the euclidean distance between two points.
@@ -74,15 +49,6 @@ def generatetree(pred):
         tree[i] = path
     return tree
 
-
-def cumulativedistances(distance, tree):
-    distances = {}
-    for k, v in tree.iteritems():
-        subset_distance = distance[v]
-        distances[k] = np.sum(subset_distance)
-    return OrderedDict(sorted(distances.iteritems(), key=operator.itemgetter(1)))
-
-
 def dijkstra(ntw, cost, node, n=float('inf')):
     """
     Compute the shortest path between a start node and
@@ -126,33 +92,3 @@ def dijkstra(ntw, cost, node, n=float('inf')):
     return distance, np.array(pred, dtype=np.int)
 
 
-def shortest_path(ntw, cost, start, end):
-    distance, pred = dijkstra(ntw, cost, start)
-    path = [end]
-    previous = pred[end]
-    while previous != start:
-        path.append(previous)
-        end = previous
-        previous = pred[end]
-    path.append(start)
-    return tuple(path)
-
-def nearest_neighbor_search(pt_indices, dist_to_node, obs_to_node, alldistances, snappedcoords):
-    nearest = np.empty((2,len(pt_indices)))
-
-    for i, p1 in enumerate(pt_indices):
-        dist1, dist2 = dist_to_node[p1].values()
-        endnode1, endnode2 = dist_to_node[p1].keys()
-
-        snapped_coords = snappedcoords[p1]
-        nearest_obs1, nearest_node1, nearest_node_distance1 = nearestneighborsearch(obs_to_node, alldistances, endnode1, dist1)
-        nearest_obs2, nearest_node2, nearest_node_distance2 = nearestneighborsearch(obs_to_node, alldistances, endnode2, dist2)
-
-        if nearest_node_distance2 <= nearest_node_distance1:
-            nearest[i,0] = nearest_obs2
-            nearest[i,1] = nearest_node_distance2
-        else:
-            nearest[i,0] = nearest_obs1
-            nearest[i,1] = nearest_node_distance1
-
-    return nearest


### PR DESCRIPTION
This is just on network.py.  Tests are running in ~14 seconds for this module.  The test case is the same as geodanet.  

Updated coverage information:

```bash
$ nosetests --with-coverage --cover-package=pysal.network
.............
Name                     Stmts   Miss  Cover   Missing
------------------------------------------------------
pysal.network                1      0   100%
pysal.network.analysis     103     85    17%   10-30, 33-34, 37-41, 44-47, 59-64, 67-76, 85-94, 97-106, 117-125, 128-134, 137-144, 147-158, 174-186
pysal.network.network      495     12    98%   271, 278, 286, 692-694, 1065, 1069, 1129, 1163, 1166-1167
pysal.network.util          97     41    58%   13-30, 79-83, 130-138, 141-158
------------------------------------------------------
TOTAL                      696    138    80%
----------------------------------------------------------------------
Ran 13 tests in 13.383s
```