### PR TITLE
Re-enable doctests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - python setup.py sdist >/dev/null
   #- nosetests --processes=-1 --process-timeout=60 --verbosity=1 --ignore-files=collection --exclude-dir=pysal/contrib
   #- nosetests
-  - nosetests --with-coverage --cover-package=pysal 
+  - nosetests --with-coverage --cover-package=pysal --with-doctest
   #- cd doc; make pickle; make doctest
 notifications:
     email:


### PR DESCRIPTION
The March14 fix for sphinx and travis-ci compatibility also killed doctests.  This PR re-enables doctests via Travis without making any alteration to Sphinx.

The linked Travis Build are the results from my master:  https://travis-ci.org/jlaura/pysal/jobs/66811136
This PR should also generate Travis-CI output with the culprits.

The network doctest failures are fixed in another PR.  The other failures will need attention, but perhaps on a different PR (some are in SPREG and look like rounding issues).

Others are in gamma.py and weights.py.