### PR TITLE
Change array assertions into allclose

### DIFF
--- a/pysal/spreg/tests/test_error_sp.py
+++ b/pysal/spreg/tests/test_error_sp.py
@@ -26,9 +26,9 @@ class TestBaseGMError(unittest.TestCase):
         predy = np.array([ 52.9930255])
         np.testing.assert_allclose(reg.predy[0],predy,4)
         n = 49
-        self.assertAlmostEqual(reg.n,n,4)
+        np.testing.assert_allclose(reg.n,n,4)
         k = 3
-        self.assertAlmostEqual(reg.k,k,4)
+        np.testing.assert_allclose(reg.k,k,4)
         y = np.array([ 80.467003])
         np.testing.assert_allclose(reg.y[0],y,4)
         x = np.array([  1.     ,  19.531  ,  15.72598])
@@ -38,13 +38,13 @@ class TestBaseGMError(unittest.TestCase):
         predy = np.array([ 52.9930255])
         np.testing.assert_allclose(reg.predy[0],predy,4)
         my = 38.43622446938776
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         sy = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy)
         vm = np.array([[  1.51884943e+02,  -5.37622793e+00,  -1.86970286e+00], [ -5.37622793e+00,   2.48972661e-01,   5.26564244e-02], [ -1.86970286e+00,   5.26564244e-02, 3.18930650e-02]])
         np.testing.assert_allclose(reg.vm,vm,4)
         sig2 = 191.73716465732355
-        self.assertAlmostEqual(reg.sig2,sig2,4)
+        np.testing.assert_allclose(reg.sig2,sig2,4)
 
 class TestGMError(unittest.TestCase):
     def setUp(self):
@@ -67,9 +67,9 @@ class TestGMError(unittest.TestCase):
         predy = np.array([ 52.9930255])
         np.testing.assert_allclose(reg.predy[0],predy,4)
         n = 49
-        self.assertAlmostEqual(reg.n,n,4)
+        np.testing.assert_allclose(reg.n,n,4)
         k = 3
-        self.assertAlmostEqual(reg.k,k,4)
+        np.testing.assert_allclose(reg.k,k,4)
         y = np.array([ 80.467003])
         np.testing.assert_allclose(reg.y[0],y,4)
         x = np.array([  1.     ,  19.531  ,  15.72598])
@@ -79,15 +79,15 @@ class TestGMError(unittest.TestCase):
         predy = np.array([ 52.9930255])
         np.testing.assert_allclose(reg.predy[0],predy,4)
         my = 38.43622446938776
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         sy = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy)
         vm = np.array([[  1.51884943e+02,  -5.37622793e+00,  -1.86970286e+00], [ -5.37622793e+00,   2.48972661e-01,   5.26564244e-02], [ -1.86970286e+00,   5.26564244e-02, 3.18930650e-02]])
         np.testing.assert_allclose(reg.vm,vm,4)
         sig2 = 191.73716465732355
-        self.assertAlmostEqual(reg.sig2,sig2,4)
+        np.testing.assert_allclose(reg.sig2,sig2,4)
         pr2 = 0.3495097406012179
-        self.assertAlmostEqual(reg.pr2,pr2)
+        np.testing.assert_allclose(reg.pr2,pr2)
         std_err = np.array([ 12.32416094,   0.4989716 ,   0.1785863 ])
         np.testing.assert_allclose(reg.std_err,std_err,4)
         z_stat = np.array([[  3.89022140e+00,   1.00152805e-04], [  1.41487186e+00,   1.57106070e-01], [ -3.11175868e+00,   1.85976455e-03]])
@@ -124,9 +124,9 @@ class TestBaseGMEndogError(unittest.TestCase):
         predy = np.array([ 53.9074875])
         np.testing.assert_allclose(reg.predy[0],predy,4)
         n = 49
-        self.assertAlmostEqual(reg.n,n)
+        np.testing.assert_allclose(reg.n,n)
         k = 3
-        self.assertAlmostEqual(reg.k,k)
+        np.testing.assert_allclose(reg.k,k)
         y = np.array([ 80.467003])
         np.testing.assert_allclose(reg.y[0],y,4)
         x = np.array([  1.   ,  19.531])
@@ -136,17 +136,17 @@ class TestBaseGMEndogError(unittest.TestCase):
         z = np.array([  1.     ,  19.531  ,  15.72598])
         np.testing.assert_allclose(reg.z[0],z,4)
         my = 38.43622446938776
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         #std_y
         sy = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy)
         #vm
         vm = np.array([[  5.29158422e+02,  -1.57833675e+01,  -8.38021080e+00],
        [ -1.57833675e+01,   5.40235041e-01,   2.31120327e-01],
        [ -8.38021080e+00,   2.31120327e-01,   1.44977385e-01]])
         np.testing.assert_allclose(reg.vm,vm,4)
         sig2 = 192.50022721929574
-        self.assertAlmostEqual(reg.sig2,sig2,4)
+        np.testing.assert_allclose(reg.sig2,sig2,4)
 
 @unittest.skipIf(int(scipy.__version__.split(".")[1]) < 11,
 "Maximum Likelihood requires SciPy version 11 or newer.")
@@ -178,9 +178,9 @@ class TestGMEndogError(unittest.TestCase):
         predy = np.array([ 53.9074875])
         np.testing.assert_allclose(reg.predy[0],predy,4)
         n = 49
-        self.assertAlmostEqual(reg.n,n)
+        np.testing.assert_allclose(reg.n,n)
         k = 3
-        self.assertAlmostEqual(reg.k,k)
+        np.testing.assert_allclose(reg.k,k)
         y = np.array([ 80.467003])
         np.testing.assert_allclose(reg.y[0],y,4)
         x = np.array([  1.   ,  19.531])
@@ -190,17 +190,17 @@ class TestGMEndogError(unittest.TestCase):
         z = np.array([  1.     ,  19.531  ,  15.72598])
         np.testing.assert_allclose(reg.z[0],z,4)
         my = 38.43622446938776
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         sy = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy)
         vm = np.array([[  5.29158422e+02,  -1.57833675e+01,  -8.38021080e+00],
        [ -1.57833675e+01,   5.40235041e-01,   2.31120327e-01],
        [ -8.38021080e+00,   2.31120327e-01,   1.44977385e-01]])
         np.testing.assert_allclose(reg.vm,vm,4)
         pr2 = 0.346472557570858
-        self.assertAlmostEqual(reg.pr2,pr2)
+        np.testing.assert_allclose(reg.pr2,pr2)
         sig2 = 192.50022721929574
-        self.assertAlmostEqual(reg.sig2,sig2,4)
+        np.testing.assert_allclose(reg.sig2,sig2,4)
         std_err = np.array([ 23.003401  ,   0.73500657,   0.38075777])
         np.testing.assert_allclose(reg.std_err,std_err,4)
         z_stat = np.array([[ 2.40664208,  0.01609994], [ 0.63144305,  0.52775088], [-1.75659016,  0.07898769]])
@@ -234,9 +234,9 @@ class TestBaseGMCombo(unittest.TestCase):
         predy = np.array([ 54.88767663])
         np.testing.assert_allclose(reg.predy[0],predy,4)
         n = 49
