### PR TITLE
turning off generatetree

### DIFF
--- a/pysal/network/network.py
+++ b/pysal/network/network.py
@@ -627,7 +627,8 @@ class Network:
         for node in self.node_list:
             distance, pred = util.dijkstra(self, self.edge_lengths, node, n=float('inf'))
             pred = np.array(pred)
-            tree = util.generatetree(pred)
+            #tree = util.generatetree(pred)
+            tree = None
             self.alldistances[node] = (distance, tree)
             self.distancematrix[node] = distance
 

--- a/pysal/network/tests/test_network.py
+++ b/pysal/network/tests/test_network.py
@@ -100,10 +100,12 @@ class TestNetworkPointPattern(unittest.TestCase):
         for k, (distances, predlist) in self.ntw.alldistances.iteritems():
             self.assertEqual(distances[k], 0)
 
-            for p, plists in predlist.iteritems():
-                self.assertEqual(plists[-1], k)
+            # turning off the tests associated with util.generatetree() for now,
+            # these can be restarted if that functionality is used in the future 
+            #for p, plists in predlist.iteritems():
+            #    self.assertEqual(plists[-1], k)
 
-            self.assertEqual(self.ntw.node_list, predlist.keys())
+            #self.assertEqual(self.ntw.node_list, predlist.keys())
 
     def test_nearest_neighbor_distances(self):
 


### PR DESCRIPTION
This PR addresses issue #621 and replaces PR #637.  By turning off generatetree() the time to compute a distance matrix is cut by approximately 90% (ymmv).