### PR TITLE
W stitch

### DIFF
--- a/pysal/weights/Wsets.py
+++ b/pysal/weights/Wsets.py
@@ -592,7 +592,8 @@ def w_stack(ws, silent_island_warning=False):
         for el in w.neighbors:
             out_neigh['%i-%s'%(i, str(el))] = ['%i-%s'%(i, str(j)) \
                                             for j in w.neighbors[el]]
-            out_weigh['%i-%s'%(i, str(el))] = w.weights[el]
+            out_weigh['%i-%s'%(i, str(el))] = []
+            out_weigh['%i-%s'%(i, str(el))] += w.weights[el]
         wid = ['%i-%s'%(i, str(j)) for j in w.id_order]
         out_ids.extend(wid)
     outW = pysal.W(out_neigh, out_weigh, id_order=out_ids, \
@@ -705,7 +706,8 @@ def w_stitch(ws, back=0, forth=0, silent_island_warning=False):
             # Contemporary neighbors
             out_neigh['%i-%s'%(i, str(el))] = ['%i-%s'%(i, str(j)) \
                                             for j in w.neighbors[el]]
-            out_weigh['%i-%s'%(i, str(el))] = w.weights[el]
+            out_weigh['%i-%s'%(i, str(el))] = []
+            out_weigh['%i-%s'%(i, str(el))] += w.weights[el]
             # Backward neighbors
             for t in range(1, back+1):
                 if i-t in range(len(ws)):
@@ -827,7 +829,8 @@ def w_stitch_single(w, t, back=0, forth=0, silent_island_warning=False):
             # Contemporary neighbors
             out_neigh['%i-%s'%(i, str(el))] = ['%i-%s'%(i, str(j)) \
                                             for j in w.neighbors[el]]
-            out_weigh['%i-%s'%(i, str(el))] = w.weights[el]
+            out_weigh['%i-%s'%(i, str(el))] = []
+            out_weigh['%i-%s'%(i, str(el))] += w.weights[el]
             # Backward neighbors
             for tb in range(1, back+1):
                 if i-tb in range(t):

--- a/pysal/weights/Wsets.py
+++ b/pysal/weights/Wsets.py
@@ -597,4 +597,37 @@ def w_stitch(ws, silent_island_warning=False):
             silent_island_warning=silent_island_warning) 
     return outW
 
+def w_stack_sp(ws, outSP=True, silent_island_warning=False):
+    '''
+    LEGACY: included only for legacy, it performs significantly worse than the
+    `W`-based method `w_stack`
+
+    Sparse source: http://wiki.scipy.org/Wiki/SciPyPackages/Sparse
+    '''
+    ns = [w.n for w in ws]
+    n = np.sum(ns)
+    out = lil_matrix((n, n), dtype=int)
+    out_ids = []
+    for i in range(len(ws)):
+        w = ws[i]
+        w_n = ns[i]
+
+        if not w.id_order:
+            w.id_order = np.arange(w.n)
+        wid = ['%i-%s'%(i, str(j)) for j in w.id_order]
+        out_ids.extend(wid)
+
+        if not isspmatrix_csr(w):
+            w = w.sparse
+        w = w.tolil()
+        beg = np.sum(ns[:i]).astype(int)
+        out[beg:beg+w_n, beg:beg+w_n] = w
+    out = ps.weights.WSP(out.tocsr(), id_order=out_ids)
+    if outSP:
+        return out
+    else:
+        out = ps.weights.WSP2W(out, \
+                silent_island_warning=silent_island_warning)
+        return out
+
 

--- a/pysal/weights/Wsets.py
+++ b/pysal/weights/Wsets.py
@@ -530,4 +530,71 @@ def w_clip(w1, w2, outSP=True, silent_island_warning=False):
         wc = pysal.weights.WSP2W(wc, silent_island_warning=silent_island_warning)
     return wc
 