-        self.assertAlmostEqual(reg.n,n)
+        np.testing.assert_allclose(reg.n,n)
         k = 4
-        self.assertAlmostEqual(reg.k,k)
+        np.testing.assert_allclose(reg.k,k)
         y = np.array([ 80.467003])
         np.testing.assert_allclose(reg.y[0],y,4)
         x = np.array([  1.     ,  19.531  ,  15.72598])
@@ -246,14 +246,14 @@ class TestBaseGMCombo(unittest.TestCase):
         z = np.array([  1.       ,  19.531    ,  15.72598  ,  35.4585005])
         np.testing.assert_allclose(reg.z[0],z,4)
         my = 38.43622446938776
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         sy = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy)
         vm = np.array([  5.22438365e+02,   2.38012873e-01,   3.20924172e-02,
          2.15753599e-01])
         np.testing.assert_allclose(np.diag(reg.vm),vm,4)
         sig2 = 181.78650186468832
-        self.assertAlmostEqual(reg.sig2,sig2,4)
+        np.testing.assert_allclose(reg.sig2,sig2,4)
 
 @unittest.skipIf(int(scipy.__version__.split(".")[1]) < 11,
 "Maximum Likelihood requires SciPy version 11 or newer.")
@@ -284,9 +284,9 @@ class TestGMCombo(unittest.TestCase):
         predy = np.array([ 54.88767685])
         np.testing.assert_allclose(reg.predy[0],predy,4)
         n = 49
-        self.assertAlmostEqual(reg.n,n)
+        np.testing.assert_allclose(reg.n,n)
         k = 4
-        self.assertAlmostEqual(reg.k,k)
+        np.testing.assert_allclose(reg.k,k)
         y = np.array([ 80.467003])
         np.testing.assert_allclose(reg.y[0],y,4)
         x = np.array([  1.     ,  19.531  ,  15.72598])
@@ -296,18 +296,18 @@ class TestGMCombo(unittest.TestCase):
         z = np.array([  1.       ,  19.531    ,  15.72598  ,  35.4585005])
         np.testing.assert_allclose(reg.z[0],z,4)
         my = 38.43622446938776
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         sy = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy)
         vm = np.array([  5.22438333e+02,   2.38012875e-01,   3.20924173e-02,
          2.15753579e-01])
         np.testing.assert_allclose(np.diag(reg.vm),vm,4)
         sig2 = 181.78650186468832
-        self.assertAlmostEqual(reg.sig2,sig2,4)
+        np.testing.assert_allclose(reg.sig2,sig2,4)
         pr2 = 0.3018280166937799
-        self.assertAlmostEqual(reg.pr2,pr2,4)
+        np.testing.assert_allclose(reg.pr2,pr2,4)
         pr2_e = 0.3561355586759414
-        self.assertAlmostEqual(reg.pr2_e,pr2_e,4)
+        np.testing.assert_allclose(reg.pr2_e,pr2_e,4)
         std_err = np.array([ 22.85692222,  0.48786559,  0.17914356,  0.46449318])
         np.testing.assert_allclose(reg.std_err,std_err,4)
         z_stat = np.array([[  2.52051597e+00,   1.17182922e-02], [  1.50535954e+00,   1.32231664e-01], [ -3.31909311e+00,   9.03103123e-04], [ -4.68530506e-01,   6.39405261e-01]])

--- a/pysal/spreg/tests/test_error_sp.py
+++ b/pysal/spreg/tests/test_error_sp.py
@@ -20,29 +20,29 @@ class TestBaseGMError(unittest.TestCase):
     def test_model(self):
         reg = SP.BaseGM_Error(self.y, self.X, self.w.sparse)
         betas = np.array([[ 47.94371455], [  0.70598088], [ -0.55571746], [  0.37230161]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,4)
         u = np.array([ 27.4739775])
-        np.testing.assert_array_almost_equal(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,4)
         predy = np.array([ 52.9930255])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,4)
         n = 49
         self.assertAlmostEqual(reg.n,n,4)
         k = 3
         self.assertAlmostEqual(reg.k,k,4)
         y = np.array([ 80.467003])
-        np.testing.assert_array_almost_equal(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,4)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.x[0],x,4)
+        np.testing.assert_allclose(reg.x[0],x,4)
         e = np.array([ 31.89620319])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e,4)
         predy = np.array([ 52.9930255])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,4)
         my = 38.43622446938776
         self.assertAlmostEqual(reg.mean_y,my)
         sy = 18.466069465206047
         self.assertAlmostEqual(reg.std_y,sy)
         vm = np.array([[  1.51884943e+02,  -5.37622793e+00,  -1.86970286e+00], [ -5.37622793e+00,   2.48972661e-01,   5.26564244e-02], [ -1.86970286e+00,   5.26564244e-02, 3.18930650e-02]])
-        np.testing.assert_array_almost_equal(reg.vm,vm,4)
+        np.testing.assert_allclose(reg.vm,vm,4)
         sig2 = 191.73716465732355
         self.assertAlmostEqual(reg.sig2,sig2,4)
 
@@ -61,37 +61,37 @@ class TestGMError(unittest.TestCase):
     def test_model(self):
         reg = SP.GM_Error(self.y, self.X, self.w)
         betas = np.array([[ 47.94371455], [  0.70598088], [ -0.55571746], [  0.37230161]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,4)
         u = np.array([ 27.4739775])
-        np.testing.assert_array_almost_equal(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,4)
         predy = np.array([ 52.9930255])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,4)
         n = 49
         self.assertAlmostEqual(reg.n,n,4)
         k = 3
         self.assertAlmostEqual(reg.k,k,4)
         y = np.array([ 80.467003])
-        np.testing.assert_array_almost_equal(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,4)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.x[0],x,4)
+        np.testing.assert_allclose(reg.x[0],x,4)
         e = np.array([ 31.89620319])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e,4)
         predy = np.array([ 52.9930255])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,4)
         my = 38.43622446938776
         self.assertAlmostEqual(reg.mean_y,my)
         sy = 18.466069465206047
         self.assertAlmostEqual(reg.std_y,sy)
         vm = np.array([[  1.51884943e+02,  -5.37622793e+00,  -1.86970286e+00], [ -5.37622793e+00,   2.48972661e-01,   5.26564244e-02], [ -1.86970286e+00,   5.26564244e-02, 3.18930650e-02]])
-        np.testing.assert_array_almost_equal(reg.vm,vm,4)
+        np.testing.assert_allclose(reg.vm,vm,4)
         sig2 = 191.73716465732355
         self.assertAlmostEqual(reg.sig2,sig2,4)
         pr2 = 0.3495097406012179
         self.assertAlmostEqual(reg.pr2,pr2)
         std_err = np.array([ 12.32416094,   0.4989716 ,   0.1785863 ])
-        np.testing.assert_array_almost_equal(reg.std_err,std_err,4)
+        np.testing.assert_allclose(reg.std_err,std_err,4)
         z_stat = np.array([[  3.89022140e+00,   1.00152805e-04], [  1.41487186e+00,   1.57106070e-01], [ -3.11175868e+00,   1.85976455e-03]])
