### PR TITLE
kdtree changes for arc distance

### DIFF
--- a/pysal/__init__.py
+++ b/pysal/__init__.py
@@ -83,6 +83,7 @@ from pysal.core.util.weight_converter import weight_convert
 import pysal.spreg
 import pysal.examples
 from pysal.network.network import Network, NetworkG, NetworkK, NetworkF
+from pysal.cg.kdtree import KDTree
 
 
 # Load the IOHandlers

--- a/pysal/esda/getisord.py
+++ b/pysal/esda/getisord.py
@@ -66,7 +66,7 @@ class G:
 
     Examples
     --------
-    >>> from pysal.weights.Distance import DistanceBand
+    >>> from pysal.weights.Distance import DistanceBand, KDTree
     >>> import numpy
     >>> numpy.random.seed(10)
 
@@ -74,7 +74,8 @@ class G:
     >>> points = [(10, 10), (20, 10), (40, 10), (15, 20), (30, 20), (30, 30)]
 
     Creating a weights object from points
-    >>> w = DistanceBand(points,threshold=15)
+    >>> kdt = KDTree(points)
+    >>> w = DistanceBand(kdt,threshold=15)
     >>> w.transform = "B"
 
     Preparing a variable
@@ -237,7 +238,7 @@ class G_Local:
 
     Examples
     --------
-    >>> from pysal.weights.Distance import DistanceBand
+    >>> from pysal.weights.Distance import DistanceBand, KDTree
     >>> import numpy
     >>> numpy.random.seed(10)
 
@@ -247,7 +248,8 @@ class G_Local:
 
     Creating a weights object from points
 
-    >>> w = DistanceBand(points,threshold=15)
+    >>> kdt = KDTree(points)
+    >>> w = DistanceBand(kdt,threshold=15)
 
     Prepareing a variable
 

--- a/pysal/esda/smoothing.py
+++ b/pysal/esda/smoothing.py
@@ -5,13 +5,13 @@ Apply smoothing to rate computation
 
 Author(s):
     Myunghwa Hwang mhwang4@gmail.com
-    David Folch dfolch@asu.edu
+    David Folch dfolch@fsu.edu
     Luc Anselin luc.anselin@asu.edu
     Serge Rey srey@asu.edu
 
 """
 
-__author__ = "Myunghwa Hwang <mhwang4@gmail.com>, David Folch <dfolch@asu.edu>, Luc Anselin <luc.anselin@asu.edu>, Serge Rey <srey@asu.edu"
+__author__ = "Myunghwa Hwang <mhwang4@gmail.com>, David Folch <dfolch@fsu.edu>, Luc Anselin <luc.anselin@asu.edu>, Serge Rey <srey@asu.edu"
 
 import pysal
 from pysal.weights import comb, Kernel
@@ -548,7 +548,7 @@ def assuncao_rate(e, b):
     Computing the rates
 
     >>> print assuncao_rate(e, b)[:4]
-    [ 1.04319254 -0.04117865 -0.56539054 -1.73762547]
+    [ 1.03843594 -0.04099089 -0.56250375 -1.73061861]
 
     """
 
@@ -822,7 +822,8 @@ class Kernel_Smoother:
 
     Creating a kernel-based spatial weights instance by using the above points
 
-    >>> kw=Kernel(points)
+    >>> kdt = pysal.KDTree(points)
+    >>> kw=Kernel(kdt)
 
     Ensuring that the elements in the kernel-based weights are ordered
     by the given sequential numbers from 0 to 5
@@ -893,7 +894,8 @@ class Age_Adjusted_Smoother:
 
     Creating a kernel-based spatial weights instance by using the above points
 
-    >>> kw=Kernel(points)
+    >>> kdt = pysal.KDTree(points)
+    >>> kw=Kernel(kdt)
 
     Ensuring that the elements in the kernel-based weights are ordered
     by the given sequential numbers from 0 to 5

--- a/pysal/esda/tests/test_getisord.py
+++ b/pysal/esda/tests/test_getisord.py
@@ -4,6 +4,7 @@ from pysal.esda import getisord
 import numpy as np
 
 POINTS = [(10, 10), (20, 10), (40, 10), (15, 20), (30, 20), (30, 30)]
+POINTS = np.array(POINTS)
 W = DistanceBand(POINTS, threshold=15)
 Y = np.array([2, 3, 3.2, 5, 8, 7])
 

--- a/pysal/esda/tests/test_smoothing.py
+++ b/pysal/esda/tests/test_smoothing.py
@@ -168,8 +168,8 @@ class TestKernel_AgeAdj_SM(unittest.TestCase):
         self.e1 = np.array([10, 8, 1, 4, 3, 5, 4, 3, 2, 1, 5, 3])
         self.b1 = np.array([100, 90, 15, 30, 25, 20, 30, 20, 80, 80, 90, 60])
         self.s = np.array([98, 88, 15, 29, 20, 23, 33, 25, 76, 80, 89, 66])