+def w_stitch(ws, silent_island_warning=False):
+    '''
+    Generate a weights object, `w`, that stacks every elements of `ws`
+    in the passed index and connects each observation with its original
+    neighbors across `back` 
+    
+    ...
+
+    Arguments
+    ---------
+    ws                      : list
+                              Sequence of `ps.W` objects to be stitched
+    silent_island_warning   : boolean
+                              Switch to turn off (default on) print statements
+                              for every observation with islands
+
+    Returns
+    -------
+    w                       : W
+                              Resulting `ps.W` object
+
+    Notes
+    -----
+    The resulting `w` contains the original indices, converted to strings if
+    necessary and preceded by 'X-', where X is the order of the original `W`
+    object in `ws`.
+
+    IMPORTANT: Weights are copied from the original weights object and do not
+    have any further check. Make sure you do not pass standardized weights!
+
+    Examples
+    --------
+
+    Build the weights for a standard lattice:
+
+    >>> import pysal as ps
+    >>> w = ps.lat2W(3, 3)
+    >>> w.n
+    9
+    >>> w[0]
+    {1: 1.0, 3: 1.0}
+    >>>
+
+    Stack it three times, so we obtain a resulting matrix that is three
+    repetitions of `w`:
+
+    >>> w_stacked = w_stack([w, w, w])
+    >>> w_stacked.n
+    27
+    >>> w_stacked['0-0']
+    {'0-1': 1.0, '0-3': 1.0}
+    >>>
+    '''
+    out_neigh = {}
+    out_weigh = {}
+    out_ids = []
+    for i, w in enumerate(ws):
+        for el in w.neighbors:
+            out_neigh['%i-%s'%(i, str(el))] = ['%i-%s'%(i, str(j)) \
+                                            for j in w.neighbors[el]]
+            out_weigh['%i-%s'%(i, str(el))] = w.weights[el]
+        wid = ['%i-%s'%(i, str(j)) for j in w.id_order]
+        out_ids.extend(wid)
+    outW = ps.W(out_neigh, out_weigh, id_order=out_ids, \
+            silent_island_warning=silent_island_warning) 
+    return outW
+
 

--- a/pysal/weights/Wsets.py
+++ b/pysal/weights/Wsets.py
@@ -545,6 +545,12 @@ def w_stitch(ws, silent_island_warning=False):
     silent_island_warning   : boolean
                               Switch to turn off (default on) print statements
                               for every observation with islands
+    back                    : int
+                              [Optional. Default=0] Number of periods an
+                              observation is connected backwards.
+    forth                   : int
+                              [Optional. Default=0] Number of periods an
+                              observation is connected forwards.
 
     Returns
     -------
@@ -596,38 +602,4 @@ def w_stitch(ws, silent_island_warning=False):
     outW = ps.W(out_neigh, out_weigh, id_order=out_ids, \
             silent_island_warning=silent_island_warning) 
     return outW
-
-def w_stack_sp(ws, outSP=True, silent_island_warning=False):
-    '''
-    LEGACY: included only for legacy, it performs significantly worse than the
-    `W`-based method `w_stack`
-
-    Sparse source: http://wiki.scipy.org/Wiki/SciPyPackages/Sparse
-    '''
-    ns = [w.n for w in ws]
-    n = np.sum(ns)
-    out = lil_matrix((n, n), dtype=int)
-    out_ids = []
-    for i in range(len(ws)):
-        w = ws[i]
-        w_n = ns[i]
-
-        if not w.id_order:
-            w.id_order = np.arange(w.n)
-        wid = ['%i-%s'%(i, str(j)) for j in w.id_order]
-        out_ids.extend(wid)
-
-        if not isspmatrix_csr(w):
-            w = w.sparse
-        w = w.tolil()
-        beg = np.sum(ns[:i]).astype(int)
-        out[beg:beg+w_n, beg:beg+w_n] = w
-    out = ps.weights.WSP(out.tocsr(), id_order=out_ids)
-    if outSP:
-        return out
-    else:
-        out = ps.weights.WSP2W(out, \
-                silent_island_warning=silent_island_warning)
-        return out
-
 


### PR DESCRIPTION
This PR adds functionality in `Wsets` to stack weights objects and to created stacked objects where observations are connected also with its contemporary neighbors a number of periods backwards and forwards.

The methods are well documented and examples are provided but no unit tests are included. Also, I'm not sure what the best way to publicise this would be (beyond the docstrings), a companion notebook? If so, where should it be hosted?

This PR is related to functionality mentioned in #378, although it is not on-the-fly Ws.