-        np.testing.assert_array_almost_equal(reg.z_stat,z_stat,4)
+        np.testing.assert_allclose(reg.z_stat,z_stat,4)
 
 @unittest.skipIf(int(scipy.__version__.split(".")[1]) < 11,
 "Maximum Likelihood requires SciPy version 11 or newer.")
@@ -116,25 +116,25 @@ class TestBaseGMEndogError(unittest.TestCase):
     def test_model(self):
         reg = SP.BaseGM_Endog_Error(self.y, self.X, self.yd, self.q, self.w.sparse)
         betas = np.array([[ 55.36095292], [  0.46411479], [ -0.66883535], [  0.38989939]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,4)
         u = np.array([ 26.55951566])
-        np.testing.assert_array_almost_equal(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,4)
         e = np.array([ 31.23925425])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e,4)
         predy = np.array([ 53.9074875])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,4)
         n = 49
         self.assertAlmostEqual(reg.n,n)
         k = 3
         self.assertAlmostEqual(reg.k,k)
         y = np.array([ 80.467003])
-        np.testing.assert_array_almost_equal(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,4)
         x = np.array([  1.   ,  19.531])
-        np.testing.assert_array_almost_equal(reg.x[0],x,4)
+        np.testing.assert_allclose(reg.x[0],x,4)
         yend = np.array([  15.72598])
-        np.testing.assert_array_almost_equal(reg.yend[0],yend,4)
+        np.testing.assert_allclose(reg.yend[0],yend,4)
         z = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.z[0],z,4)
+        np.testing.assert_allclose(reg.z[0],z,4)
         my = 38.43622446938776
         self.assertAlmostEqual(reg.mean_y,my)
         #std_y
@@ -144,7 +144,7 @@ class TestBaseGMEndogError(unittest.TestCase):
         vm = np.array([[  5.29158422e+02,  -1.57833675e+01,  -8.38021080e+00],
        [ -1.57833675e+01,   5.40235041e-01,   2.31120327e-01],
        [ -8.38021080e+00,   2.31120327e-01,   1.44977385e-01]])
-        np.testing.assert_array_almost_equal(reg.vm,vm,4)
+        np.testing.assert_allclose(reg.vm,vm,4)
         sig2 = 192.50022721929574
         self.assertAlmostEqual(reg.sig2,sig2,4)
 
@@ -170,25 +170,25 @@ class TestGMEndogError(unittest.TestCase):
     def test_model(self):
         reg = SP.GM_Endog_Error(self.y, self.X, self.yd, self.q, self.w)
         betas = np.array([[ 55.36095292], [  0.46411479], [ -0.66883535], [  0.38989939]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,4)
         u = np.array([ 26.55951566])
-        np.testing.assert_array_almost_equal(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,4)
         e = np.array([ 31.23925425])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e,4)
         predy = np.array([ 53.9074875])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,4)
         n = 49
         self.assertAlmostEqual(reg.n,n)
         k = 3
         self.assertAlmostEqual(reg.k,k)
         y = np.array([ 80.467003])
-        np.testing.assert_array_almost_equal(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,4)
         x = np.array([  1.   ,  19.531])
-        np.testing.assert_array_almost_equal(reg.x[0],x,4)
+        np.testing.assert_allclose(reg.x[0],x,4)
         yend = np.array([  15.72598])
-        np.testing.assert_array_almost_equal(reg.yend[0],yend,4)
+        np.testing.assert_allclose(reg.yend[0],yend,4)
         z = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.z[0],z,4)
+        np.testing.assert_allclose(reg.z[0],z,4)
         my = 38.43622446938776
         self.assertAlmostEqual(reg.mean_y,my)
         sy = 18.466069465206047
@@ -196,15 +196,15 @@ class TestGMEndogError(unittest.TestCase):
         vm = np.array([[  5.29158422e+02,  -1.57833675e+01,  -8.38021080e+00],
        [ -1.57833675e+01,   5.40235041e-01,   2.31120327e-01],
        [ -8.38021080e+00,   2.31120327e-01,   1.44977385e-01]])
-        np.testing.assert_array_almost_equal(reg.vm,vm,4)
+        np.testing.assert_allclose(reg.vm,vm,4)
         pr2 = 0.346472557570858
         self.assertAlmostEqual(reg.pr2,pr2)
         sig2 = 192.50022721929574
         self.assertAlmostEqual(reg.sig2,sig2,4)
         std_err = np.array([ 23.003401  ,   0.73500657,   0.38075777])
-        np.testing.assert_array_almost_equal(reg.std_err,std_err,4)
+        np.testing.assert_allclose(reg.std_err,std_err,4)
         z_stat = np.array([[ 2.40664208,  0.01609994], [ 0.63144305,  0.52775088], [-1.75659016,  0.07898769]])
-        np.testing.assert_array_almost_equal(reg.z_stat,z_stat,4)
+        np.testing.assert_allclose(reg.z_stat,z_stat,4)
 
 @unittest.skipIf(int(scipy.__version__.split(".")[1]) < 11,
 "Maximum Likelihood requires SciPy version 11 or newer.")
@@ -226,32 +226,32 @@ class TestBaseGMCombo(unittest.TestCase):
         self.X = np.hstack((np.ones(self.y.shape),self.X))
         reg = SP.BaseGM_Combo(self.y, self.X, yend=yd2, q=q2, w=self.w.sparse)
         betas = np.array([[ 57.61123461],[  0.73441314], [ -0.59459416], [ -0.21762921], [  0.54732051]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,4)
         u = np.array([ 25.57932637])
-        np.testing.assert_array_almost_equal(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,4)
         e_filtered = np.array([ 31.65374945])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e_filtered,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e_filtered,4)
         predy = np.array([ 54.88767663])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,4)
         n = 49
         self.assertAlmostEqual(reg.n,n)
         k = 4
         self.assertAlmostEqual(reg.k,k)
         y = np.array([ 80.467003])
-        np.testing.assert_array_almost_equal(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,4)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.x[0],x,4)
+        np.testing.assert_allclose(reg.x[0],x,4)
         yend = np.array([  35.4585005])
-        np.testing.assert_array_almost_equal(reg.yend[0],yend,4)
+        np.testing.assert_allclose(reg.yend[0],yend,4)
         z = np.array([  1.       ,  19.531    ,  15.72598  ,  35.4585005])
-        np.testing.assert_array_almost_equal(reg.z[0],z,4)
+        np.testing.assert_allclose(reg.z[0],z,4)
         my = 38.43622446938776
         self.assertAlmostEqual(reg.mean_y,my)
         sy = 18.466069465206047
         self.assertAlmostEqual(reg.std_y,sy)
         vm = np.array([  5.22438365e+02,   2.38012873e-01,   3.20924172e-02,
          2.15753599e-01])
-        np.testing.assert_array_almost_equal(np.diag(reg.vm),vm,4)
+        np.testing.assert_allclose(np.diag(reg.vm),vm,4)
         sig2 = 181.78650186468832
         self.assertAlmostEqual(reg.sig2,sig2,4)
 