-        self.points = [(
-            10, 10), (20, 10), (40, 10), (15, 20), (30, 20), (30, 30)]
+        self.points = [( 10, 10), (20, 10), (40, 10), (15, 20), (30, 20), (30, 30)]
+        self.points = np.array(self.points)
         self.kw = pysal.weights.Kernel(self.points)
         if not self.kw.id_order_set:
             self.kw.id_order = range(0, len(self.points))

--- a/pysal/weights/tests/test_user.py
+++ b/pysal/weights/tests/test_user.py
@@ -56,6 +56,10 @@ class Testuser(unittest.TestCase):
 
     def test_threshold_binaryW_from_array(self):
         points = [(10, 10), (20, 10), (40, 10), (15, 20), (30, 20), (30, 30)]
+        points = np.array(points)
+        w = pysal.threshold_binaryW_from_array(np.array(points), threshold=11.2)
+        self.assertEquals(w.weights, {0: [1, 1], 1: [1, 1], 2: [],
+                                      3: [1, 1], 4: [1], 5: [1]})
         w = pysal.threshold_binaryW_from_array(points, threshold=11.2)
         self.assertEquals(w.weights, {0: [1, 1], 1: [1, 1], 2: [],
                                       3: [1, 1], 4: [1], 5: [1]})
@@ -70,6 +74,7 @@ class Testuser(unittest.TestCase):
 
     def test_threshold_continuousW_from_array(self):
         points = [(10, 10), (20, 10), (40, 10), (15, 20), (30, 20), (30, 30)]
+        points = np.array(points)
         wid = pysal.threshold_continuousW_from_array(points, 11.2)
         self.assertEquals(wid.weights[0], [0.10000000000000001,
                                            0.089442719099991588])
@@ -84,7 +89,10 @@ class Testuser(unittest.TestCase):
 
     def test_kernelW(self):
         points = [(10, 10), (20, 10), (40, 10), (15, 20), (30, 20), (30, 30)]
-        kw = pysal.kernelW(points)
+        kw = pysal.kernelW(np.array(points))
+        self.assertEquals(kw.weights[0], [1.0, 0.50000004999999503,
+                                          0.44098306152674649])
+        kw = pysal.kernelW(pysal.KDTree(points))
         self.assertEquals(kw.weights[0], [1.0, 0.50000004999999503,
                                           0.44098306152674649])
         self.assertEquals(kw.neighbors[0], [0, 1, 3])
@@ -115,8 +123,13 @@ class Testuser(unittest.TestCase):
 
     def test_adaptive_kernelW(self):
         points = [(10, 10), (20, 10), (40, 10), (15, 20), (30, 20), (30, 30)]
+        points = np.array(points)   
         bw = [25.0, 15.0, 25.0, 16.0, 14.5, 25.0]
         kwa = pysal.adaptive_kernelW(points, bandwidths=bw)
+        self.assertEqual(kwa.weights[0], [1.0, 0.59999999999999998,
+                                          0.55278640450004202,
+                                          0.10557280900008403])
+        kwa = pysal.adaptive_kernelW(pysal.KDTree(points), bandwidths=bw)
         self.assertEqual(kwa.weights[0], [1.0, 0.59999999999999998,
                                           0.55278640450004202,
                                           0.10557280900008403])

--- a/pysal/weights/user.py
+++ b/pysal/weights/user.py
@@ -229,9 +229,9 @@ def knnW_from_array(array, k=2, p=2, ids=None, radius=None):
 
     """
     if radius is not None:
-        kdtree = pysal.cg.KDTree(array, distance_metric='Arc', radius=radius)
+        kdtree = pysal.KDTree(array, distance_metric='Arc', radius=radius)
     else:
-        kdtree = pysal.cg.KDTree(array)
+        kdtree = pysal.KDTree(array)
     return knnW(kdtree, k=k, p=p, ids=ids)
 
 
@@ -319,9 +319,9 @@ def knnW_from_shapefile(shapefile, k=2, p=2, idVariable=None, radius=None):
     data = get_points_array_from_shapefile(shapefile)
 
     if radius is not None:
-        kdtree = pysal.cg.KDTree(data, distance_metric='Arc', radius=radius)
+        kdtree = pysal.KDTree(data, distance_metric='Arc', radius=radius)
     else:
-        kdtree = pysal.cg.KDTree(data)
+        kdtree = pysal.KDTree(data)
     if idVariable:
         ids = get_ids(shapefile, idVariable)
         return knnW(kdtree, k=k, p=p, ids=ids)
@@ -359,6 +359,7 @@ def threshold_binaryW_from_array(array, threshold, p=2, radius=None):
     Examples
     --------
     >>> points=[(10, 10), (20, 10), (40, 10), (15, 20), (30, 20), (30, 30)]
+    >>> points=np.array(points)
     >>> w=threshold_binaryW_from_array(points,threshold=11.2)
     WARNING: there is one disconnected observation (no neighbors)
     Island id:  [2]
@@ -369,7 +370,7 @@ def threshold_binaryW_from_array(array, threshold, p=2, radius=None):
     >>>
     """
     if radius is not None:
-        array = pysal.cg.KDTree(array, distance_metric='Arc', radius=radius)
+        array = pysal.KDTree(array, distance_metric='Arc', radius=radius)
     return DistanceBand(array, threshold=threshold, p=p)
 
 
@@ -419,7 +420,7 @@ def threshold_binaryW_from_shapefile(shapefile, threshold, p=2, idVariable=None,
 
     data = get_points_array_from_shapefile(shapefile)
     if radius is not None:
-        data = pysal.cg.KDTree(data, distance_metric='Arc', radius=radius)
+        data = pysal.KDTree(data, distance_metric='Arc', radius=radius)
     if idVariable:
         ids = get_ids(shapefile, idVariable)
         w = DistanceBand(data, threshold=threshold, p=p)
@@ -466,6 +467,7 @@ def threshold_continuousW_from_array(array, threshold, p=2,
     inverse distance weights
 
     >>> points=[(10, 10), (20, 10), (40, 10), (15, 20), (30, 20), (30, 30)]
+    >>> points=np.array(points)
     >>> wid=threshold_continuousW_from_array(points,11.2)
     WARNING: there is one disconnected observation (no neighbors)
     Island id:  [2]
@@ -483,7 +485,7 @@ def threshold_continuousW_from_array(array, threshold, p=2,
     """
 
     if radius is not None:
-        array = pysal.cg.KDTree(array, distance_metric='Arc', radius=radius)
+        array = pysal.KDTree(array, distance_metric='Arc', radius=radius)
     w = DistanceBand(
         array, threshold=threshold, p=p, alpha=alpha, binary=False)
     return w
@@ -539,13 +541,13 @@ def threshold_continuousW_from_shapefile(shapefile, threshold, p=2,
 
     data = get_points_array_from_shapefile(shapefile)
     if radius is not None:
-        data = pysal.cg.KDTree(data, distance_metric='Arc', radius=radius)
+        data = pysal.KDTree(data, distance_metric='Arc', radius=radius)
     if idVariable:
         ids = get_ids(shapefile, idVariable)
         w = DistanceBand(data, threshold=threshold, p=p, alpha=alpha, binary=False)
         w.remap_ids(ids)
     else:
-        w =  threshold_continuousW_from_array(data, threshold, p=p, alpha=alpha)
+        w = threshold_continuousW_from_array(data, threshold, p=p, alpha=alpha)
     w.set_shapefile(shapefile,idVariable)
     return w
 
@@ -638,6 +640,7 @@ def kernelW(points, k=2, function='triangular', fixed=True,
     Examples
     --------
     >>> points=[(10, 10), (20, 10), (40, 10), (15, 20), (30, 20), (30, 30)]
+    >>> points=np.array(points)
     >>> kw=kernelW(points)
     >>> kw.weights[0]
     [1.0, 0.500000049999995, 0.4409830615267465]
@@ -676,7 +679,7 @@ def kernelW(points, k=2, function='triangular', fixed=True,
     """
 
     if radius is not None:
-        points = pysal.cg.KDTree(points, distance_metric='Arc', radius=radius)
+        points = pysal.KDTree(points, distance_metric='Arc', radius=radius)
     return Kernel(points, function=function, k=k, fixed=fixed,
             diagonal=diagonal)
 
@@ -791,7 +794,7 @@ def kernelW_from_shapefile(shapefile, k=2, function='triangular',
 
     points = get_points_array_from_shapefile(shapefile)
     if radius is not None:
-        points = pysal.cg.KDTree(points, distance_metric='Arc', radius=radius)
+        points = pysal.KDTree(points, distance_metric='Arc', radius=radius)
     if idVariable:
         ids = get_ids(shapefile, idVariable)
         return Kernel(points, function=function, k=k, ids=ids, fixed=fixed,
@@ -879,6 +882,7 @@ def adaptive_kernelW(points, bandwidths=None, k=2, function='triangular',
     User specified bandwidths
 
     >>> points=[(10, 10), (20, 10), (40, 10), (15, 20), (30, 20), (30, 30)]
+    >>> points=np.array(points)
     >>> bw=[25.0,15.0,25.0,16.0,14.5,25.0]
     >>> kwa=adaptive_kernelW(points,bandwidths=bw)
     >>> kwa.weights[0]
@@ -936,7 +940,7 @@ def adaptive_kernelW(points, bandwidths=None, k=2, function='triangular',
 
     """
     if radius is not None:
-        points = pysal.cg.KDTree(points, distance_metric='Arc', radius=radius)
+        points = pysal.KDTree(points, distance_metric='Arc', radius=radius)
     return Kernel(points, bandwidth=bandwidths, fixed=False, k=k,
             function=function, diagonal=diagonal)
 
@@ -1039,7 +1043,7 @@ def adaptive_kernelW_from_shapefile(shapefile, bandwidths=None, k=2, function='t
     """
     points = get_points_array_from_shapefile(shapefile)
     if radius is not None:
-        points = pysal.cg.KDTree(points, distance_metric='Arc', radius=radius)
+        points = pysal.KDTree(points, distance_metric='Arc', radius=radius)
     if idVariable:
         ids = get_ids(shapefile, idVariable)
         return Kernel(points, bandwidth=bandwidths, fixed=False, k=k,
@@ -1089,7 +1093,7 @@ def min_threshold_dist_from_shapefile(shapefile, radius=None, p=2):
     """
     points = get_points_array_from_shapefile(shapefile)
     if radius is not None:
-        points = pysal.cg.KDTree(points, distance_metric='Arc', radius=radius)
+        points = pysal.KDTree(points, distance_metric='Arc', radius=radius)
     return min_threshold_distance(points,p)
 
 

--- a/pysal/weights/util.py
+++ b/pysal/weights/util.py
@@ -1,3 +1,4 @@
+import warnings
 import pysal
 from pysal.common import *
 import pysal.weights
@@ -13,6 +14,12 @@ __all__ = ['lat2W', 'block_weights', 'comb', 'order', 'higher_order',
            'insert_diagonal', 'get_ids', 'get_points_array_from_shapefile',
            'min_threshold_distance', 'lat2SW', 'w_local_cluster',
            'higher_order_sp', 'hexLat2W', 'regime_weights']
+
+
+def custom_formatwarning(msg, *a):
+    # ignore everything except the message
+    return str(msg) + '\n'
+warnings.formatwarning = custom_formatwarning
 
 
 def hexLat2W(nrows=5, ncols=5):
@@ -1065,8 +1072,8 @@ def min_threshold_distance(data, p=2):
     Parameters
     ----------
 
-    data    : array
-              (n,k) or KDTree where KDtree.data is array (n,k)
+    data    : object
+              PySAL KDTree where KDtree.data is array (n,k)
               n observations on k attributes
     p       : float
               Minkowski p-norm distance metric parameter:
@@ -1087,15 +1094,15 @@ def min_threshold_distance(data, p=2):
     >>> x.shape = (25, 1)
     >>> y.shape = (25, 1)
     >>> data = np.hstack([x, y])
-    >>> min_threshold_distance(data)
+    >>> min_threshold_distance(pysal.KDTree(data))
     1.0
 
     """
-    if issubclass(type(data), scipy.spatial.KDTree):
-        kd = data
-        data = kd.data
-    else:
-        kd = KDTree(data)
+    if issubclass(type(data), np.ndarray):
+        data = KDTree(data)
+        warnings.warn("Deprecation warning: array converted to euclidean distance pysal.KDTree; pysal.KDTree will be required in the future.")
+    kd = data
+    data = kd.data
     nn = kd.query(data, k=2, p=p)
     nnd = nn[0].max(axis=0)[1]
     return nnd


### PR DESCRIPTION
This PR applies issue #646 to the entire library, and extends PR #647. It also addresses #652 and does some other stuff.

This PR allows the user to choose euclidean or arc distance (via the kd-tree) when using distance related functions. It does not change the API or reduce documented functionality. However, we might want to think about point handling more broadly in the future (see #651). It also speeds up arc distance queries by using cKDTree under the hood.

Changes:

 1. The default functionality for most distance related functions and classes is to take a kd-tree instead of an array of points. When an array is passed, we convert to euclidean distance kd-tree and give a deprecation warning. The only functions and classes that don't require a kd-tree are those that explicitly take an array or shapefile. 

 2. Made the pysal kd-tree accessible at the top level, i.e. pysal.KDTree.

 3. Modified Arc_KDTree to be built on top of scipy.spatial.cKDTree instead of scipy.spatial.KDTree when the user has scipy 0.12 or greater.


Notes:

 1. None of the numeric values in the tests had to change for this PR to pass (on my computer).

 2. Previously, most of these functions accepted lists, even though the docs all called for arrays. Now, if an array is passed it raises a deprecation  warning and a list fails. This is an artifact of how the changes were implemented, not an intended consequence. 