@@ -272,36 +272,36 @@ class TestGMCombo(unittest.TestCase):
         # Only spatial lag
         reg = SP.GM_Combo(self.y, self.X, w=self.w)
         e_reduced = np.array([ 28.18617481])
-        np.testing.assert_array_almost_equal(reg.e_pred[0],e_reduced,4)
+        np.testing.assert_allclose(reg.e_pred[0],e_reduced,4)
         predy_e = np.array([ 52.28082782])
-        np.testing.assert_array_almost_equal(reg.predy_e[0],predy_e,4)
+        np.testing.assert_allclose(reg.predy_e[0],predy_e,4)
         betas = np.array([[ 57.61123515],[  0.73441313], [ -0.59459416], [ -0.21762921], [  0.54732051]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,4)
         u = np.array([ 25.57932637])
-        np.testing.assert_array_almost_equal(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,4)
         e_filtered = np.array([ 31.65374945])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e_filtered,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e_filtered,4)
         predy = np.array([ 54.88767685])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,4)
         n = 49
         self.assertAlmostEqual(reg.n,n)
         k = 4
         self.assertAlmostEqual(reg.k,k)
         y = np.array([ 80.467003])
-        np.testing.assert_array_almost_equal(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,4)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.x[0],x,4)
+        np.testing.assert_allclose(reg.x[0],x,4)
         yend = np.array([  35.4585005])
-        np.testing.assert_array_almost_equal(reg.yend[0],yend,4)
+        np.testing.assert_allclose(reg.yend[0],yend,4)
         z = np.array([  1.       ,  19.531    ,  15.72598  ,  35.4585005])
-        np.testing.assert_array_almost_equal(reg.z[0],z,4)
+        np.testing.assert_allclose(reg.z[0],z,4)
         my = 38.43622446938776
         self.assertAlmostEqual(reg.mean_y,my)
         sy = 18.466069465206047
         self.assertAlmostEqual(reg.std_y,sy)
         vm = np.array([  5.22438333e+02,   2.38012875e-01,   3.20924173e-02,
          2.15753579e-01])
-        np.testing.assert_array_almost_equal(np.diag(reg.vm),vm,4)
+        np.testing.assert_allclose(np.diag(reg.vm),vm,4)
         sig2 = 181.78650186468832
         self.assertAlmostEqual(reg.sig2,sig2,4)
         pr2 = 0.3018280166937799
@@ -309,9 +309,9 @@ class TestGMCombo(unittest.TestCase):
         pr2_e = 0.3561355586759414
         self.assertAlmostEqual(reg.pr2_e,pr2_e,4)
         std_err = np.array([ 22.85692222,  0.48786559,  0.17914356,  0.46449318])
-        np.testing.assert_array_almost_equal(reg.std_err,std_err,4)
+        np.testing.assert_allclose(reg.std_err,std_err,4)
         z_stat = np.array([[  2.52051597e+00,   1.17182922e-02], [  1.50535954e+00,   1.32231664e-01], [ -3.31909311e+00,   9.03103123e-04], [ -4.68530506e-01,   6.39405261e-01]])
-        np.testing.assert_array_almost_equal(reg.z_stat,z_stat,4)
+        np.testing.assert_allclose(reg.z_stat,z_stat,4)
 
 if __name__ == '__main__':
     unittest.main()

--- a/pysal/spreg/tests/test_error_sp_sparse.py
+++ b/pysal/spreg/tests/test_error_sp_sparse.py
@@ -22,31 +22,31 @@ class TestBaseGMError(unittest.TestCase):
     def test_model(self):
         reg = SP.BaseGM_Error(self.y, self.X, self.w.sparse)
         betas = np.array([[ 47.94371455], [  0.70598088], [ -0.55571746], [  0.37230161]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,4)
+        np.allclose(reg.betas,betas,4)
         u = np.array([ 27.4739775])
-        np.testing.assert_array_almost_equal(reg.u[0],u,4)
+        np.allclose(reg.u[0],u,4)
         predy = np.array([ 52.9930255])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,4)
+        np.allclose(reg.predy[0],predy,4)
         n = 49
-        self.assertAlmostEqual(reg.n,n,4)
+        np.allclose(reg.n,n,4)
         k = 3
-        self.assertAlmostEqual(reg.k,k,4)
+        np.allclose(reg.k,k,4)
         y = np.array([ 80.467003])
-        np.testing.assert_array_almost_equal(reg.y[0],y,4)
+        np.allclose(reg.y[0],y,4)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.x.toarray()[0],x,4)
+        np.allclose(reg.x.toarray()[0],x,4)
         e = np.array([ 31.89620319])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e,4)
+        np.allclose(reg.e_filtered[0],e,4)
         predy = np.array([ 52.9930255])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,4)
+        np.allclose(reg.predy[0],predy,4)
         my = 38.43622446938776
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.allclose(reg.mean_y,my)
         sy = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y,sy)
+        np.allclose(reg.std_y,sy)
         vm = np.array([[  1.51884943e+02,  -5.37622793e+00,  -1.86970286e+00], [ -5.37622793e+00,   2.48972661e-01,   5.26564244e-02], [ -1.86970286e+00,   5.26564244e-02, 3.18930650e-02]])
-        np.testing.assert_array_almost_equal(reg.vm,vm,4)
+        np.allclose(reg.vm,vm,4)
         sig2 = 191.73716465732355
-        self.assertAlmostEqual(reg.sig2,sig2,4)
+        np.allclose(reg.sig2,sig2,4)
 
 class TestGMError(unittest.TestCase):
     def setUp(self):
@@ -64,37 +64,37 @@ class TestGMError(unittest.TestCase):
     def test_model(self):
         reg = SP.GM_Error(self.y, self.X, self.w)
         betas = np.array([[ 47.94371455], [  0.70598088], [ -0.55571746], [  0.37230161]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,4)
+        np.allclose(reg.betas,betas,4)
         u = np.array([ 27.4739775])
-        np.testing.assert_array_almost_equal(reg.u[0],u,4)
+        np.allclose(reg.u[0],u,4)
         predy = np.array([ 52.9930255])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,4)
+        np.allclose(reg.predy[0],predy,4)
         n = 49
-        self.assertAlmostEqual(reg.n,n,4)
+        np.allclose(reg.n,n,4)
         k = 3
-        self.assertAlmostEqual(reg.k,k,4)
+        np.allclose(reg.k,k,4)
         y = np.array([ 80.467003])
-        np.testing.assert_array_almost_equal(reg.y[0],y,4)
+        np.allclose(reg.y[0],y,4)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.x.toarray()[0],x,4)
+        np.allclose(reg.x.toarray()[0],x,4)
         e = np.array([ 31.89620319])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e,4)
+        np.allclose(reg.e_filtered[0],e,4)
         predy = np.array([ 52.9930255])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,4)
+        np.allclose(reg.predy[0],predy,4)
         my = 38.43622446938776
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.allclose(reg.mean_y,my)
         sy = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y,sy)
+        np.allclose(reg.std_y,sy)
         vm = np.array([[  1.51884943e+02,  -5.37622793e+00,  -1.86970286e+00], [ -5.37622793e+00,   2.48972661e-01,   5.26564244e-02], [ -1.86970286e+00,   5.26564244e-02, 3.18930650e-02]])
-        np.testing.assert_array_almost_equal(reg.vm,vm,4)
+        np.allclose(reg.vm,vm,4)
         sig2 = 191.73716465732355
-        self.assertAlmostEqual(reg.sig2,sig2,4)
+        np.allclose(reg.sig2,sig2,4)
         pr2 = 0.3495097406012179
-        self.assertAlmostEqual(reg.pr2,pr2)
+        np.allclose(reg.pr2,pr2)
         std_err = np.array([ 12.32416094,   0.4989716 ,   0.1785863 ])
-        np.testing.assert_array_almost_equal(reg.std_err,std_err,4)
+        np.allclose(reg.std_err,std_err,4)
         z_stat = np.array([[  3.89022140e+00,   1.00152805e-04], [  1.41487186e+00,   1.57106070e-01], [ -3.11175868e+00,   1.85976455e-03]])
-        np.testing.assert_array_almost_equal(reg.z_stat,z_stat,4)
+        np.allclose(reg.z_stat,z_stat,4)
 
 @unittest.skipIf(int(scipy.__version__.split(".")[1]) < 11,
 "Maximum Likelihood requires SciPy version 11 or newer.")
@@ -120,37 +120,37 @@ class TestBaseGMEndogError(unittest.TestCase):
     def test_model(self):
         reg = SP.BaseGM_Endog_Error(self.y, self.X, self.yd, self.q, self.w.sparse)
         betas = np.array([[ 55.36095292], [  0.46411479], [ -0.66883535], [  0.38989939]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,4)
+        np.allclose(reg.betas,betas,4)
         u = np.array([ 26.55951566])
-        np.testing.assert_array_almost_equal(reg.u[0],u,4)
+        np.allclose(reg.u[0],u,4)
         e = np.array([ 31.23925425])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e,4)
+        np.allclose(reg.e_filtered[0],e,4)
         predy = np.array([ 53.9074875])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,4)
+        np.allclose(reg.predy[0],predy,4)
         n = 49
-        self.assertAlmostEqual(reg.n,n)
+        np.allclose(reg.n,n)
         k = 3
-        self.assertAlmostEqual(reg.k,k)
+        np.allclose(reg.k,k)
         y = np.array([ 80.467003])
-        np.testing.assert_array_almost_equal(reg.y[0],y,4)
+        np.allclose(reg.y[0],y,4)
         x = np.array([  1.   ,  19.531])
-        np.testing.assert_array_almost_equal(reg.x.toarray()[0],x,4)
+        np.allclose(reg.x.toarray()[0],x,4)
         yend = np.array([  15.72598])
-        np.testing.assert_array_almost_equal(reg.yend[0],yend,4)
+        np.allclose(reg.yend[0],yend,4)
         z = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.z.toarray()[0],z,4)
+        np.allclose(reg.z.toarray()[0],z,4)
         my = 38.43622446938776
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.allclose(reg.mean_y,my)
         #std_y
         sy = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y,sy)
+        np.allclose(reg.std_y,sy)
         #vm
         vm = np.array([[ 529.15840986,  -15.78336736,   -8.38021053],
        [ -15.78336736,    0.54023504,    0.23112032],
        [  -8.38021053,    0.23112032,    0.14497738]])
-        np.testing.assert_array_almost_equal(reg.vm,vm,4)
+        np.allclose(reg.vm,vm,4)
         sig2 = 192.5002
-        self.assertAlmostEqual(round(reg.sig2,4),round(sig2,4),4)
+        np.allclose(round(reg.sig2,4),round(sig2,4),4)
 
 @unittest.skipIf(int(scipy.__version__.split(".")[1]) < 11,
 "Maximum Likelihood requires SciPy version 11 or newer.")
@@ -175,41 +175,41 @@ class TestGMEndogError(unittest.TestCase):
     def test_model(self):
         reg = SP.GM_Endog_Error(self.y, self.X, self.yd, self.q, self.w)
         betas = np.array([[ 55.36095292], [  0.46411479], [ -0.66883535], [  0.38989939]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,4)
+        np.allclose(reg.betas,betas,4)
         u = np.array([ 26.55951566])
-        np.testing.assert_array_almost_equal(reg.u[0],u,4)
+        np.allclose(reg.u[0],u,4)
         e = np.array([ 31.23925425])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e,4)
+        np.allclose(reg.e_filtered[0],e,4)
         predy = np.array([ 53.9074875])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,4)
+        np.allclose(reg.predy[0],predy,4)
         n = 49
-        self.assertAlmostEqual(reg.n,n)
+        np.allclose(reg.n,n)
         k = 3
-        self.assertAlmostEqual(reg.k,k)
+        np.allclose(reg.k,k)
         y = np.array([ 80.467003])
-        np.testing.assert_array_almost_equal(reg.y[0],y,4)
+        np.allclose(reg.y[0],y,4)
         x = np.array([  1.   ,  19.531])
-        np.testing.assert_array_almost_equal(reg.x.toarray()[0],x,4)
+        np.allclose(reg.x.toarray()[0],x,4)
         yend = np.array([  15.72598])
-        np.testing.assert_array_almost_equal(reg.yend[0],yend,4)
+        np.allclose(reg.yend[0],yend,4)
         z = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.z.toarray()[0],z,4)
+        np.allclose(reg.z.toarray()[0],z,4)
         my = 38.43622446938776
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.allclose(reg.mean_y,my)
         sy = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y,sy)
+        np.allclose(reg.std_y,sy)
         vm = np.array([[ 529.15840986,  -15.78336736,   -8.38021053],
        [ -15.78336736,    0.54023504,    0.23112032],
        [  -8.38021053,    0.23112032,    0.14497738]])
-        np.testing.assert_array_almost_equal(reg.vm,vm,4)
+        np.allclose(reg.vm,vm,4)
         pr2 = 0.346472557570858
-        self.assertAlmostEqual(reg.pr2,pr2)
+        np.allclose(reg.pr2,pr2)
         sig2 = 192.5002
-        self.assertAlmostEqual(round(reg.sig2,4),round(sig2,4),4)
+        np.allclose(round(reg.sig2,4),round(sig2,4),4)
         std_err = np.array([ 23.003401  ,   0.73500657,   0.38075777])
-        np.testing.assert_array_almost_equal(reg.std_err,std_err,4)
+        np.allclose(reg.std_err,std_err,4)
         z_stat = np.array([[ 2.40664208,  0.01609994], [ 0.63144305,  0.52775088], [-1.75659016,  0.07898769]])
-        np.testing.assert_array_almost_equal(reg.z_stat,z_stat,4)
+        np.allclose(reg.z_stat,z_stat,4)
 
 @unittest.skipIf(int(scipy.__version__.split(".")[1]) < 11,
 "Maximum Likelihood requires SciPy version 11 or newer.")
@@ -232,36 +232,36 @@ class TestBaseGMCombo(unittest.TestCase):
         self.X = sparse.csr_matrix(self.X)
         reg = SP.BaseGM_Combo(self.y, self.X, yend=yd2, q=q2, w=self.w.sparse)
         betas = np.array([[ 57.61123461],[  0.73441314], [ -0.59459416], [ -0.21762921], [  0.54732051]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,4)
+        np.allclose(reg.betas,betas,4)
         u = np.array([ 25.57932637])
-        np.testing.assert_array_almost_equal(reg.u[0],u,4)
+        np.allclose(reg.u[0],u,4)
         e_filtered = np.array([ 31.65374945])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e_filtered,4)
+        np.allclose(reg.e_filtered[0],e_filtered,4)
         predy = np.array([ 54.88767663])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,4)
+        np.allclose(reg.predy[0],predy,4)
         n = 49
-        self.assertAlmostEqual(reg.n,n)
+        np.allclose(reg.n,n)
         k = 4
-        self.assertAlmostEqual(reg.k,k)
+        np.allclose(reg.k,k)
         y = np.array([ 80.467003])
-        np.testing.assert_array_almost_equal(reg.y[0],y,4)
+        np.allclose(reg.y[0],y,4)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.x.toarray()[0],x,4)
+        np.allclose(reg.x.toarray()[0],x,4)
         yend = np.array([  35.4585005])
-        np.testing.assert_array_almost_equal(reg.yend[0],yend,4)
+        np.allclose(reg.yend[0],yend,4)
         z = np.array([  1.       ,  19.531    ,  15.72598  ,  35.4585005])
-        np.testing.assert_array_almost_equal(reg.z.toarray()[0],z,4)
+        np.allclose(reg.z.toarray()[0],z,4)
         my = 38.43622446938776
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.allclose(reg.mean_y,my)
         sy = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y,sy)
+        np.allclose(reg.std_y,sy)
         vm = np.array([[ 522.43841148,   -6.07256915,   -1.91429117,   -8.97133162],
        [  -6.07256915,    0.23801287,    0.0470161 ,    0.02809628],
        [  -1.91429117,    0.0470161 ,    0.03209242,    0.00314973],
        [  -8.97133162,    0.02809628,    0.00314973,    0.21575363]])
-        np.testing.assert_array_almost_equal(reg.vm,vm,4)
+        np.allclose(reg.vm,vm,4)
         sig2 = 181.78650186468832
-        self.assertAlmostEqual(reg.sig2,sig2,4)
+        np.allclose(reg.sig2,sig2,4)
 
 @unittest.skipIf(int(scipy.__version__.split(".")[1]) < 11,
 "Maximum Likelihood requires SciPy version 11 or newer.")
@@ -281,49 +281,49 @@ class TestGMCombo(unittest.TestCase):
         # Only spatial lag
         reg = SP.GM_Combo(self.y, self.X, w=self.w)
         e_reduced = np.array([ 28.18617481])
-        np.testing.assert_array_almost_equal(reg.e_pred[0],e_reduced,4)
+        np.allclose(reg.e_pred[0],e_reduced,4)
         predy_e = np.array([ 52.28082782])
-        np.testing.assert_array_almost_equal(reg.predy_e[0],predy_e,4)
+        np.allclose(reg.predy_e[0],predy_e,4)
         betas = np.array([[ 57.61123515],[  0.73441313], [ -0.59459416], [ -0.21762921], [  0.54732051]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,4)
+        np.allclose(reg.betas,betas,4)
         u = np.array([ 25.57932637])
-        np.testing.assert_array_almost_equal(reg.u[0],u,4)
+        np.allclose(reg.u[0],u,4)
         e_filtered = np.array([ 31.65374945])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e_filtered,4)
+        np.allclose(reg.e_filtered[0],e_filtered,4)
         predy = np.array([ 54.88767685])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,4)
+        np.allclose(reg.predy[0],predy,4)
         n = 49
-        self.assertAlmostEqual(reg.n,n)
+        np.allclose(reg.n,n)
         k = 4
-        self.assertAlmostEqual(reg.k,k)
+        np.allclose(reg.k,k)
         y = np.array([ 80.467003])
-        np.testing.assert_array_almost_equal(reg.y[0],y,4)
+        np.allclose(reg.y[0],y,4)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.x.toarray()[0],x,4)
+        np.allclose(reg.x.toarray()[0],x,4)
         yend = np.array([  35.4585005])
-        np.testing.assert_array_almost_equal(reg.yend[0],yend,4)
+        np.allclose(reg.yend[0],yend,4)
         z = np.array([  1.       ,  19.531    ,  15.72598  ,  35.4585005])
-        np.testing.assert_array_almost_equal(reg.z.toarray()[0],z,4)
+        np.allclose(reg.z.toarray()[0],z,4)
         my = 38.43622446938776
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.allclose(reg.mean_y,my)
         sy = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y,sy)
+        np.allclose(reg.std_y,sy)
         vm = np.array([[ 522.43841148,   -6.07256915,   -1.91429117,   -8.97133162],
        [  -6.07256915,    0.23801287,    0.0470161 ,    0.02809628],
        [  -1.91429117,    0.0470161 ,    0.03209242,    0.00314973],
        [  -8.97133162,    0.02809628,    0.00314973,    0.21575363]])
-        #np.testing.assert_array_almost_equal(reg.vm,vm,4)
+        #np.allclose(reg.vm,vm,4)
         np.testing.assert_allclose(reg.vm, vm, rtol=1e-05)
         sig2 = 181.78650186468832
-        self.assertAlmostEqual(reg.sig2,sig2,4)
+        np.allclose(reg.sig2,sig2,4)
         pr2 = 0.3018280166937799
-        self.assertAlmostEqual(reg.pr2,pr2,4)
+        np.allclose(reg.pr2,pr2,4)
         pr2_e = 0.3561355587000738
-        self.assertAlmostEqual(reg.pr2_e,pr2_e,4)
+        np.allclose(reg.pr2_e,pr2_e,4)
         std_err = np.array([ 22.85692222,  0.48786559,  0.17914356,  0.46449318])
-        np.testing.assert_array_almost_equal(reg.std_err,std_err,4)
+        np.allclose(reg.std_err,std_err,4)
         z_stat = np.array([[  2.52051597e+00,   1.17182922e-02], [  1.50535954e+00,   1.32231664e-01], [ -3.31909311e+00,   9.03103123e-04], [ -4.68530506e-01,   6.39405261e-01]])
-        np.testing.assert_array_almost_equal(reg.z_stat,z_stat,4)
+        np.allclose(reg.z_stat,z_stat,4)
 
 if __name__ == '__main__':
     start_suppress = np.get_printoptions()['suppress']

--- a/pysal/spreg/tests/test_ml_error.py
+++ b/pysal/spreg/tests/test_ml_error.py
@@ -30,9 +30,9 @@ class TestMLError(unittest.TestCase):
         predy = np.array([ 6.92258051])
         np.testing.assert_array_almost_equal(reg.predy[0],predy,4)
         n = 1412
-        self.assertAlmostEqual(reg.n,n,4)
+        np.allclose(reg.n,n,4)
         k = 5
-        self.assertAlmostEqual(reg.k,k,4)
+        np.allclose(reg.k,k,4)
         y = np.array([ 0.94608274])
         np.testing.assert_array_almost_equal(reg.y[0],y,4)
         x = np.array([ 1.        , -0.39902838,  0.89645344,  6.85780705,  7.2636377 ])
@@ -40,16 +40,16 @@ class TestMLError(unittest.TestCase):
         e = np.array([-4.92843327])
         np.testing.assert_array_almost_equal(reg.e_filtered[0],e,4)
         my = 9.5492931620846928
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.allclose(reg.mean_y,my)
         sy = 7.0388508798387219
-        self.assertAlmostEqual(reg.std_y,sy)
+        np.allclose(reg.std_y,sy)
         vm = np.array([ 1.06476526,  0.05548248,  0.04544514,  0.00614425,  0.01481356,
         0.00143001])
         np.testing.assert_array_almost_equal(reg.vm.diagonal(),vm,4)
         sig2 = [ 32.40685441]
-        self.assertAlmostEqual(reg.sig2,sig2,4)
+        np.allclose(reg.sig2,sig2,4)
         pr2 = 0.3057664820364818
-        self.assertAlmostEqual(reg.pr2,pr2)
+        np.allclose(reg.pr2,pr2)
         std_err = np.array([ 1.03187463,  0.23554719,  0.21317867,  0.07838525,  0.12171098,
         0.03781546])
         np.testing.assert_array_almost_equal(reg.std_err,std_err,4)
@@ -61,11 +61,11 @@ class TestMLError(unittest.TestCase):
  (7.9088780724028922, 2.5971882547279339e-15)]
         np.testing.assert_array_almost_equal(reg.z_stat,z_stat,4)
         logll = -4471.407066887894
-        self.assertAlmostEqual(reg.logll,logll,4)
+        np.allclose(reg.logll,logll,4)
         aic = 8952.8141337757879
-        self.assertAlmostEqual(reg.aic,aic,4)
+        np.allclose(reg.aic,aic,4)
         schwarz = 8979.0779458660545
-        self.assertAlmostEqual(reg.schwarz,schwarz,4)
+        np.allclose(reg.schwarz,schwarz,4)
 
 if __name__ == '__main__':
     unittest.main()

--- a/pysal/spreg/tests/test_ml_error.py
+++ b/pysal/spreg/tests/test_ml_error.py
@@ -24,42 +24,42 @@ class TestMLError(unittest.TestCase):
         reg = ML_Error(self.y,self.x,w=self.w,name_y=self.y_name,name_x=self.x_names,\
                name_w="south_q.gal")
         betas = np.array([[ 6.1492], [ 4.4024], [ 1.7784], [-0.3781], [ 0.4858], [ 0.2991]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,4)
+        np.allclose(reg.betas,betas,4)
         u = np.array([-5.97649777])
-        np.testing.assert_array_almost_equal(reg.u[0],u,4)
+        np.allclose(reg.u[0],u,4)
         predy = np.array([ 6.92258051])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,4)
+        np.allclose(reg.predy[0],predy,4)
         n = 1412
         np.allclose(reg.n,n,4)
         k = 5
         np.allclose(reg.k,k,4)
         y = np.array([ 0.94608274])
-        np.testing.assert_array_almost_equal(reg.y[0],y,4)
+        np.allclose(reg.y[0],y,4)
         x = np.array([ 1.        , -0.39902838,  0.89645344,  6.85780705,  7.2636377 ])
-        np.testing.assert_array_almost_equal(reg.x[0],x,4)
+        np.allclose(reg.x[0],x,4)
         e = np.array([-4.92843327])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e,4)
+        np.allclose(reg.e_filtered[0],e,4)
         my = 9.5492931620846928
         np.allclose(reg.mean_y,my)
         sy = 7.0388508798387219
         np.allclose(reg.std_y,sy)
         vm = np.array([ 1.06476526,  0.05548248,  0.04544514,  0.00614425,  0.01481356,
         0.00143001])
-        np.testing.assert_array_almost_equal(reg.vm.diagonal(),vm,4)
+        np.allclose(reg.vm.diagonal(),vm,4)
         sig2 = [ 32.40685441]
         np.allclose(reg.sig2,sig2,4)
         pr2 = 0.3057664820364818
         np.allclose(reg.pr2,pr2)
         std_err = np.array([ 1.03187463,  0.23554719,  0.21317867,  0.07838525,  0.12171098,
         0.03781546])
-        np.testing.assert_array_almost_equal(reg.std_err,std_err,4)
+        np.allclose(reg.std_err,std_err,4)
         z_stat = [(5.9592751097983534, 2.5335926307459251e-09),
  (18.690182928021841, 5.9508619446611137e-78),
  (8.3421632936950338, 7.2943630281051907e-17),
  (-4.8232686291115678, 1.4122456582517099e-06),
  (3.9913060809142995, 6.5710406838016854e-05),
  (7.9088780724028922, 2.5971882547279339e-15)]
-        np.testing.assert_array_almost_equal(reg.z_stat,z_stat,4)
+        np.allclose(reg.z_stat,z_stat,4)
         logll = -4471.407066887894
         np.allclose(reg.logll,logll,4)
         aic = 8952.8141337757879

--- a/pysal/spreg/tests/test_ml_error_regimes.py
+++ b/pysal/spreg/tests/test_ml_error_regimes.py
@@ -50,35 +50,35 @@ class TestMLError(unittest.TestCase):
        [ -0.23710892],
        [  0.80581127],
        [  0.61770744]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,4)
+        np.allclose(reg.betas,betas,4)
         u = np.array([ 30.46599009])
-        np.testing.assert_array_almost_equal(reg.u[0],u,4)
+        np.allclose(reg.u[0],u,4)
         predy = np.array([ 16.53400991])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,4)
+        np.allclose(reg.predy[0],predy,4)
         n = 211
         np.allclose(reg.n,n,4)
         k = 8
         np.allclose(reg.k,k,4)
         y = np.array([ 47.])
-        np.testing.assert_array_almost_equal(reg.y[0],y,4)
+        np.allclose(reg.y[0],y,4)
         x = np.array([   1.  ,    4.  ,  148.  ,   11.25,    0.  ,    0.  ,    0.  ,    0.  ])
-        np.testing.assert_array_almost_equal(reg.x[0],x,4)
+        np.allclose(reg.x[0],x,4)
         e = np.array([ 34.69181334])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e,4)
+        np.allclose(reg.e_filtered[0],e,4)
         my = 44.307180094786695
         np.allclose(reg.mean_y,my)
         sy = 23.606076835380495
         np.allclose(reg.std_y,sy)
         vm = np.array([ 58.50551173,   2.42952002,   0.00721525,   0.06391736,
         80.59249161,   3.1610047 ,   0.0119782 ,   0.0499432 ,   0.00502785])
-        np.testing.assert_array_almost_equal(reg.vm.diagonal(),vm,4)
+        np.allclose(reg.vm.diagonal(),vm,4)
         sig2 = np.array([[ 209.60639741]])
         np.allclose(reg.sig2,sig2,4)
         pr2 = 0.43600837301477025
         np.allclose(reg.pr2,pr2)
         std_err = np.array([ 7.64888957,  1.55869177,  0.08494262,  0.25281882,  8.9773321 ,
         1.77792146,  0.10944497,  0.22347975,  0.07090735])
-        np.testing.assert_array_almost_equal(reg.std_err,std_err,4)
+        np.allclose(reg.std_err,std_err,4)
         logll = -870.3331059537576
         np.allclose(reg.logll,logll,4)
         aic = 1756.6662119075154
@@ -89,7 +89,7 @@ class TestMLError(unittest.TestCase):
        [ 0.64080535,  0.42341932],
        [ 2.25389396,  0.13327865],
        [ 1.96544702,  0.16093197]])
-        np.testing.assert_array_almost_equal(reg.chow.regi,chow_r,4)
+        np.allclose(reg.chow.regi,chow_r,4)
         chow_j = 25.367913028011799
         np.allclose(reg.chow.joint[0],chow_j,4)
 
@@ -106,23 +106,23 @@ class TestMLError(unittest.TestCase):
        [ -0.18803509],
        [  0.68956598],
        [  0.75599089]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,4)
+        np.allclose(reg.betas,betas,4)
         vm = np.array([ 40.60994599,  -7.25413138,  -0.16605501,   0.48961884,
          0.        ,   0.        ,   0.        ,   0.        ,
          0.        ,   0.        ])
-        np.testing.assert_array_almost_equal(reg.vm[0],vm,4)
+        np.allclose(reg.vm[0],vm,4)
         u = np.array([ 31.97771505])
-        np.testing.assert_array_almost_equal(reg.u[0],u,4)
+        np.allclose(reg.u[0],u,4)
         predy = np.array([ 15.02228495])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,4)
+        np.allclose(reg.predy[0],predy,4)
         e = np.array([ 33.83065421])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e,4)
+        np.allclose(reg.e_filtered[0],e,4)
         chow_r = np.array([[  6.88023639,   0.0087154 ],
        [  0.90512612,   0.34141092],
        [  0.75996258,   0.38334023],
        [  0.56882946,   0.45072443],
        [ 12.18358581,   0.00048212]])
-        np.testing.assert_array_almost_equal(reg.chow.regi,chow_r,4)
+        np.allclose(reg.chow.regi,chow_r,4)
         chow_j = 26.673798071789673
         np.allclose(reg.chow.joint[0],chow_j,4)
         #Artficial:
@@ -130,9 +130,9 @@ class TestMLError(unittest.TestCase):
         model1 = ML_Error(self.y_a[0:(self.n2)].reshape((self.n2),1), self.x_a[0:(self.n2)], w=self.w_a1)
         model2 = ML_Error(self.y_a[(self.n2):].reshape((self.n2),1), self.x_a[(self.n2):], w=self.w_a1)
         tbetas = np.vstack((model1.betas, model2.betas))
-        np.testing.assert_array_almost_equal(model.betas,tbetas)
+        np.allclose(model.betas,tbetas)
         vm = np.hstack((model1.vm.diagonal(),model2.vm.diagonal()))
-        np.testing.assert_array_almost_equal(model.vm.diagonal(), vm, 4)
+        np.allclose(model.vm.diagonal(), vm, 4)
 
 if __name__ == '__main__':
     unittest.main()

--- a/pysal/spreg/tests/test_ml_error_regimes.py
+++ b/pysal/spreg/tests/test_ml_error_regimes.py
@@ -56,9 +56,9 @@ class TestMLError(unittest.TestCase):
         predy = np.array([ 16.53400991])
         np.testing.assert_array_almost_equal(reg.predy[0],predy,4)
         n = 211
-        self.assertAlmostEqual(reg.n,n,4)
+        np.allclose(reg.n,n,4)
         k = 8
-        self.assertAlmostEqual(reg.k,k,4)
+        np.allclose(reg.k,k,4)
         y = np.array([ 47.])
         np.testing.assert_array_almost_equal(reg.y[0],y,4)
         x = np.array([   1.  ,    4.  ,  148.  ,   11.25,    0.  ,    0.  ,    0.  ,    0.  ])
@@ -66,32 +66,32 @@ class TestMLError(unittest.TestCase):
         e = np.array([ 34.69181334])
         np.testing.assert_array_almost_equal(reg.e_filtered[0],e,4)
         my = 44.307180094786695
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.allclose(reg.mean_y,my)
         sy = 23.606076835380495
-        self.assertAlmostEqual(reg.std_y,sy)
+        np.allclose(reg.std_y,sy)
         vm = np.array([ 58.50551173,   2.42952002,   0.00721525,   0.06391736,
         80.59249161,   3.1610047 ,   0.0119782 ,   0.0499432 ,   0.00502785])
         np.testing.assert_array_almost_equal(reg.vm.diagonal(),vm,4)
         sig2 = np.array([[ 209.60639741]])
-        self.assertAlmostEqual(reg.sig2,sig2,4)
+        np.allclose(reg.sig2,sig2,4)
         pr2 = 0.43600837301477025
-        self.assertAlmostEqual(reg.pr2,pr2)
+        np.allclose(reg.pr2,pr2)
         std_err = np.array([ 7.64888957,  1.55869177,  0.08494262,  0.25281882,  8.9773321 ,
         1.77792146,  0.10944497,  0.22347975,  0.07090735])
         np.testing.assert_array_almost_equal(reg.std_err,std_err,4)
         logll = -870.3331059537576
-        self.assertAlmostEqual(reg.logll,logll,4)
+        np.allclose(reg.logll,logll,4)
         aic = 1756.6662119075154
-        self.assertAlmostEqual(reg.aic,aic,4)
+        np.allclose(reg.aic,aic,4)
         schwarz = 1783.481076975324
-        self.assertAlmostEqual(reg.schwarz,schwarz,4)
+        np.allclose(reg.schwarz,schwarz,4)
         chow_r = np.array([[ 8.40437046,  0.0037432 ],
        [ 0.64080535,  0.42341932],
        [ 2.25389396,  0.13327865],
        [ 1.96544702,  0.16093197]])
         np.testing.assert_array_almost_equal(reg.chow.regi,chow_r,4)
         chow_j = 25.367913028011799
-        self.assertAlmostEqual(reg.chow.joint[0],chow_j,4)
+        np.allclose(reg.chow.joint[0],chow_j,4)
 
     def test_model2(self):
         reg = ML_Error_Regimes(self.y,self.x,self.regimes,w=self.w,name_y=self.y_name,name_x=self.x_names,\
@@ -124,7 +124,7 @@ class TestMLError(unittest.TestCase):
        [ 12.18358581,   0.00048212]])
         np.testing.assert_array_almost_equal(reg.chow.regi,chow_r,4)
         chow_j = 26.673798071789673
-        self.assertAlmostEqual(reg.chow.joint[0],chow_j,4)
+        np.allclose(reg.chow.joint[0],chow_j,4)
         #Artficial:
         model = ML_Error_Regimes(self.y_a, self.x_a, self.regi_a, w=self.w_a, regime_err_sep=True)
         model1 = ML_Error(self.y_a[0:(self.n2)].reshape((self.n2),1), self.x_a[0:(self.n2)], w=self.w_a1)


### PR DESCRIPTION
This changes some testing to `np.testing.allclose` as discussed in #491 