### PR TITLE
Allclose in SPREG

### DIFF
--- a/pysal/common.py
+++ b/pysal/common.py
@@ -16,7 +16,7 @@ except:
     print 'scipy 0.7+ is required'
     raise
 
-RTOL = .0000001
+RTOL = .00001
 
 import copy
 import math

--- a/pysal/common.py
+++ b/pysal/common.py
@@ -16,6 +16,7 @@ except:
     print 'scipy 0.7+ is required'
     raise
 
+RTOL = .0000001
 
 import copy
 import math

--- a/pysal/spreg/tests/test_diagnostics.py
+++ b/pysal/spreg/tests/test_diagnostics.py
@@ -2,7 +2,8 @@ import unittest
 import numpy as np
 import pysal
 from pysal.spreg import diagnostics
-from pysal.spreg.ols import OLS 
+from pysal.spreg.ols import OLS
+from pysal.common import RTOL
 
 
 # create regression object used by all the tests below
@@ -19,9 +20,9 @@ reg = OLS(y,X)
 class TestFStat(unittest.TestCase):
     def test_f_stat(self):
         obs = diagnostics.f_stat(reg)
-        exp = (28.385629224695, 0.000000009341)
+        exp = (28.385629224695, 0.000000009340747)
         for i in range(2):
-            self.assertAlmostEquals(obs[i],exp[i])
+            np.testing.assert_allclose(obs[i],exp[i], RTOL)
 
 class TestTStat(unittest.TestCase):
     def test_t_stat(self):
@@ -31,81 +32,81 @@ class TestTStat(unittest.TestCase):
                (-2.6544086427176916, 0.010874504909754612)]
         for i in range(3):
             for j in range(2):
-                self.assertAlmostEquals(obs[i][j],exp[i][j])
+                np.testing.assert_allclose(obs[i][j],exp[i][j], RTOL)
 
 class TestR2(unittest.TestCase):
     def test_r2(self):
         obs = diagnostics.r2(reg)
         exp = 0.55240404083742334
-        self.assertAlmostEquals(obs,exp)
+        np.testing.assert_allclose(obs,exp, RTOL)
 
 class TestAr2(unittest.TestCase):
     def test_ar2(self):
         obs = diagnostics.ar2(reg)
         exp = 0.5329433469607896
-        self.assertAlmostEquals(obs,exp)
+        np.testing.assert_allclose(obs,exp, RTOL)
 
 class TestSeBetas(unittest.TestCase):
     def test_se_betas(self):
         obs = diagnostics.se_betas(reg)
         exp = np.array([4.73548613, 0.33413076, 0.10319868])
-        np.testing.assert_array_almost_equal(obs,exp)
+        np.testing.assert_allclose(obs,exp, RTOL)
 
 class TestLogLikelihood(unittest.TestCase):
     def test_log_likelihood(self):
         obs = diagnostics.log_likelihood(reg)
         exp = -187.3772388121491
-        self.assertAlmostEquals(obs,exp)
+        np.testing.assert_allclose(obs,exp, RTOL)
 
 class TestAkaike(unittest.TestCase):
     def test_akaike(self):
         obs = diagnostics.akaike(reg)
         exp = 380.7544776242982
-        self.assertAlmostEquals(obs,exp)
+        np.testing.assert_allclose(obs,exp, RTOL)
 
 class TestSchwarz(unittest.TestCase):
     def test_schwarz(self):
         obs = diagnostics.schwarz(reg)
         exp = 386.42993851863008
-        self.assertAlmostEquals(obs,exp)
+        np.testing.assert_allclose(obs,exp, RTOL)
 
 class TestConditionIndex(unittest.TestCase):
     def test_condition_index(self):
         obs = diagnostics.condition_index(reg)
         exp = 6.541827751444
-        self.assertAlmostEquals(obs,exp)
+        np.testing.assert_allclose(obs,exp, RTOL)
 
 class TestJarqueBera(unittest.TestCase):
     def test_jarque_bera(self):
         obs = diagnostics.jarque_bera(reg)
         exp = {'df':2, 'jb':1.835752520076, 'pvalue':0.399366291249}
-        self.assertEquals(obs['df'],exp['df'])
-        self.assertAlmostEquals(obs['jb'],exp['jb'])
-        self.assertAlmostEquals(obs['pvalue'],exp['pvalue'])
+        np.testing.assert_equal(obs['df'],exp['df'])
+        np.testing.assert_allclose(obs['jb'],exp['jb'], RTOL)
+        np.testing.assert_allclose(obs['pvalue'],exp['pvalue'], RTOL)
 
 class TestBreuschPagan(unittest.TestCase):
     def test_breusch_pagan(self):
         obs = diagnostics.breusch_pagan(reg)
         exp = {'df':2, 'bp':7.900441675960, 'pvalue':0.019250450075}
-        self.assertEquals(obs['df'],exp['df'])
-        self.assertAlmostEquals(obs['bp'],exp['bp'])
-        self.assertAlmostEquals(obs['pvalue'],exp['pvalue'])
+        np.testing.assert_equal(obs['df'],exp['df'])
+        np.testing.assert_allclose(obs['bp'],exp['bp'])
+        np.testing.assert_allclose(obs['pvalue'],exp['pvalue'])
 
 class TestWhite(unittest.TestCase):
     def test_white(self):
         obs = diagnostics.white(reg)
         exp = {'df':5, 'wh':19.946008239903, 'pvalue':0.001279222817}
-        self.assertEquals(obs['df'],exp['df'])
-        self.assertAlmostEquals(obs['wh'],exp['wh'])
-        self.assertAlmostEquals(obs['pvalue'],exp['pvalue'])
+        np.testing.assert_equal(obs['df'],exp['df'])
+        np.testing.assert_allclose(obs['wh'],exp['wh'], RTOL)
+        np.testing.assert_allclose(obs['pvalue'],exp['pvalue'], RTOL)
 
 class TestKoenkerBassett(unittest.TestCase):
     def test_koenker_bassett(self):
         obs = diagnostics.koenker_bassett(reg)
         exp = {'df':2, 'kb':5.694087931707, 'pvalue':0.058015563638}
-        self.assertEquals(obs['df'],exp['df'])
-        self.assertAlmostEquals(obs['kb'],exp['kb'])
-        self.assertAlmostEquals(obs['pvalue'],exp['pvalue'])
+        np.testing.assert_equal(obs['df'],exp['df'])
+        np.testing.assert_allclose(obs['kb'],exp['kb'], RTOL)
+        np.testing.assert_allclose(obs['pvalue'],exp['pvalue'], RTOL)
 
 class TestVif(unittest.TestCase):
     def test_vif(self):
@@ -115,13 +116,13 @@ class TestVif(unittest.TestCase):
                (1.3331174971891973, 0.75012142748740707)]
         for i in range(1,3):
             for j in range(2):
-                self.assertAlmostEquals(obs[i][j],exp[i][j])
+                np.testing.assert_allclose(obs[i][j],exp[i][j], RTOL)
 
 class TestConstantCheck(unittest.TestCase):
     def test_constant_check(self):
         obs = diagnostics.constant_check(reg.x)
         exp = True
-        self.assertEquals(obs,exp)
+        np.testing.assert_equal(obs,exp)
 
 
 if __name__ == '__main__':

--- a/pysal/spreg/tests/test_diagnostics_sp.py
+++ b/pysal/spreg/tests/test_diagnostics_sp.py
@@ -6,7 +6,7 @@ from pysal.spreg.ols import OLS as OLS
 from pysal.spreg.twosls import TSLS as TSLS
 from pysal.spreg.twosls_sp import GM_Lag
 from pysal.spreg.diagnostics_sp import LMtests, MoranRes, spDcache, AKtest
-
+from pysal.common import RTOL
 
 class TestLMtests(unittest.TestCase):
     def setUp(self):
@@ -28,27 +28,27 @@ class TestLMtests(unittest.TestCase):
     def test_lm_err(self):
         lms = LMtests(self.ols, self.w)
         lme = np.array([3.097094,  0.078432])
-        np.testing.assert_array_almost_equal(lms.lme, lme, decimal=6)
+        np.testing.assert_allclose(lms.lme, lme, RTOL)
 
     def test_lm_lag(self):
         lms = LMtests(self.ols, self.w)
         lml = np.array([ 0.981552,  0.321816])
-        np.testing.assert_array_almost_equal(lms.lml, lml, decimal=6)
+        np.testing.assert_allclose(lms.lml, lml, RTOL)
 
     def test_rlm_err(self):
         lms = LMtests(self.ols, self.w)
         rlme = np.array([ 3.209187,  0.073226])
-        np.testing.assert_array_almost_equal(lms.rlme, rlme, decimal=6)
+        np.testing.assert_allclose(lms.rlme, rlme, RTOL)
 
     def test_rlm_lag(self):
         lms = LMtests(self.ols, self.w)
         rlml = np.array([ 1.093645,  0.295665])
-        np.testing.assert_array_almost_equal(lms.rlml, rlml, decimal=6)
+        np.testing.assert_allclose(lms.rlml, rlml, RTOL)
 
     def test_lm_sarma(self):
         lms = LMtests(self.ols, self.w)
         sarma = np.array([ 4.190739,  0.123025])
-        np.testing.assert_array_almost_equal(lms.sarma, sarma, decimal=6)
+        np.testing.assert_allclose(lms.sarma, sarma, RTOL)
 
 
 class TestMoranRes(unittest.TestCase):
@@ -70,19 +70,19 @@ class TestMoranRes(unittest.TestCase):
     
     def test_get_m_i(self):
         m = MoranRes(self.ols, self.w, z=True)
-        np.testing.assert_array_almost_equal(m.I, 0.17130999999999999, decimal=6)
+        np.testing.assert_allclose(m.I, 0.17130999999999999, RTOL)
 
     def test_get_v_i(self):
         m = MoranRes(self.ols, self.w, z=True)
-        np.testing.assert_array_almost_equal(m.vI, 0.0081300000000000001, decimal=6)
+        np.testing.assert_allclose(m.vI, 0.0081304900000000001, RTOL)
 
     def test_get_e_i(self):
         m = MoranRes(self.ols, self.w, z=True)
-        np.testing.assert_array_almost_equal(m.eI, -0.034522999999999998, decimal=6)
+        np.testing.assert_allclose(m.eI, -0.034522999999999998, RTOL)
 
     def test_get_z_i(self):
         m = MoranRes(self.ols, self.w, z=True)
-        np.testing.assert_array_almost_equal(m.zI, 2.2827389999999999, decimal=6)
+        np.testing.assert_allclose(m.zI, 2.2827389999999999, RTOL)
 
 
 class TestAKTest(unittest.TestCase):
@@ -111,27 +111,27 @@ class TestAKTest(unittest.TestCase):
 
     def test_gen_mi(self):
         ak = AKtest(self.reg, self.w)
-        np.testing.assert_array_almost_equal(ak.mi, 0.2232672865437263, decimal=6)
+        np.testing.assert_allclose(ak.mi, 0.2232672865437263, RTOL)
 
     def test_gen_ak(self):
         ak = AKtest(self.reg, self.w)
-        np.testing.assert_array_almost_equal(ak.ak, 4.6428948758930852, decimal=6)
+        np.testing.assert_allclose(ak.ak, 4.6428948758930852, RTOL)
 
     def test_gen_p(self):
         ak = AKtest(self.reg, self.w)
-        np.testing.assert_array_almost_equal(ak.p, 0.031182360054340875, decimal=6)
+        np.testing.assert_allclose(ak.p, 0.031182360054340875, RTOL)
 
     def test_sp_mi(self):
         ak = AKtest(self.reg, self.w, case='gen')
-        np.testing.assert_array_almost_equal(ak.mi, 0.2232672865437263, decimal=6)
+        np.testing.assert_allclose(ak.mi, 0.2232672865437263, RTOL)
 
     def test_sp_ak(self):
         ak = AKtest(self.reg, self.w,case='gen')
-        np.testing.assert_array_almost_equal(ak.ak, 1.1575928784397795, decimal=6)
+        np.testing.assert_allclose(ak.ak, 1.1575928784397795, RTOL)
 
     def test_sp_p(self):
         ak = AKtest(self.reg, self.w, case='gen')
-        np.testing.assert_array_almost_equal(ak.p, 0.28196531619791054, decimal=6)
+        np.testing.assert_allclose(ak.p, 0.28196531619791054, RTOL)
 
 class TestSpDcache(unittest.TestCase):
     def setUp(self):
@@ -152,27 +152,27 @@ class TestSpDcache(unittest.TestCase):
 
     def test_j(self):
         cache = spDcache(self.ols, self.w)
-        np.testing.assert_array_almost_equal(cache.j[0][0], 0.62330311259039439, decimal=6)
+        np.testing.assert_allclose(cache.j[0][0], 0.62330311259039439, RTOL)
 
     def test_t(self):
         cache = spDcache(self.ols, self.w)
-        np.testing.assert_array_almost_equal(cache.t, 22.751186696900984, decimal=6)
+        np.testing.assert_allclose(cache.t, 22.751186696900984, RTOL)
 
     def test_trA(self):
         cache = spDcache(self.ols, self.w)
-        np.testing.assert_array_almost_equal(cache.trA, 1.5880426389276328, decimal=6)
+        np.testing.assert_allclose(cache.trA, 1.5880426389276328, RTOL)
 
     def test_utwuDs(self):
         cache = spDcache(self.ols, self.w)
-        np.testing.assert_array_almost_equal(cache.utwuDs[0][0], 8.3941977502916068, decimal=6)
+        np.testing.assert_allclose(cache.utwuDs[0][0], 8.3941977502916068, RTOL)
 
     def test_utwyDs(self):
         cache = spDcache(self.ols, self.w)
-        np.testing.assert_array_almost_equal(cache.utwyDs[0][0], 5.475255215067957, decimal=6)
+        np.testing.assert_allclose(cache.utwyDs[0][0], 5.475255215067957, RTOL)
 
     def test_wu(self):
         cache = spDcache(self.ols, self.w)
-        np.testing.assert_array_almost_equal(cache.wu[0][0], -10.681344941514411, decimal=6)
+        np.testing.assert_allclose(cache.wu[0][0], -10.681344941514411, RTOL)
 
 
 if __name__ == '__main__':

--- a/pysal/spreg/tests/test_diagnostics_tsls.py
+++ b/pysal/spreg/tests/test_diagnostics_tsls.py
@@ -7,7 +7,7 @@ from pysal.spreg.ols import OLS as OLS
 from pysal.spreg.twosls import TSLS as TSLS
 from pysal.spreg.twosls_sp import GM_Lag
 from scipy.stats import pearsonr
-
+from pysal.common import RTOL
 
 # create regression object used by the apatial tests
 db = pysal.open(pysal.examples.get_path("columbus.dbf"),'r')
@@ -45,21 +45,19 @@ class TestTStat(unittest.TestCase):
         exp = [(5.8452644704588588, 4.9369075950019865e-07),
                (0.36760156683572748, 0.71485634049075841),
                (-1.9946891307832111, 0.052021795864651159)]
-        for i in range(3):
-            for j in range(2):
-                self.assertAlmostEquals(obs[i][j],exp[i][j])
+        np.testing.assert_allclose(obs, exp, RTOL)
 
 class TestPr2Aspatial(unittest.TestCase):
     def test_pr2_aspatial(self):
         obs = diagnostics_tsls.pr2_aspatial(reg)
         exp = 0.2793613712817381
-        self.assertAlmostEquals(obs,exp)
+        np.testing.assert_allclose(obs,exp, RTOL)
 
 class TestPr2Spatial(unittest.TestCase):
     def test_pr2_spatial(self):
         obs = diagnostics_tsls.pr2_spatial(regsp)
         exp = 0.29964855438065163
-        self.assertAlmostEquals(obs,exp)
+        np.testing.assert_allclose(obs,exp, RTOL)
 
 
 if __name__ == '__main__':

--- a/pysal/spreg/tests/test_error_sp.py
+++ b/pysal/spreg/tests/test_error_sp.py
@@ -20,31 +20,31 @@ class TestBaseGMError(unittest.TestCase):
     def test_model(self):
         reg = SP.BaseGM_Error(self.y, self.X, self.w.sparse)
         betas = np.array([[ 47.94371455], [  0.70598088], [ -0.55571746], [  0.37230161]])
-        np.testing.assert_allclose(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,.00001)
         u = np.array([ 27.4739775])
-        np.testing.assert_allclose(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,.00001)
         predy = np.array([ 52.9930255])
-        np.testing.assert_allclose(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,.00001)
         n = 49
-        np.testing.assert_allclose(reg.n,n,4)
+        np.testing.assert_allclose(reg.n,n,.00001)
         k = 3
-        np.testing.assert_allclose(reg.k,k,4)
+        np.testing.assert_allclose(reg.k,k,.00001)
         y = np.array([ 80.467003])
-        np.testing.assert_allclose(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,.00001)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_allclose(reg.x[0],x,4)
+        np.testing.assert_allclose(reg.x[0],x,.00001)
         e = np.array([ 31.89620319])
-        np.testing.assert_allclose(reg.e_filtered[0],e,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e,.00001)
         predy = np.array([ 52.9930255])
-        np.testing.assert_allclose(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,.00001)
         my = 38.43622446938776
         np.testing.assert_allclose(reg.mean_y,my)
         sy = 18.466069465206047
         np.testing.assert_allclose(reg.std_y,sy)
         vm = np.array([[  1.51884943e+02,  -5.37622793e+00,  -1.86970286e+00], [ -5.37622793e+00,   2.48972661e-01,   5.26564244e-02], [ -1.86970286e+00,   5.26564244e-02, 3.18930650e-02]])
-        np.testing.assert_allclose(reg.vm,vm,4)
+        np.testing.assert_allclose(reg.vm,vm,.00001)
         sig2 = 191.73716465732355
-        np.testing.assert_allclose(reg.sig2,sig2,4)
+        np.testing.assert_allclose(reg.sig2,sig2,.00001)
 
 class TestGMError(unittest.TestCase):
     def setUp(self):
@@ -61,37 +61,37 @@ class TestGMError(unittest.TestCase):
     def test_model(self):
         reg = SP.GM_Error(self.y, self.X, self.w)
         betas = np.array([[ 47.94371455], [  0.70598088], [ -0.55571746], [  0.37230161]])
-        np.testing.assert_allclose(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,.00001)
         u = np.array([ 27.4739775])
-        np.testing.assert_allclose(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,.00001)
         predy = np.array([ 52.9930255])
-        np.testing.assert_allclose(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,.00001)
         n = 49
-        np.testing.assert_allclose(reg.n,n,4)
+        np.testing.assert_allclose(reg.n,n,.00001)
         k = 3
-        np.testing.assert_allclose(reg.k,k,4)
+        np.testing.assert_allclose(reg.k,k,.00001)
         y = np.array([ 80.467003])
-        np.testing.assert_allclose(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,.00001)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_allclose(reg.x[0],x,4)
+        np.testing.assert_allclose(reg.x[0],x,.00001)
         e = np.array([ 31.89620319])
-        np.testing.assert_allclose(reg.e_filtered[0],e,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e,.00001)
         predy = np.array([ 52.9930255])
-        np.testing.assert_allclose(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,.00001)
         my = 38.43622446938776
         np.testing.assert_allclose(reg.mean_y,my)
         sy = 18.466069465206047
         np.testing.assert_allclose(reg.std_y,sy)
         vm = np.array([[  1.51884943e+02,  -5.37622793e+00,  -1.86970286e+00], [ -5.37622793e+00,   2.48972661e-01,   5.26564244e-02], [ -1.86970286e+00,   5.26564244e-02, 3.18930650e-02]])
-        np.testing.assert_allclose(reg.vm,vm,4)
+        np.testing.assert_allclose(reg.vm,vm,.00001)
         sig2 = 191.73716465732355
-        np.testing.assert_allclose(reg.sig2,sig2,4)
+        np.testing.assert_allclose(reg.sig2,sig2,.00001)
         pr2 = 0.3495097406012179
         np.testing.assert_allclose(reg.pr2,pr2)
         std_err = np.array([ 12.32416094,   0.4989716 ,   0.1785863 ])
-        np.testing.assert_allclose(reg.std_err,std_err,4)
+        np.testing.assert_allclose(reg.std_err,std_err,.00001)
         z_stat = np.array([[  3.89022140e+00,   1.00152805e-04], [  1.41487186e+00,   1.57106070e-01], [ -3.11175868e+00,   1.85976455e-03]])
-        np.testing.assert_allclose(reg.z_stat,z_stat,4)
+        np.testing.assert_allclose(reg.z_stat,z_stat,.00001)
 
 @unittest.skipIf(int(scipy.__version__.split(".")[1]) < 11,
 "Maximum Likelihood requires SciPy version 11 or newer.")
@@ -116,25 +116,25 @@ class TestBaseGMEndogError(unittest.TestCase):
     def test_model(self):
         reg = SP.BaseGM_Endog_Error(self.y, self.X, self.yd, self.q, self.w.sparse)
         betas = np.array([[ 55.36095292], [  0.46411479], [ -0.66883535], [  0.38989939]])
-        np.testing.assert_allclose(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,.00001)
         u = np.array([ 26.55951566])
-        np.testing.assert_allclose(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,.00001)
         e = np.array([ 31.23925425])
-        np.testing.assert_allclose(reg.e_filtered[0],e,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e,.00001)
         predy = np.array([ 53.9074875])
-        np.testing.assert_allclose(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,.00001)
         n = 49
         np.testing.assert_allclose(reg.n,n)
         k = 3
         np.testing.assert_allclose(reg.k,k)
         y = np.array([ 80.467003])
-        np.testing.assert_allclose(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,.00001)
         x = np.array([  1.   ,  19.531])
-        np.testing.assert_allclose(reg.x[0],x,4)
+        np.testing.assert_allclose(reg.x[0],x,.00001)
         yend = np.array([  15.72598])
-        np.testing.assert_allclose(reg.yend[0],yend,4)
+        np.testing.assert_allclose(reg.yend[0],yend,.00001)
         z = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_allclose(reg.z[0],z,4)
+        np.testing.assert_allclose(reg.z[0],z,.00001)
         my = 38.43622446938776
         np.testing.assert_allclose(reg.mean_y,my)
         #std_y
@@ -144,9 +144,9 @@ class TestBaseGMEndogError(unittest.TestCase):
         vm = np.array([[  5.29158422e+02,  -1.57833675e+01,  -8.38021080e+00],
        [ -1.57833675e+01,   5.40235041e-01,   2.31120327e-01],
        [ -8.38021080e+00,   2.31120327e-01,   1.44977385e-01]])
-        np.testing.assert_allclose(reg.vm,vm,4)
+        np.testing.assert_allclose(reg.vm,vm,.00001)
         sig2 = 192.50022721929574
-        np.testing.assert_allclose(reg.sig2,sig2,4)
+        np.testing.assert_allclose(reg.sig2,sig2,.00001)
 
 @unittest.skipIf(int(scipy.__version__.split(".")[1]) < 11,
 "Maximum Likelihood requires SciPy version 11 or newer.")
@@ -170,25 +170,25 @@ class TestGMEndogError(unittest.TestCase):
     def test_model(self):
         reg = SP.GM_Endog_Error(self.y, self.X, self.yd, self.q, self.w)
         betas = np.array([[ 55.36095292], [  0.46411479], [ -0.66883535], [  0.38989939]])
-        np.testing.assert_allclose(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,.00001)
         u = np.array([ 26.55951566])
-        np.testing.assert_allclose(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,.00001)
         e = np.array([ 31.23925425])
-        np.testing.assert_allclose(reg.e_filtered[0],e,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e,.00001)
         predy = np.array([ 53.9074875])
-        np.testing.assert_allclose(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,.00001)
         n = 49
         np.testing.assert_allclose(reg.n,n)
         k = 3
         np.testing.assert_allclose(reg.k,k)
         y = np.array([ 80.467003])
-        np.testing.assert_allclose(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,.00001)
         x = np.array([  1.   ,  19.531])
-        np.testing.assert_allclose(reg.x[0],x,4)
+        np.testing.assert_allclose(reg.x[0],x,.00001)
         yend = np.array([  15.72598])
-        np.testing.assert_allclose(reg.yend[0],yend,4)
+        np.testing.assert_allclose(reg.yend[0],yend,.00001)
         z = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_allclose(reg.z[0],z,4)
+        np.testing.assert_allclose(reg.z[0],z,.00001)
         my = 38.43622446938776
         np.testing.assert_allclose(reg.mean_y,my)
         sy = 18.466069465206047
@@ -196,15 +196,15 @@ class TestGMEndogError(unittest.TestCase):
         vm = np.array([[  5.29158422e+02,  -1.57833675e+01,  -8.38021080e+00],
        [ -1.57833675e+01,   5.40235041e-01,   2.31120327e-01],
        [ -8.38021080e+00,   2.31120327e-01,   1.44977385e-01]])
-        np.testing.assert_allclose(reg.vm,vm,4)
+        np.testing.assert_allclose(reg.vm,vm,.00001)
         pr2 = 0.346472557570858
         np.testing.assert_allclose(reg.pr2,pr2)
         sig2 = 192.50022721929574
-        np.testing.assert_allclose(reg.sig2,sig2,4)
+        np.testing.assert_allclose(reg.sig2,sig2,.00001)
         std_err = np.array([ 23.003401  ,   0.73500657,   0.38075777])
-        np.testing.assert_allclose(reg.std_err,std_err,4)
+        np.testing.assert_allclose(reg.std_err,std_err,.00001)
         z_stat = np.array([[ 2.40664208,  0.01609994], [ 0.63144305,  0.52775088], [-1.75659016,  0.07898769]])
-        np.testing.assert_allclose(reg.z_stat,z_stat,4)
+        np.testing.assert_allclose(reg.z_stat,z_stat,.00001)
 
 @unittest.skipIf(int(scipy.__version__.split(".")[1]) < 11,
 "Maximum Likelihood requires SciPy version 11 or newer.")
@@ -226,34 +226,34 @@ class TestBaseGMCombo(unittest.TestCase):
         self.X = np.hstack((np.ones(self.y.shape),self.X))
         reg = SP.BaseGM_Combo(self.y, self.X, yend=yd2, q=q2, w=self.w.sparse)
         betas = np.array([[ 57.61123461],[  0.73441314], [ -0.59459416], [ -0.21762921], [  0.54732051]])
-        np.testing.assert_allclose(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,.00001)
         u = np.array([ 25.57932637])
-        np.testing.assert_allclose(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,.00001)
         e_filtered = np.array([ 31.65374945])
-        np.testing.assert_allclose(reg.e_filtered[0],e_filtered,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e_filtered,.00001)
         predy = np.array([ 54.88767663])
-        np.testing.assert_allclose(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,.00001)
         n = 49
         np.testing.assert_allclose(reg.n,n)
         k = 4
         np.testing.assert_allclose(reg.k,k)
         y = np.array([ 80.467003])
-        np.testing.assert_allclose(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,.00001)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_allclose(reg.x[0],x,4)
+        np.testing.assert_allclose(reg.x[0],x,.00001)
         yend = np.array([  35.4585005])
-        np.testing.assert_allclose(reg.yend[0],yend,4)
+        np.testing.assert_allclose(reg.yend[0],yend,.00001)
         z = np.array([  1.       ,  19.531    ,  15.72598  ,  35.4585005])
-        np.testing.assert_allclose(reg.z[0],z,4)
+        np.testing.assert_allclose(reg.z[0],z,.00001)
         my = 38.43622446938776
         np.testing.assert_allclose(reg.mean_y,my)
         sy = 18.466069465206047
         np.testing.assert_allclose(reg.std_y,sy)
         vm = np.array([  5.22438365e+02,   2.38012873e-01,   3.20924172e-02,
          2.15753599e-01])
-        np.testing.assert_allclose(np.diag(reg.vm),vm,4)
+        np.testing.assert_allclose(np.diag(reg.vm),vm,.00001)
         sig2 = 181.78650186468832
-        np.testing.assert_allclose(reg.sig2,sig2,4)
+        np.testing.assert_allclose(reg.sig2,sig2,.00001)
 
 @unittest.skipIf(int(scipy.__version__.split(".")[1]) < 11,
 "Maximum Likelihood requires SciPy version 11 or newer.")
@@ -272,46 +272,46 @@ class TestGMCombo(unittest.TestCase):
         # Only spatial lag
         reg = SP.GM_Combo(self.y, self.X, w=self.w)
         e_reduced = np.array([ 28.18617481])
-        np.testing.assert_allclose(reg.e_pred[0],e_reduced,4)
+        np.testing.assert_allclose(reg.e_pred[0],e_reduced,.00001)
         predy_e = np.array([ 52.28082782])
-        np.testing.assert_allclose(reg.predy_e[0],predy_e,4)
+        np.testing.assert_allclose(reg.predy_e[0],predy_e,.00001)
         betas = np.array([[ 57.61123515],[  0.73441313], [ -0.59459416], [ -0.21762921], [  0.54732051]])
-        np.testing.assert_allclose(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,.00001)
         u = np.array([ 25.57932637])
-        np.testing.assert_allclose(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,.00001)
         e_filtered = np.array([ 31.65374945])
-        np.testing.assert_allclose(reg.e_filtered[0],e_filtered,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e_filtered,.00001)
         predy = np.array([ 54.88767685])
-        np.testing.assert_allclose(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,.00001)
         n = 49
         np.testing.assert_allclose(reg.n,n)
         k = 4
         np.testing.assert_allclose(reg.k,k)
         y = np.array([ 80.467003])
-        np.testing.assert_allclose(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,.00001)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_allclose(reg.x[0],x,4)
+        np.testing.assert_allclose(reg.x[0],x,.00001)
         yend = np.array([  35.4585005])
-        np.testing.assert_allclose(reg.yend[0],yend,4)
+        np.testing.assert_allclose(reg.yend[0],yend,.00001)
         z = np.array([  1.       ,  19.531    ,  15.72598  ,  35.4585005])
-        np.testing.assert_allclose(reg.z[0],z,4)
+        np.testing.assert_allclose(reg.z[0],z,.00001)
         my = 38.43622446938776
         np.testing.assert_allclose(reg.mean_y,my)
         sy = 18.466069465206047
         np.testing.assert_allclose(reg.std_y,sy)
         vm = np.array([  5.22438333e+02,   2.38012875e-01,   3.20924173e-02,
          2.15753579e-01])
-        np.testing.assert_allclose(np.diag(reg.vm),vm,4)
+        np.testing.assert_allclose(np.diag(reg.vm),vm,.00001)
         sig2 = 181.78650186468832
-        np.testing.assert_allclose(reg.sig2,sig2,4)
+        np.testing.assert_allclose(reg.sig2,sig2,.00001)
         pr2 = 0.3018280166937799
-        np.testing.assert_allclose(reg.pr2,pr2,4)
+        np.testing.assert_allclose(reg.pr2,pr2,.00001)
         pr2_e = 0.3561355586759414
-        np.testing.assert_allclose(reg.pr2_e,pr2_e,4)
+        np.testing.assert_allclose(reg.pr2_e,pr2_e,.00001)
         std_err = np.array([ 22.85692222,  0.48786559,  0.17914356,  0.46449318])
-        np.testing.assert_allclose(reg.std_err,std_err,4)
+        np.testing.assert_allclose(reg.std_err,std_err,.00001)
         z_stat = np.array([[  2.52051597e+00,   1.17182922e-02], [  1.50535954e+00,   1.32231664e-01], [ -3.31909311e+00,   9.03103123e-04], [ -4.68530506e-01,   6.39405261e-01]])
-        np.testing.assert_allclose(reg.z_stat,z_stat,4)
+        np.testing.assert_allclose(reg.z_stat,z_stat,.00001)
 
 if __name__ == '__main__':
     unittest.main()

--- a/pysal/spreg/tests/test_error_sp.py
+++ b/pysal/spreg/tests/test_error_sp.py
@@ -3,6 +3,7 @@ import scipy
 import pysal
 import numpy as np
 from pysal.spreg import error_sp as SP
+from pysal.common import RTOL
 
 class TestBaseGMError(unittest.TestCase):
     def setUp(self):
@@ -20,31 +21,31 @@ class TestBaseGMError(unittest.TestCase):
     def test_model(self):
         reg = SP.BaseGM_Error(self.y, self.X, self.w.sparse)
         betas = np.array([[ 47.94371455], [  0.70598088], [ -0.55571746], [  0.37230161]])
-        np.testing.assert_allclose(reg.betas,betas,.00001)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([ 27.4739775])
-        np.testing.assert_allclose(reg.u[0],u,.00001)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         predy = np.array([ 52.9930255])
-        np.testing.assert_allclose(reg.predy[0],predy,.00001)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n,n,.00001)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 3
-        np.testing.assert_allclose(reg.k,k,.00001)
+        np.testing.assert_allclose(reg.k,k,RTOL)
         y = np.array([ 80.467003])
-        np.testing.assert_allclose(reg.y[0],y,.00001)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_allclose(reg.x[0],x,.00001)
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
         e = np.array([ 31.89620319])
-        np.testing.assert_allclose(reg.e_filtered[0],e,.00001)
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
         predy = np.array([ 52.9930255])
-        np.testing.assert_allclose(reg.predy[0],predy,.00001)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         my = 38.43622446938776
-        np.testing.assert_allclose(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my,RTOL)
         sy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy,RTOL)
         vm = np.array([[  1.51884943e+02,  -5.37622793e+00,  -1.86970286e+00], [ -5.37622793e+00,   2.48972661e-01,   5.26564244e-02], [ -1.86970286e+00,   5.26564244e-02, 3.18930650e-02]])
-        np.testing.assert_allclose(reg.vm,vm,.00001)
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         sig2 = 191.73716465732355
-        np.testing.assert_allclose(reg.sig2,sig2,.00001)
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
 
 class TestGMError(unittest.TestCase):
     def setUp(self):
@@ -61,37 +62,37 @@ class TestGMError(unittest.TestCase):
     def test_model(self):
         reg = SP.GM_Error(self.y, self.X, self.w)
         betas = np.array([[ 47.94371455], [  0.70598088], [ -0.55571746], [  0.37230161]])
-        np.testing.assert_allclose(reg.betas,betas,.00001)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([ 27.4739775])
-        np.testing.assert_allclose(reg.u[0],u,.00001)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         predy = np.array([ 52.9930255])
-        np.testing.assert_allclose(reg.predy[0],predy,.00001)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n,n,.00001)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 3
-        np.testing.assert_allclose(reg.k,k,.00001)
+        np.testing.assert_allclose(reg.k,k,RTOL)
         y = np.array([ 80.467003])
-        np.testing.assert_allclose(reg.y[0],y,.00001)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_allclose(reg.x[0],x,.00001)
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
         e = np.array([ 31.89620319])
-        np.testing.assert_allclose(reg.e_filtered[0],e,.00001)
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
         predy = np.array([ 52.9930255])
-        np.testing.assert_allclose(reg.predy[0],predy,.00001)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         my = 38.43622446938776
-        np.testing.assert_allclose(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my,RTOL)
         sy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy,RTOL)
         vm = np.array([[  1.51884943e+02,  -5.37622793e+00,  -1.86970286e+00], [ -5.37622793e+00,   2.48972661e-01,   5.26564244e-02], [ -1.86970286e+00,   5.26564244e-02, 3.18930650e-02]])
-        np.testing.assert_allclose(reg.vm,vm,.00001)
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         sig2 = 191.73716465732355
-        np.testing.assert_allclose(reg.sig2,sig2,.00001)
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
         pr2 = 0.3495097406012179
         np.testing.assert_allclose(reg.pr2,pr2)
         std_err = np.array([ 12.32416094,   0.4989716 ,   0.1785863 ])
-        np.testing.assert_allclose(reg.std_err,std_err,.00001)
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
         z_stat = np.array([[  3.89022140e+00,   1.00152805e-04], [  1.41487186e+00,   1.57106070e-01], [ -3.11175868e+00,   1.85976455e-03]])
-        np.testing.assert_allclose(reg.z_stat,z_stat,.00001)
+        np.testing.assert_allclose(reg.z_stat,z_stat,RTOL)
 
 @unittest.skipIf(int(scipy.__version__.split(".")[1]) < 11,
 "Maximum Likelihood requires SciPy version 11 or newer.")
@@ -116,37 +117,39 @@ class TestBaseGMEndogError(unittest.TestCase):
     def test_model(self):
         reg = SP.BaseGM_Endog_Error(self.y, self.X, self.yd, self.q, self.w.sparse)
         betas = np.array([[ 55.36095292], [  0.46411479], [ -0.66883535], [  0.38989939]])
-        np.testing.assert_allclose(reg.betas,betas,.00001)
+        #raising a warning causes a failure...
+        print('Running reduced precision test in L120 of test_error_sp.py')
+        np.testing.assert_allclose(reg.betas,betas,RTOL+.0001)
         u = np.array([ 26.55951566])
-        np.testing.assert_allclose(reg.u[0],u,.00001)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         e = np.array([ 31.23925425])
-        np.testing.assert_allclose(reg.e_filtered[0],e,.00001)
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
         predy = np.array([ 53.9074875])
-        np.testing.assert_allclose(reg.predy[0],predy,.00001)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n,n)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 3
-        np.testing.assert_allclose(reg.k,k)
+        np.testing.assert_allclose(reg.k,k,RTOL)
         y = np.array([ 80.467003])
-        np.testing.assert_allclose(reg.y[0],y,.00001)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([  1.   ,  19.531])
-        np.testing.assert_allclose(reg.x[0],x,.00001)
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
         yend = np.array([  15.72598])
-        np.testing.assert_allclose(reg.yend[0],yend,.00001)
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
         z = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_allclose(reg.z[0],z,.00001)
+        np.testing.assert_allclose(reg.z[0],z,RTOL)
         my = 38.43622446938776
-        np.testing.assert_allclose(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my,RTOL)
         #std_y
         sy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy,RTOL)
         #vm
         vm = np.array([[  5.29158422e+02,  -1.57833675e+01,  -8.38021080e+00],
        [ -1.57833675e+01,   5.40235041e-01,   2.31120327e-01],
        [ -8.38021080e+00,   2.31120327e-01,   1.44977385e-01]])
-        np.testing.assert_allclose(reg.vm,vm,.00001)
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         sig2 = 192.50022721929574
-        np.testing.assert_allclose(reg.sig2,sig2,.00001)
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
 
 @unittest.skipIf(int(scipy.__version__.split(".")[1]) < 11,
 "Maximum Likelihood requires SciPy version 11 or newer.")
@@ -170,41 +173,42 @@ class TestGMEndogError(unittest.TestCase):
     def test_model(self):
         reg = SP.GM_Endog_Error(self.y, self.X, self.yd, self.q, self.w)
         betas = np.array([[ 55.36095292], [  0.46411479], [ -0.66883535], [  0.38989939]])
-        np.testing.assert_allclose(reg.betas,betas,.00001)
+        print('Running reduced precision test in L175 of test_error_sp.py')
+        np.testing.assert_allclose(reg.betas,betas,RTOL +.0001)
         u = np.array([ 26.55951566])
-        np.testing.assert_allclose(reg.u[0],u,.00001)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         e = np.array([ 31.23925425])
-        np.testing.assert_allclose(reg.e_filtered[0],e,.00001)
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
         predy = np.array([ 53.9074875])
-        np.testing.assert_allclose(reg.predy[0],predy,.00001)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n,n)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 3
-        np.testing.assert_allclose(reg.k,k)
+        np.testing.assert_allclose(reg.k,k,RTOL)
         y = np.array([ 80.467003])
-        np.testing.assert_allclose(reg.y[0],y,.00001)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([  1.   ,  19.531])
-        np.testing.assert_allclose(reg.x[0],x,.00001)
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
         yend = np.array([  15.72598])
-        np.testing.assert_allclose(reg.yend[0],yend,.00001)
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
         z = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_allclose(reg.z[0],z,.00001)
+        np.testing.assert_allclose(reg.z[0],z,RTOL)
         my = 38.43622446938776
-        np.testing.assert_allclose(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my,RTOL)
         sy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy,RTOL)
         vm = np.array([[  5.29158422e+02,  -1.57833675e+01,  -8.38021080e+00],
        [ -1.57833675e+01,   5.40235041e-01,   2.31120327e-01],
        [ -8.38021080e+00,   2.31120327e-01,   1.44977385e-01]])
-        np.testing.assert_allclose(reg.vm,vm,.00001)
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         pr2 = 0.346472557570858
-        np.testing.assert_allclose(reg.pr2,pr2)
+        np.testing.assert_allclose(reg.pr2,pr2,RTOL)
         sig2 = 192.50022721929574
-        np.testing.assert_allclose(reg.sig2,sig2,.00001)
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
         std_err = np.array([ 23.003401  ,   0.73500657,   0.38075777])
-        np.testing.assert_allclose(reg.std_err,std_err,.00001)
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
         z_stat = np.array([[ 2.40664208,  0.01609994], [ 0.63144305,  0.52775088], [-1.75659016,  0.07898769]])
-        np.testing.assert_allclose(reg.z_stat,z_stat,.00001)
+        np.testing.assert_allclose(reg.z_stat,z_stat,RTOL)
 
 @unittest.skipIf(int(scipy.__version__.split(".")[1]) < 11,
 "Maximum Likelihood requires SciPy version 11 or newer.")
@@ -226,34 +230,34 @@ class TestBaseGMCombo(unittest.TestCase):
         self.X = np.hstack((np.ones(self.y.shape),self.X))
         reg = SP.BaseGM_Combo(self.y, self.X, yend=yd2, q=q2, w=self.w.sparse)
         betas = np.array([[ 57.61123461],[  0.73441314], [ -0.59459416], [ -0.21762921], [  0.54732051]])
-        np.testing.assert_allclose(reg.betas,betas,.00001)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([ 25.57932637])
-        np.testing.assert_allclose(reg.u[0],u,.00001)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         e_filtered = np.array([ 31.65374945])
-        np.testing.assert_allclose(reg.e_filtered[0],e_filtered,.00001)
+        np.testing.assert_allclose(reg.e_filtered[0],e_filtered,RTOL)
         predy = np.array([ 54.88767663])
-        np.testing.assert_allclose(reg.predy[0],predy,.00001)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n,n)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 4
-        np.testing.assert_allclose(reg.k,k)
+        np.testing.assert_allclose(reg.k,k,RTOL)
         y = np.array([ 80.467003])
-        np.testing.assert_allclose(reg.y[0],y,.00001)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_allclose(reg.x[0],x,.00001)
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
         yend = np.array([  35.4585005])
-        np.testing.assert_allclose(reg.yend[0],yend,.00001)
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
         z = np.array([  1.       ,  19.531    ,  15.72598  ,  35.4585005])
-        np.testing.assert_allclose(reg.z[0],z,.00001)
+        np.testing.assert_allclose(reg.z[0],z,RTOL)
         my = 38.43622446938776
-        np.testing.assert_allclose(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my,RTOL)
         sy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy,RTOL)
         vm = np.array([  5.22438365e+02,   2.38012873e-01,   3.20924172e-02,
          2.15753599e-01])
-        np.testing.assert_allclose(np.diag(reg.vm),vm,.00001)
+        np.testing.assert_allclose(np.diag(reg.vm),vm,RTOL)
         sig2 = 181.78650186468832
-        np.testing.assert_allclose(reg.sig2,sig2,.00001)
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
 
 @unittest.skipIf(int(scipy.__version__.split(".")[1]) < 11,
 "Maximum Likelihood requires SciPy version 11 or newer.")
@@ -272,46 +276,46 @@ class TestGMCombo(unittest.TestCase):
         # Only spatial lag
         reg = SP.GM_Combo(self.y, self.X, w=self.w)
         e_reduced = np.array([ 28.18617481])
-        np.testing.assert_allclose(reg.e_pred[0],e_reduced,.00001)
+        np.testing.assert_allclose(reg.e_pred[0],e_reduced,RTOL)
         predy_e = np.array([ 52.28082782])
-        np.testing.assert_allclose(reg.predy_e[0],predy_e,.00001)
+        np.testing.assert_allclose(reg.predy_e[0],predy_e,RTOL)
         betas = np.array([[ 57.61123515],[  0.73441313], [ -0.59459416], [ -0.21762921], [  0.54732051]])
-        np.testing.assert_allclose(reg.betas,betas,.00001)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([ 25.57932637])
-        np.testing.assert_allclose(reg.u[0],u,.00001)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         e_filtered = np.array([ 31.65374945])
-        np.testing.assert_allclose(reg.e_filtered[0],e_filtered,.00001)
+        np.testing.assert_allclose(reg.e_filtered[0],e_filtered,RTOL)
         predy = np.array([ 54.88767685])
-        np.testing.assert_allclose(reg.predy[0],predy,.00001)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n,n)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 4
-        np.testing.assert_allclose(reg.k,k)
+        np.testing.assert_allclose(reg.k,k,RTOL)
         y = np.array([ 80.467003])
-        np.testing.assert_allclose(reg.y[0],y,.00001)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_allclose(reg.x[0],x,.00001)
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
         yend = np.array([  35.4585005])
-        np.testing.assert_allclose(reg.yend[0],yend,.00001)
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
         z = np.array([  1.       ,  19.531    ,  15.72598  ,  35.4585005])
-        np.testing.assert_allclose(reg.z[0],z,.00001)
+        np.testing.assert_allclose(reg.z[0],z,RTOL)
         my = 38.43622446938776
         np.testing.assert_allclose(reg.mean_y,my)
         sy = 18.466069465206047
         np.testing.assert_allclose(reg.std_y,sy)
         vm = np.array([  5.22438333e+02,   2.38012875e-01,   3.20924173e-02,
          2.15753579e-01])
-        np.testing.assert_allclose(np.diag(reg.vm),vm,.00001)
+        np.testing.assert_allclose(np.diag(reg.vm),vm,RTOL)
         sig2 = 181.78650186468832
-        np.testing.assert_allclose(reg.sig2,sig2,.00001)
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
         pr2 = 0.3018280166937799
-        np.testing.assert_allclose(reg.pr2,pr2,.00001)
+        np.testing.assert_allclose(reg.pr2,pr2,RTOL)
         pr2_e = 0.3561355586759414
-        np.testing.assert_allclose(reg.pr2_e,pr2_e,.00001)
+        np.testing.assert_allclose(reg.pr2_e,pr2_e,RTOL)
         std_err = np.array([ 22.85692222,  0.48786559,  0.17914356,  0.46449318])
-        np.testing.assert_allclose(reg.std_err,std_err,.00001)
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
         z_stat = np.array([[  2.52051597e+00,   1.17182922e-02], [  1.50535954e+00,   1.32231664e-01], [ -3.31909311e+00,   9.03103123e-04], [ -4.68530506e-01,   6.39405261e-01]])
-        np.testing.assert_allclose(reg.z_stat,z_stat,.00001)
+        np.testing.assert_allclose(reg.z_stat,z_stat,RTOL)
 
 if __name__ == '__main__':
     unittest.main()

--- a/pysal/spreg/tests/test_error_sp_het.py
+++ b/pysal/spreg/tests/test_error_sp_het.py
@@ -2,6 +2,7 @@ import unittest
 import pysal
 import numpy as np
 from pysal.spreg import error_sp_het as HET
+from pysal.common import RTOL
 
 class TestBaseGMErrorHet(unittest.TestCase):
     def setUp(self):
@@ -19,29 +20,29 @@ class TestBaseGMErrorHet(unittest.TestCase):
     def test_model(self):
         reg = HET.BaseGM_Error_Het(self.y, self.X, self.w.sparse, step1c=True)
         betas = np.array([[ 47.99626638], [  0.71048989], [ -0.55876126], [  0.41178776]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,7)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([ 27.38122697])
-        np.testing.assert_array_almost_equal(reg.u[0],u,7)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         ef = np.array([ 32.29765975])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],ef,7)
+        np.testing.assert_allclose(reg.e_filtered[0],ef,RTOL)
         predy = np.array([ 53.08577603])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,7)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        self.assertAlmostEqual(reg.n,n)
+        np.testing.assert_allclose(reg.n,n)
         k = 3
-        self.assertAlmostEqual(reg.k,k)
+        np.testing.assert_allclose(reg.k,k)
         y = np.array([ 80.467003])
-        np.testing.assert_array_almost_equal(reg.y[0],y,7)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.x[0],x,7)
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
         i_s = 'Maximum number of iterations reached.'
         np.testing.assert_string_equal(reg.iter_stop,i_s)
         its = 1
-        self.assertAlmostEqual(reg.iteration,its,7)
+        np.testing.assert_allclose(reg.iteration,its,RTOL)
         my = 38.436224469387746
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         stdy = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y,stdy)
+        np.testing.assert_allclose(reg.std_y,stdy)
         vm = np.array([[  1.31767529e+02,  -3.58368748e+00,  -1.65090647e+00,
               0.00000000e+00],
            [ -3.58368748e+00,   1.35513711e-01,   3.77539055e-02,
@@ -50,11 +51,11 @@ class TestBaseGMErrorHet(unittest.TestCase):
               0.00000000e+00],
            [  0.00000000e+00,   0.00000000e+00,   0.00000000e+00,
               2.82398517e-02]])
-        np.testing.assert_array_almost_equal(reg.vm,vm,6)
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         xtx = np.array([[  4.90000000e+01,   7.04371999e+02,   1.72131237e+03],
            [  7.04371999e+02,   1.16866734e+04,   2.15575320e+04],
            [  1.72131237e+03,   2.15575320e+04,   7.39058986e+04]])
-        np.testing.assert_array_almost_equal(reg.xtx,xtx,4)
+        np.testing.assert_allclose(reg.xtx,xtx,RTOL)
              
 class TestGMErrorHet(unittest.TestCase):
     def setUp(self):
@@ -71,29 +72,29 @@ class TestGMErrorHet(unittest.TestCase):
     def test_model(self):
         reg = HET.GM_Error_Het(self.y, self.X, self.w, step1c=True)
         betas = np.array([[ 47.99626638], [  0.71048989], [ -0.55876126], [  0.41178776]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,7)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([ 27.38122697])
-        np.testing.assert_array_almost_equal(reg.u[0],u,7)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         ef = np.array([ 32.29765975])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],ef,7)
+        np.testing.assert_allclose(reg.e_filtered[0],ef,RTOL)
         predy = np.array([ 53.08577603])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,7)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        self.assertAlmostEqual(reg.n,n)
+        np.testing.assert_allclose(reg.n,n)
         k = 3
-        self.assertAlmostEqual(reg.k,k)
+        np.testing.assert_allclose(reg.k,k)
         y = np.array([ 80.467003])
-        np.testing.assert_array_almost_equal(reg.y[0],y,7)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.x[0],x,7)
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
         i_s = 'Maximum number of iterations reached.'
         np.testing.assert_string_equal(reg.iter_stop,i_s)
         its = 1
-        self.assertAlmostEqual(reg.iteration,its,7)
+        np.testing.assert_allclose(reg.iteration,its,RTOL)
         my = 38.436224469387746
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         stdy = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y,stdy)
+        np.testing.assert_allclose(reg.std_y,stdy)
         vm = np.array([[  1.31767529e+02,  -3.58368748e+00,  -1.65090647e+00,
               0.00000000e+00],
            [ -3.58368748e+00,   1.35513711e-01,   3.77539055e-02,
@@ -102,20 +103,20 @@ class TestGMErrorHet(unittest.TestCase):
               0.00000000e+00],
            [  0.00000000e+00,   0.00000000e+00,   0.00000000e+00,
               2.82398517e-02]])
-        np.testing.assert_array_almost_equal(reg.vm,vm,6)
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         pr2 = 0.34951013222581306
-        self.assertAlmostEqual(reg.pr2,pr2)
+        np.testing.assert_allclose(reg.pr2,pr2)
         stde = np.array([ 11.47900385,   0.36812187,   0.16156816,   0.16804717])
-        np.testing.assert_array_almost_equal(reg.std_err,stde,4)
+        np.testing.assert_allclose(reg.std_err,stde,RTOL)
         z_stat = np.array([[  4.18122226e+00,   2.89946274e-05],
            [  1.93003988e+00,   5.36018970e-02],
            [ -3.45836247e+00,   5.43469673e-04],
            [  2.45042960e+00,   1.42685863e-02]])
-        np.testing.assert_array_almost_equal(reg.z_stat,z_stat,4)
+        np.testing.assert_allclose(reg.z_stat,z_stat,RTOL)
         xtx = np.array([[  4.90000000e+01,   7.04371999e+02,   1.72131237e+03],
            [  7.04371999e+02,   1.16866734e+04,   2.15575320e+04],
            [  1.72131237e+03,   2.15575320e+04,   7.39058986e+04]])
-        np.testing.assert_array_almost_equal(reg.xtx,xtx,4)
+        np.testing.assert_allclose(reg.xtx,xtx,RTOL)
 
 class TestBaseGMEndogErrorHet(unittest.TestCase):
     def setUp(self):
@@ -138,37 +139,37 @@ class TestBaseGMEndogErrorHet(unittest.TestCase):
     def test_model(self):
         reg = HET.BaseGM_Endog_Error_Het(self.y, self.X, self.yd, self.q, self.w.sparse, step1c=True)
         betas = np.array([[ 55.39707924], [  0.46563046], [ -0.67038326], [  0.41135023]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,7)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([ 26.51812895])
-        np.testing.assert_array_almost_equal(reg.u[0],u,7)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         ef = np.array([ 31.46604707])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],ef,7)
+        np.testing.assert_allclose(reg.e_filtered[0],ef,RTOL)
         predy = np.array([ 53.94887405])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,7)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        self.assertAlmostEqual(reg.n,n)
+        np.testing.assert_allclose(reg.n,n)
         k = 3
-        self.assertAlmostEqual(reg.k,k)
+        np.testing.assert_allclose(reg.k,k)
         y = np.array([ 80.467003])
-        np.testing.assert_array_almost_equal(reg.y[0],y,7)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([  1.   ,  19.531])
-        np.testing.assert_array_almost_equal(reg.x[0],x,7)
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
         yend = np.array([ 15.72598])
-        np.testing.assert_array_almost_equal(reg.yend[0],yend,7)
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
         q = np.array([ 5.03])
-        np.testing.assert_array_almost_equal(reg.q[0],q,7)
+        np.testing.assert_allclose(reg.q[0],q,RTOL)
         z = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.z[0],z,7)
+        np.testing.assert_allclose(reg.z[0],z,RTOL)
         h = np.array([  1.   ,  19.531,   5.03 ])
-        np.testing.assert_array_almost_equal(reg.h[0],h,7)
+        np.testing.assert_allclose(reg.h[0],h,RTOL)
         i_s = 'Maximum number of iterations reached.'
         np.testing.assert_string_equal(reg.iter_stop,i_s)
         its = 1
-        self.assertAlmostEqual(reg.iteration,its,7)
+        np.testing.assert_allclose(reg.iteration,its,RTOL)
         my = 38.436224469387746
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         stdy = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y,stdy)
+        np.testing.assert_allclose(reg.std_y,stdy)
         vm = np.array([[  8.34637805e+02,  -2.16932259e+01,  -1.33327894e+01,
                   1.65840848e+00],
                [ -2.16932259e+01,   5.97683070e-01,   3.39503523e-01,
@@ -177,11 +178,11 @@ class TestBaseGMEndogErrorHet(unittest.TestCase):
                  -2.81929695e-02],
                [  1.65840848e+00,  -3.90111107e-02,  -2.81929695e-02,
                   3.15686105e-02]])
-        np.testing.assert_array_almost_equal(reg.vm,vm,6)
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         hth = np.array([[    49.        ,    704.371999  ,    139.75      ],
                [   704.371999  ,  11686.67338121,   2246.12800625],
                [   139.75      ,   2246.12800625,    498.5851    ]])
-        np.testing.assert_array_almost_equal(reg.hth,hth,6)
+        np.testing.assert_allclose(reg.hth,hth,RTOL)
         
 class TestGMEndogErrorHet(unittest.TestCase):
     def setUp(self):
@@ -203,35 +204,35 @@ class TestGMEndogErrorHet(unittest.TestCase):
     def test_model(self):
         reg = HET.GM_Endog_Error_Het(self.y, self.X, self.yd, self.q, self.w, step1c=True)
         betas = np.array([[ 55.39707924], [  0.46563046], [ -0.67038326], [  0.41135023]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,7)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([ 26.51812895])
-        np.testing.assert_array_almost_equal(reg.u[0],u,7)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         predy = np.array([ 53.94887405])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,7)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        self.assertAlmostEqual(reg.n,n)
+        np.testing.assert_allclose(reg.n,n)
         k = 3
-        self.assertAlmostEqual(reg.k,k)
+        np.testing.assert_allclose(reg.k,k)
         y = np.array([ 80.467003])
-        np.testing.assert_array_almost_equal(reg.y[0],y,7)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([  1.   ,  19.531])
-        np.testing.assert_array_almost_equal(reg.x[0],x,7)
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
         yend = np.array([ 15.72598])
-        np.testing.assert_array_almost_equal(reg.yend[0],yend,7)
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
         q = np.array([ 5.03])
-        np.testing.assert_array_almost_equal(reg.q[0],q,7)
+        np.testing.assert_allclose(reg.q[0],q,RTOL)
         z = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.z[0],z,7)
+        np.testing.assert_allclose(reg.z[0],z,RTOL)
         h = np.array([  1.   ,  19.531,   5.03 ])
-        np.testing.assert_array_almost_equal(reg.h[0],h,7)
+        np.testing.assert_allclose(reg.h[0],h,RTOL)
         i_s = 'Maximum number of iterations reached.'
         np.testing.assert_string_equal(reg.iter_stop,i_s)
         its = 1
-        self.assertAlmostEqual(reg.iteration,its,7)
+        np.testing.assert_allclose(reg.iteration,its,RTOL)
         my = 38.436224469387746
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         stdy = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y,stdy)
+        np.testing.assert_allclose(reg.std_y,stdy)
         vm = np.array([[  8.34637805e+02,  -2.16932259e+01,  -1.33327894e+01,
                   1.65840848e+00],
                [ -2.16932259e+01,   5.97683070e-01,   3.39503523e-01,
@@ -240,18 +241,18 @@ class TestGMEndogErrorHet(unittest.TestCase):
                  -2.81929695e-02],
                [  1.65840848e+00,  -3.90111107e-02,  -2.81929695e-02,
                   3.15686105e-02]])
-        np.testing.assert_array_almost_equal(reg.vm,vm,6)
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         pr2 = 0.34648011338954804
-        self.assertAlmostEqual(reg.pr2,pr2,7)
+        np.testing.assert_allclose(reg.pr2,pr2,RTOL)
         std_err = np.array([ 28.89009873,  0.77309965,  0.46798299,
             0.17767558])
-        np.testing.assert_array_almost_equal(reg.std_err,std_err,6)
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
         z_stat = np.array([(1.9175109006819244, 0.055173057472126787), (0.60229035155742305, 0.54698088217644414), (-1.4324949211864271, 0.15200223057569454), (2.3151759776869496, 0.020603303355572443)])
-        np.testing.assert_array_almost_equal(reg.z_stat,z_stat,6)
+        np.testing.assert_allclose(reg.z_stat,z_stat,RTOL)
         hth = np.array([[    49.        ,    704.371999  ,    139.75      ],
                [   704.371999  ,  11686.67338121,   2246.12800625],
                [   139.75      ,   2246.12800625,    498.5851    ]])
-        np.testing.assert_array_almost_equal(reg.hth,hth,6)
+        np.testing.assert_allclose(reg.hth,hth,RTOL)
  
 class TestBaseGMComboHet(unittest.TestCase):
     def setUp(self):
@@ -271,35 +272,35 @@ class TestBaseGMComboHet(unittest.TestCase):
         self.X = np.hstack((np.ones(self.y.shape),self.X))
         reg = HET.BaseGM_Combo_Het(self.y, self.X, yend=yd2, q=q2, w=self.w.sparse, step1c=True)
         betas = np.array([[ 57.7778574 ], [  0.73034922], [ -0.59257362], [ -0.2230231 ], [  0.56636724]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,7)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([ 25.65156033])
-        np.testing.assert_array_almost_equal(reg.u[0],u,7)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         ef = np.array([ 31.87664403])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],ef,7)
+        np.testing.assert_allclose(reg.e_filtered[0],ef,RTOL)
         predy = np.array([ 54.81544267])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,7)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        self.assertAlmostEqual(reg.n,n)
+        np.testing.assert_allclose(reg.n,n)
         k = 4
-        self.assertAlmostEqual(reg.k,k)
+        np.testing.assert_allclose(reg.k,k)
         y = np.array([ 80.467003])
-        np.testing.assert_array_almost_equal(reg.y[0],y,7)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.x[0],x,7)
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
         yend = np.array([ 35.4585005])
-        np.testing.assert_array_almost_equal(reg.yend[0],yend,7)
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
         q = np.array([ 18.594    ,  24.7142675])
-        np.testing.assert_array_almost_equal(reg.q[0],q,7)
+        np.testing.assert_allclose(reg.q[0],q,RTOL)
         z = np.array([  1.       ,  19.531    ,  15.72598  ,  35.4585005])
-        np.testing.assert_array_almost_equal(reg.z[0],z,7)
+        np.testing.assert_allclose(reg.z[0],z,RTOL)
         i_s = 'Maximum number of iterations reached.'
         np.testing.assert_string_equal(reg.iter_stop,i_s)
         its = 1
-        self.assertAlmostEqual(reg.iteration,its,7)
+        np.testing.assert_allclose(reg.iteration,its,RTOL)
         my = 38.436224469387746
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         stdy = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y,stdy,7)
+        np.testing.assert_allclose(reg.std_y,stdy,RTOL)
         vm = np.array([[  4.86218274e+02,  -2.77268729e+00,  -1.59987770e+00,
              -1.01969471e+01,   2.74302006e+00],
            [ -2.77268729e+00,   1.04680972e-01,   2.51172238e-02,
@@ -310,7 +311,7 @@ class TestBaseGMComboHet(unittest.TestCase):
               2.78273684e-01,  -6.89402590e-02],
            [  2.74302006e+00,   3.70052723e-03,  -7.30173070e-03,
              -6.89402590e-02,   7.12034037e-02]])
-        np.testing.assert_array_almost_equal(reg.vm,vm,6)
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         hth = np.array([[  4.90000000e+01,   7.04371999e+02,   1.72131237e+03,
               7.24743592e+02,   1.70735413e+03],
            [  7.04371999e+02,   1.16866734e+04,   2.15575320e+04,
@@ -321,7 +322,7 @@ class TestBaseGMComboHet(unittest.TestCase):
               1.16146226e+04,   2.30304624e+04],
            [  1.70735413e+03,   2.23848036e+04,   6.70145378e+04,
               2.30304624e+04,   6.69879858e+04]])
-        np.testing.assert_array_almost_equal(reg.hth,hth,4)
+        np.testing.assert_allclose(reg.hth,hth,RTOL)
 
 class TestGMComboHet(unittest.TestCase):
     def setUp(self):
@@ -339,39 +340,39 @@ class TestGMComboHet(unittest.TestCase):
         # Only spatial lag
         reg = HET.GM_Combo_Het(self.y, self.X, w=self.w, step1c=True)
         betas = np.array([[ 57.7778574 ], [  0.73034922], [ -0.59257362], [ -0.2230231 ], [  0.56636724]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,7)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([ 25.65156033])
-        np.testing.assert_array_almost_equal(reg.u[0],u,7)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         ef = np.array([ 31.87664403])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],ef,7)
+        np.testing.assert_allclose(reg.e_filtered[0],ef,RTOL)
         ep = np.array([ 28.30648145])
-        np.testing.assert_array_almost_equal(reg.e_pred[0],ep,7)
+        np.testing.assert_allclose(reg.e_pred[0],ep,RTOL)
         pe = np.array([ 52.16052155])
-        np.testing.assert_array_almost_equal(reg.predy_e[0],pe,7)
+        np.testing.assert_allclose(reg.predy_e[0],pe,RTOL)
         predy = np.array([ 54.81544267])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,7)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        self.assertAlmostEqual(reg.n,n)
+        np.testing.assert_allclose(reg.n,n)
         k = 4
-        self.assertAlmostEqual(reg.k,k)
+        np.testing.assert_allclose(reg.k,k)
         y = np.array([ 80.467003])
-        np.testing.assert_array_almost_equal(reg.y[0],y,7)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.x[0],x,7)
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
         yend = np.array([ 35.4585005])
-        np.testing.assert_array_almost_equal(reg.yend[0],yend,7)
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
         q = np.array([ 18.594    ,  24.7142675])
-        np.testing.assert_array_almost_equal(reg.q[0],q,7)
+        np.testing.assert_allclose(reg.q[0],q,RTOL)
         z = np.array([  1.       ,  19.531    ,  15.72598  ,  35.4585005])
-        np.testing.assert_array_almost_equal(reg.z[0],z,7)
+        np.testing.assert_allclose(reg.z[0],z,RTOL)
         i_s = 'Maximum number of iterations reached.'
         np.testing.assert_string_equal(reg.iter_stop,i_s)
         its = 1
-        self.assertAlmostEqual(reg.iteration,its,7)
+        np.testing.assert_allclose(reg.iteration,its,RTOL)
         my = 38.436224469387746
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         stdy = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y,stdy)
+        np.testing.assert_allclose(reg.std_y,stdy)
         vm = np.array([[  4.86218274e+02,  -2.77268729e+00,  -1.59987770e+00,
              -1.01969471e+01,   2.74302006e+00],
            [ -2.77268729e+00,   1.04680972e-01,   2.51172238e-02,
@@ -382,15 +383,15 @@ class TestGMComboHet(unittest.TestCase):
               2.78273684e-01,  -6.89402590e-02],
            [  2.74302006e+00,   3.70052723e-03,  -7.30173070e-03,
              -6.89402590e-02,   7.12034037e-02]])
-        np.testing.assert_array_almost_equal(reg.vm,vm,6)
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         pr2 = 0.3001582877472412
-        self.assertAlmostEqual(reg.pr2,pr2,7)
+        np.testing.assert_allclose(reg.pr2,pr2,RTOL)
         pr2_e = 0.35613102283621967
-        self.assertAlmostEqual(reg.pr2_e,pr2_e,7)
+        np.testing.assert_allclose(reg.pr2_e,pr2_e,RTOL)
         std_err = np.array([ 22.05035768,  0.32354439,  0.14685221,  0.52751653,  0.26683966])
-        np.testing.assert_array_almost_equal(reg.std_err,std_err,6)
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
         z_stat = np.array([(2.6202684885795335, 0.00878605635338265), (2.2573385444145524, 0.023986928627746887), (-4.0351698589183433, 5.456281036278686e-05), (-0.42277935292121521, 0.67245625315942159), (2.1225002455741895, 0.033795752094112265)])
-        np.testing.assert_array_almost_equal(reg.z_stat,z_stat,6)
+        np.testing.assert_allclose(reg.z_stat,z_stat,RTOL)
         hth = np.array([[  4.90000000e+01,   7.04371999e+02,   1.72131237e+03,
               7.24743592e+02,   1.70735413e+03],
            [  7.04371999e+02,   1.16866734e+04,   2.15575320e+04,
@@ -401,7 +402,7 @@ class TestGMComboHet(unittest.TestCase):
               1.16146226e+04,   2.30304624e+04],
            [  1.70735413e+03,   2.23848036e+04,   6.70145378e+04,
               2.30304624e+04,   6.69879858e+04]])
-        np.testing.assert_array_almost_equal(reg.hth,hth,4)
+        np.testing.assert_allclose(reg.hth,hth,RTOL)
 
 if __name__ == '__main__':
     unittest.main()

--- a/pysal/spreg/tests/test_error_sp_het_regimes.py
+++ b/pysal/spreg/tests/test_error_sp_het_regimes.py
@@ -3,6 +3,7 @@ import pysal
 import numpy as np
 from pysal.spreg import error_sp_het_regimes as SP
 from pysal.spreg.error_sp_het import GM_Error_Het, GM_Endog_Error_Het, GM_Combo_Het
+from pysal.common import RTOL
 
 class TestGM_Error_Het_Regimes(unittest.TestCase):
     def setUp(self):
@@ -51,40 +52,40 @@ class TestGM_Error_Het_Regimes(unittest.TestCase):
        [ -0.3358993 ],
        [ -0.82129289],
        [  0.54662719]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,6)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([-2.19031456])
-        np.testing.assert_array_almost_equal(reg.u[0],u,6)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         predy = np.array([ 17.91629456])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,6)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        self.assertAlmostEqual(reg.n,n,6)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 6
-        self.assertAlmostEqual(reg.k,k,6)
+        np.testing.assert_allclose(reg.k,k,RTOL)
         y = np.array([ 15.72598])
-        np.testing.assert_array_almost_equal(reg.y[0],y,6)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([[  0.      ,   0.      ,   0.      ,   1.      ,  80.467003,  19.531   ]])
-        np.testing.assert_array_almost_equal(reg.x[0].toarray(),x,6)
+        np.testing.assert_allclose(reg.x[0].toarray(),x,RTOL)
         e = np.array([ 2.77847355])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e,6)
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
         my = 35.128823897959187
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my, RTOL)
         sy = 16.732092091229699
-        self.assertAlmostEqual(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy, RTOL)
         vm = np.array([  3.86154100e+01,  -2.51553730e-01,  -8.20138673e-01,
          1.71714184e+00,  -1.94929113e-02,   1.23118051e-01,
          0.00000000e+00])
-        np.testing.assert_array_almost_equal(reg.vm[0],vm,6)
+        np.testing.assert_allclose(reg.vm[0],vm,RTOL)
         pr2 = 0.5515791216043385
-        self.assertAlmostEqual(reg.pr2,pr2)
+        np.testing.assert_allclose(reg.pr2,pr2, RTOL)
         std_err = np.array([ 6.21412987,  0.15340022,  0.44060473,  7.6032169 ,  0.19353719,
         0.73621596,  0.13968272])
-        np.testing.assert_array_almost_equal(reg.std_err,std_err,6)
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
         chow_r = np.array([[ 0.04190799,  0.83779526],
        [ 0.5736724 ,  0.44880328],
        [ 0.62498575,  0.42920056]])
-        np.testing.assert_array_almost_equal(reg.chow.regi,chow_r,6)
+        np.testing.assert_allclose(reg.chow.regi,chow_r,RTOL)
         chow_j = 0.72341901308525713
-        self.assertAlmostEqual(reg.chow.joint[0],chow_j)
+        np.testing.assert_allclose(reg.chow.joint[0],chow_j, RTOL)
 
     def test_model_regi_error(self):
         #Columbus:
@@ -97,31 +98,31 @@ class TestGM_Error_Het_Regimes(unittest.TestCase):
        [ -0.31841139],
        [ -1.27502813],
        [  0.11515312]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,6)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         vm = np.array([ 44.9411672 ,  -0.34343354,  -0.39946055,   0.        ,
          0.        ,   0.        ,   0.        ,   0.        ])
-        np.testing.assert_array_almost_equal(reg.vm[0],vm,6)
+        np.testing.assert_allclose(reg.vm[0],vm,RTOL)
         u = np.array([-0.05357818])
-        np.testing.assert_array_almost_equal(reg.u[0],u,6)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         predy = np.array([ 15.77955818])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,6)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         e = np.array([ 0.70542044])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e,6)
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
         chow_r = np.array([[  3.11061225e-01,   5.77029704e-01],
        [  3.39747489e-01,   5.59975012e-01],
        [  3.86371771e-03,   9.50436364e-01],
        [  4.02884201e+00,   4.47286322e-02]])
-        np.testing.assert_array_almost_equal(reg.chow.regi,chow_r,6)
+        np.testing.assert_allclose(reg.chow.regi,chow_r,RTOL)
         chow_j = 4.7467070503995412
-        self.assertAlmostEqual(reg.chow.joint[0],chow_j)
+        np.testing.assert_allclose(reg.chow.joint[0],chow_j, RTOL)
         #Artficial:
         model = SP.GM_Error_Het_Regimes(self.y_a, self.x_a, self.regi_a, w=self.w_a, regime_err_sep=True)
         model1 = GM_Error_Het(self.y_a[0:(self.n2)].reshape((self.n2),1), self.x_a[0:(self.n2)], w=self.w_a1)
         model2 = GM_Error_Het(self.y_a[(self.n2):].reshape((self.n2),1), self.x_a[(self.n2):], w=self.w_a1)
         tbetas = np.vstack((model1.betas, model2.betas))
-        np.testing.assert_array_almost_equal(model.betas,tbetas)
+        np.testing.assert_allclose(model.betas,tbetas, RTOL)
         vm = np.hstack((model1.vm.diagonal(),model2.vm.diagonal()))
-        np.testing.assert_array_almost_equal(model.vm.diagonal(), vm, 6)
+        np.testing.assert_allclose(model.vm.diagonal(), vm, RTOL)
 
     def test_model_endog(self):
         reg = SP.GM_Endog_Error_Het_Regimes(self.y, self.X2, self.yd, self.q, self.regimes, self.w)
@@ -132,44 +133,44 @@ class TestGM_Error_Het_Regimes(unittest.TestCase):
        [ -3.20196286],
        [ -1.13672283],
        [  0.2174965 ]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,6)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([ 20.50716917])
-        np.testing.assert_array_almost_equal(reg.u[0],u,6)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         e = np.array([ 25.13517175])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e,6)
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
         predy = np.array([-4.78118917])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,6)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        self.assertAlmostEqual(reg.n,n)
+        np.testing.assert_allclose(reg.n,n, RTOL)
         k = 6
-        self.assertAlmostEqual(reg.k,k)
+        np.testing.assert_allclose(reg.k,k, RTOL)
         y = np.array([ 15.72598])
-        np.testing.assert_array_almost_equal(reg.y[0],y,6)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([[  0.   ,   0.   ,   1.   ,  19.531]])
-        np.testing.assert_array_almost_equal(reg.x[0].toarray(),x,6)
+        np.testing.assert_allclose(reg.x[0].toarray(),x,RTOL)
         yend = np.array([[  0.      ,  80.467003]])
-        np.testing.assert_array_almost_equal(reg.yend[0].toarray(),yend,6)
+        np.testing.assert_allclose(reg.yend[0].toarray(),yend,RTOL)
         z = np.array([[  0.      ,   0.      ,   1.      ,  19.531   ,   0.      ,
          80.467003]])
-        np.testing.assert_array_almost_equal(reg.z[0].toarray(),z,6)
+        np.testing.assert_allclose(reg.z[0].toarray(),z,RTOL)
         my = 35.128823897959187
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my, RTOL)
         sy = 16.732092091229699
-        self.assertAlmostEqual(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy, RTOL)
         vm = np.array([ 509.66122149,  150.5845341 ,    9.64413821,    5.54782831,
         -80.95846045,   -2.25308524,   -3.2045214 ])
-        np.testing.assert_array_almost_equal(reg.vm[0],vm,5)
+        np.testing.assert_allclose(reg.vm[0],vm,RTOL)
         pr2 = 0.19776512679331681
-        self.assertAlmostEqual(reg.pr2,pr2)
+        np.testing.assert_allclose(reg.pr2,pr2)
         std_err = np.array([ 22.57567765,  11.34616946,  17.43881791,   1.30953812,
          5.4830829 ,   0.74634612,   0.29973079])
-        np.testing.assert_array_almost_equal(reg.std_err,std_err,6)
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
         chow_r = np.array([[ 0.0022216 ,  0.96240654],
        [ 0.13127347,  0.7171153 ],
        [ 0.14367307,  0.70465645]])
-        np.testing.assert_array_almost_equal(reg.chow.regi,chow_r,6)
+        np.testing.assert_allclose(reg.chow.regi,chow_r,RTOL)
         chow_j = 1.2329971019087163
-        self.assertAlmostEqual(reg.chow.joint[0],chow_j)
+        np.testing.assert_allclose(reg.chow.joint[0],chow_j, RTOL)
 
     def test_model_endog_regi_error(self):
         #Columbus:
@@ -182,32 +183,32 @@ class TestGM_Error_Het_Regimes(unittest.TestCase):
        [  5.48294187e-01],
        [ -1.28432891e+00],
        [  3.57661629e-02]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,6)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         vm = np.array([  7.55988579e+02,   2.53659722e+02,  -1.34288316e+02,
         -2.66141766e-01,   0.00000000e+00,   0.00000000e+00,
          0.00000000e+00,   0.00000000e+00])
-        np.testing.assert_array_almost_equal(reg.vm[0],vm,6)
+        np.testing.assert_allclose(reg.vm[0],vm,RTOL)
         u = np.array([ 25.73781918])
-        np.testing.assert_array_almost_equal(reg.u[0],u,6)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         predy = np.array([-10.01183918])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,6)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         e = np.array([ 26.5449135])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e,6)
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
         chow_r = np.array([[ 0.00998573,  0.92040097],
        [ 0.12660165,  0.72198192],
        [ 0.12737281,  0.72117171],
        [ 0.43507956,  0.50950696]])
-        np.testing.assert_array_almost_equal(reg.chow.regi,chow_r,6)
+        np.testing.assert_allclose(reg.chow.regi,chow_r,RTOL)
         chow_j = 1.3756768204399892
-        self.assertAlmostEqual(reg.chow.joint[0],chow_j)
+        np.testing.assert_allclose(reg.chow.joint[0],chow_j, RTOL)
         #Artficial:
         model = SP.GM_Endog_Error_Het_Regimes(self.y_a, self.x_a1, yend=self.x_a2, q=self.q_a, regimes=self.regi_a, w=self.w_a, regime_err_sep=True)
         model1 = GM_Endog_Error_Het(self.y_a[0:(self.n2)].reshape((self.n2),1), self.x_a1[0:(self.n2)], yend=self.x_a2[0:(self.n2)], q=self.q_a[0:(self.n2)], w=self.w_a1)
         model2 = GM_Endog_Error_Het(self.y_a[(self.n2):].reshape((self.n2),1), self.x_a1[(self.n2):], yend=self.x_a2[(self.n2):], q=self.q_a[(self.n2):], w=self.w_a1)
         tbetas = np.vstack((model1.betas, model2.betas))
-        np.testing.assert_array_almost_equal(model.betas,tbetas)
+        np.testing.assert_allclose(model.betas,tbetas, RTOL)
         vm = np.hstack((model1.vm.diagonal(),model2.vm.diagonal()))
-        np.testing.assert_array_almost_equal(model.vm.diagonal(), vm, 6)
+        np.testing.assert_allclose(model.vm.diagonal(), vm, RTOL)
 
     def test_model_combo(self):
         reg = SP.GM_Combo_Het_Regimes(self.y, self.X2, self.regimes, self.yd, self.q, w=self.w)
@@ -219,48 +220,48 @@ class TestGM_Error_Het_Regimes(unittest.TestCase):
        [ -2.21328949e-01],
        [  6.41902155e-01],
        [ -2.45714919e-02]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,6)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([ 0.94039246])
-        np.testing.assert_array_almost_equal(reg.u[0],u,6)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         e_filtered = np.array([ 0.8737864])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e_filtered,5)
+        np.testing.assert_allclose(reg.e_filtered[0],e_filtered,RTOL)
         predy_e = np.array([ 18.68732105])
-        np.testing.assert_array_almost_equal(reg.predy_e[0],predy_e,6)
+        np.testing.assert_allclose(reg.predy_e[0],predy_e,RTOL)
         predy = np.array([ 14.78558754])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,6)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        self.assertAlmostEqual(reg.n,n)
+        np.testing.assert_allclose(reg.n,n, RTOL)
         k = 7
-        self.assertAlmostEqual(reg.k,k)
+        np.testing.assert_allclose(reg.k,k, RTOL)
         y = np.array([ 15.72598])
-        np.testing.assert_array_almost_equal(reg.y[0],y,6)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([[  0.   ,   0.   ,   1.   ,  19.531]])
-        np.testing.assert_array_almost_equal(reg.x[0].toarray(),x,6)
+        np.testing.assert_allclose(reg.x[0].toarray(),x,RTOL)
         yend = np.array([[  0.       ,  80.467003 ,  24.7142675]])
-        np.testing.assert_array_almost_equal(reg.yend[0].toarray(),yend,6)
+        np.testing.assert_allclose(reg.yend[0].toarray(),yend,RTOL)
         z = np.array([[  0.       ,   0.       ,   1.       ,  19.531    ,   0.       ,
          80.467003 ,  24.7142675]])
-        np.testing.assert_array_almost_equal(reg.z[0].toarray(),z,6)
+        np.testing.assert_allclose(reg.z[0].toarray(),z,RTOL)
         my = 35.128823897959187
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my, RTOL)
         sy = 16.732092091229699
-        self.assertAlmostEqual(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy, RTOL)
         vm = np.array([ 71.26851365,  -0.58278032,  50.53169815,  -0.74561147,
         -0.79510274,  -0.10823496,  -0.98141395,   1.16575965])
-        np.testing.assert_array_almost_equal(reg.vm[0],vm,4)
+        np.testing.assert_allclose(reg.vm[0],vm,RTOL)
         pr2 = 0.6504148883602958
-        self.assertAlmostEqual(reg.pr2,pr2)
+        np.testing.assert_allclose(reg.pr2,pr2,RTOL)
         pr2_e = 0.527136896994038
-        self.assertAlmostEqual(reg.pr2_e,pr2_e)
+        np.testing.assert_allclose(reg.pr2_e,pr2_e,RTOL)
         std_err = np.array([ 8.44206809,  0.72363219,  9.85790968,  0.77218082,  0.34084146,
         0.21752916,  0.14371614,  0.39226478])
-        np.testing.assert_array_almost_equal(reg.std_err,std_err,5)
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
         chow_r = np.array([[ 0.54688708,  0.45959243],
        [ 0.01035136,  0.91896175],
        [ 0.03981108,  0.84185042]])
-        np.testing.assert_array_almost_equal(reg.chow.regi,chow_r,6)
+        np.testing.assert_allclose(reg.chow.regi,chow_r,RTOL)
         chow_j = 0.78070369988354349
-        self.assertAlmostEqual(reg.chow.joint[0],chow_j)
+        np.testing.assert_allclose(reg.chow.joint[0],chow_j,RTOL)
 
     def test_model_combo_regi_error(self):
         #Columbus:
@@ -275,33 +276,33 @@ class TestGM_Error_Het_Regimes(unittest.TestCase):
        [ -0.49175217],
        [  0.65733173],
        [ -0.07713581]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,6)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         vm = np.array([ 77.49519689,   0.57226879,  -1.18856422,  -1.28088712,
          0.866752  ,   0.        ,   0.        ,   0.        ,
          0.        ,   0.        ])
-        np.testing.assert_array_almost_equal(reg.vm[0],vm,6)
+        np.testing.assert_allclose(reg.vm[0],vm,RTOL)
         u = np.array([ 7.81039418])
-        np.testing.assert_array_almost_equal(reg.u[0],u,6)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         predy = np.array([ 7.91558582])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,6)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         e = np.array([ 7.22996911])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e,6)
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
         chow_r = np.array([[  1.90869079e-01,   6.62194273e-01],
        [  4.56118982e-05,   9.94611401e-01],
        [  3.12104263e-02,   8.59771748e-01],
        [  1.56368204e-01,   6.92522476e-01],
        [  7.52928732e-01,   3.85550558e-01]])
-        np.testing.assert_array_almost_equal(reg.chow.regi,chow_r,6)
+        np.testing.assert_allclose(reg.chow.regi,chow_r,RTOL)
         chow_j = 1.1316136604755913
-        self.assertAlmostEqual(reg.chow.joint[0],chow_j)
+        np.testing.assert_allclose(reg.chow.joint[0],chow_j,RTOL)
         #Artficial:
         model = SP.GM_Combo_Het_Regimes(self.y_a, self.x_a1, yend=self.x_a2, q=self.q_a, regimes=self.regi_a, w=self.w_a, regime_err_sep=True, regime_lag_sep=True)
         model1 = GM_Combo_Het(self.y_a[0:(self.n2)].reshape((self.n2),1), self.x_a1[0:(self.n2)], yend=self.x_a2[0:(self.n2)], q=self.q_a[0:(self.n2)], w=self.w_a1)
         model2 = GM_Combo_Het(self.y_a[(self.n2):].reshape((self.n2),1), self.x_a1[(self.n2):], yend=self.x_a2[(self.n2):], q=self.q_a[(self.n2):], w=self.w_a1)
         tbetas = np.vstack((model1.betas, model2.betas))
-        np.testing.assert_array_almost_equal(model.betas,tbetas)
+        np.testing.assert_allclose(model.betas,tbetas,RTOL)
         vm = np.hstack((model1.vm.diagonal(),model2.vm.diagonal()))
-
+        #was this supposed to get tested?
 
 if __name__ == '__main__':
     unittest.main()

--- a/pysal/spreg/tests/test_error_sp_het_sparse.py
+++ b/pysal/spreg/tests/test_error_sp_het_sparse.py
@@ -3,6 +3,7 @@ import pysal
 import numpy as np
 from scipy import sparse
 from pysal.spreg import error_sp_het as HET
+from pysal.common import RTOL
 
 class TestBaseGMErrorHet(unittest.TestCase):
     def setUp(self):
@@ -21,29 +22,29 @@ class TestBaseGMErrorHet(unittest.TestCase):
     def test_model(self):
         reg = HET.BaseGM_Error_Het(self.y, self.X, self.w.sparse, step1c=True)
         betas = np.array([[ 47.99626638], [  0.71048989], [ -0.55876126], [  0.41178776]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,7)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([ 27.38122697])
-        np.testing.assert_array_almost_equal(reg.u[0],u,7)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         ef = np.array([ 32.29765975])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],ef,7)
+        np.testing.assert_allclose(reg.e_filtered[0],ef,RTOL)
         predy = np.array([ 53.08577603])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,7)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        self.assertAlmostEqual(reg.n,n)
+        np.testing.assert_allclose(reg.n,n)
         k = 3
-        self.assertAlmostEqual(reg.k,k)
+        np.testing.assert_allclose(reg.k,k)
         y = np.array([ 80.467003])
-        np.testing.assert_array_almost_equal(reg.y[0],y,7)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.x[0].toarray()[0],x,7)
+        np.testing.assert_allclose(reg.x[0].toarray()[0],x,RTOL)
         i_s = 'Maximum number of iterations reached.'
         np.testing.assert_string_equal(reg.iter_stop,i_s)
         its = 1
-        self.assertAlmostEqual(reg.iteration,its,7)
+        np.testing.assert_allclose(reg.iteration,its,RTOL)
         my = 38.436224469387746
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         stdy = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y,stdy)
+        np.testing.assert_allclose(reg.std_y,stdy)
         vm = np.array([[  1.31767529e+02,  -3.58368748e+00,  -1.65090647e+00,
               0.00000000e+00],
            [ -3.58368748e+00,   1.35513711e-01,   3.77539055e-02,
@@ -52,11 +53,11 @@ class TestBaseGMErrorHet(unittest.TestCase):
               0.00000000e+00],
            [  0.00000000e+00,   0.00000000e+00,   0.00000000e+00,
               2.82398517e-02]])
-        np.testing.assert_array_almost_equal(reg.vm,vm,6)
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         xtx = np.array([[  4.90000000e+01,   7.04371999e+02,   1.72131237e+03],
            [  7.04371999e+02,   1.16866734e+04,   2.15575320e+04],
            [  1.72131237e+03,   2.15575320e+04,   7.39058986e+04]])
-        np.testing.assert_array_almost_equal(reg.xtx,xtx,4)
+        np.testing.assert_allclose(reg.xtx,xtx,RTOL)
              
 class TestGMErrorHet(unittest.TestCase):
     def setUp(self):
@@ -74,29 +75,29 @@ class TestGMErrorHet(unittest.TestCase):
     def test_model(self):
         reg = HET.GM_Error_Het(self.y, self.X, self.w, step1c=True)
         betas = np.array([[ 47.99626638], [  0.71048989], [ -0.55876126], [  0.41178776]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,7)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([ 27.38122697])
-        np.testing.assert_array_almost_equal(reg.u[0],u,7)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         ef = np.array([ 32.29765975])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],ef,7)
+        np.testing.assert_allclose(reg.e_filtered[0],ef,RTOL)
         predy = np.array([ 53.08577603])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,7)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        self.assertAlmostEqual(reg.n,n)
+        np.testing.assert_allclose(reg.n,n)
         k = 3
-        self.assertAlmostEqual(reg.k,k)
+        np.testing.assert_allclose(reg.k,k)
         y = np.array([ 80.467003])
-        np.testing.assert_array_almost_equal(reg.y[0],y,7)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.x[0].toarray()[0],x,7)
+        np.testing.assert_allclose(reg.x[0].toarray()[0],x,RTOL)
         i_s = 'Maximum number of iterations reached.'
         np.testing.assert_string_equal(reg.iter_stop,i_s)
         its = 1
-        self.assertAlmostEqual(reg.iteration,its,7)
+        np.testing.assert_allclose(reg.iteration,its,RTOL)
         my = 38.436224469387746
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         stdy = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y,stdy)
+        np.testing.assert_allclose(reg.std_y,stdy)
         vm = np.array([[  1.31767529e+02,  -3.58368748e+00,  -1.65090647e+00,
               0.00000000e+00],
            [ -3.58368748e+00,   1.35513711e-01,   3.77539055e-02,
@@ -105,20 +106,20 @@ class TestGMErrorHet(unittest.TestCase):
               0.00000000e+00],
            [  0.00000000e+00,   0.00000000e+00,   0.00000000e+00,
               2.82398517e-02]])
-        np.testing.assert_array_almost_equal(reg.vm,vm,6)
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         pr2 = 0.34951013222581306
-        self.assertAlmostEqual(reg.pr2,pr2)
+        np.testing.assert_allclose(reg.pr2,pr2)
         stde = np.array([ 11.47900385,   0.36812187,   0.16156816,   0.16804717])
-        np.testing.assert_array_almost_equal(reg.std_err,stde,4)
+        np.testing.assert_allclose(reg.std_err,stde,RTOL)
         z_stat = np.array([[  4.18122226e+00,   2.89946274e-05],
            [  1.93003988e+00,   5.36018970e-02],
            [ -3.45836247e+00,   5.43469673e-04],
            [  2.45042960e+00,   1.42685863e-02]])
-        np.testing.assert_array_almost_equal(reg.z_stat,z_stat,4)
+        np.testing.assert_allclose(reg.z_stat,z_stat,RTOL)
         xtx = np.array([[  4.90000000e+01,   7.04371999e+02,   1.72131237e+03],
            [  7.04371999e+02,   1.16866734e+04,   2.15575320e+04],
            [  1.72131237e+03,   2.15575320e+04,   7.39058986e+04]])
-        np.testing.assert_array_almost_equal(reg.xtx,xtx,4)
+        np.testing.assert_allclose(reg.xtx,xtx,RTOL)
 
 class TestBaseGMEndogErrorHet(unittest.TestCase):
     def setUp(self):
@@ -142,37 +143,37 @@ class TestBaseGMEndogErrorHet(unittest.TestCase):
     def test_model(self):
         reg = HET.BaseGM_Endog_Error_Het(self.y, self.X, self.yd, self.q, self.w.sparse, step1c=True)
         betas = np.array([[ 55.39707924], [  0.46563046], [ -0.67038326], [  0.41135023]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,7)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([ 26.51812895])
-        np.testing.assert_array_almost_equal(reg.u[0],u,7)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         ef = np.array([ 31.46604707])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],ef,7)
+        np.testing.assert_allclose(reg.e_filtered[0],ef,RTOL)
         predy = np.array([ 53.94887405])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,7)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        self.assertAlmostEqual(reg.n,n)
+        np.testing.assert_allclose(reg.n,n)
         k = 3
-        self.assertAlmostEqual(reg.k,k)
+        np.testing.assert_allclose(reg.k,k)
         y = np.array([ 80.467003])
-        np.testing.assert_array_almost_equal(reg.y[0],y,7)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([  1.   ,  19.531])
-        np.testing.assert_array_almost_equal(reg.x[0].toarray()[0],x,7)
+        np.testing.assert_allclose(reg.x[0].toarray()[0],x,RTOL)
         yend = np.array([ 15.72598])
-        np.testing.assert_array_almost_equal(reg.yend[0],yend,7)
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
         q = np.array([ 5.03])
-        np.testing.assert_array_almost_equal(reg.q[0],q,7)
+        np.testing.assert_allclose(reg.q[0],q,RTOL)
         z = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.z[0].toarray()[0],z,7)
+        np.testing.assert_allclose(reg.z[0].toarray()[0],z,RTOL)
         h = np.array([  1.   ,  19.531,   5.03 ])
-        np.testing.assert_array_almost_equal(reg.h[0].toarray()[0],h,7)
+        np.testing.assert_allclose(reg.h[0].toarray()[0],h,RTOL)
         i_s = 'Maximum number of iterations reached.'
         np.testing.assert_string_equal(reg.iter_stop,i_s)
         its = 1
-        self.assertAlmostEqual(reg.iteration,its,7)
+        np.testing.assert_allclose(reg.iteration,its,RTOL)
         my = 38.436224469387746
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         stdy = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y,stdy)
+        np.testing.assert_allclose(reg.std_y,stdy)
         vm = np.array([[  8.34637805e+02,  -2.16932259e+01,  -1.33327894e+01,
                   1.65840848e+00],
                [ -2.16932259e+01,   5.97683070e-01,   3.39503523e-01,
@@ -181,11 +182,11 @@ class TestBaseGMEndogErrorHet(unittest.TestCase):
                  -2.81929695e-02],
                [  1.65840848e+00,  -3.90111107e-02,  -2.81929695e-02,
                   3.15686105e-02]])
-        np.testing.assert_array_almost_equal(reg.vm,vm,6)
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         hth = np.array([[    49.        ,    704.371999  ,    139.75      ],
                [   704.371999  ,  11686.67338121,   2246.12800625],
                [   139.75      ,   2246.12800625,    498.5851    ]])
-        np.testing.assert_array_almost_equal(reg.hth,hth,6)
+        np.testing.assert_allclose(reg.hth,hth,RTOL)
         
 class TestGMEndogErrorHet(unittest.TestCase):
     def setUp(self):
@@ -208,35 +209,35 @@ class TestGMEndogErrorHet(unittest.TestCase):
     def test_model(self):
         reg = HET.GM_Endog_Error_Het(self.y, self.X, self.yd, self.q, self.w, step1c=True)
         betas = np.array([[ 55.39707924], [  0.46563046], [ -0.67038326], [  0.41135023]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,7)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([ 26.51812895])
-        np.testing.assert_array_almost_equal(reg.u[0],u,7)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         predy = np.array([ 53.94887405])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,7)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        self.assertAlmostEqual(reg.n,n)
+        np.testing.assert_allclose(reg.n,n)
         k = 3
-        self.assertAlmostEqual(reg.k,k)
+        np.testing.assert_allclose(reg.k,k)
         y = np.array([ 80.467003])
-        np.testing.assert_array_almost_equal(reg.y[0],y,7)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([  1.   ,  19.531])
-        np.testing.assert_array_almost_equal(reg.x[0].toarray()[0],x,7)
+        np.testing.assert_allclose(reg.x[0].toarray()[0],x,RTOL)
         yend = np.array([ 15.72598])
-        np.testing.assert_array_almost_equal(reg.yend[0],yend,7)
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
         q = np.array([ 5.03])
-        np.testing.assert_array_almost_equal(reg.q[0],q,7)
+        np.testing.assert_allclose(reg.q[0],q,RTOL)
         z = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.z[0].toarray()[0],z,7)
+        np.testing.assert_allclose(reg.z[0].toarray()[0],z,RTOL)
         h = np.array([  1.   ,  19.531,   5.03 ])
-        np.testing.assert_array_almost_equal(reg.h[0].toarray()[0],h,7)
+        np.testing.assert_allclose(reg.h[0].toarray()[0],h,RTOL)
         i_s = 'Maximum number of iterations reached.'
         np.testing.assert_string_equal(reg.iter_stop,i_s)
         its = 1
-        self.assertAlmostEqual(reg.iteration,its,7)
+        np.testing.assert_allclose(reg.iteration,its,RTOL)
         my = 38.436224469387746
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         stdy = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y,stdy)
+        np.testing.assert_allclose(reg.std_y,stdy)
         vm = np.array([[  8.34637805e+02,  -2.16932259e+01,  -1.33327894e+01,
                   1.65840848e+00],
                [ -2.16932259e+01,   5.97683070e-01,   3.39503523e-01,
@@ -245,18 +246,18 @@ class TestGMEndogErrorHet(unittest.TestCase):
                  -2.81929695e-02],
                [  1.65840848e+00,  -3.90111107e-02,  -2.81929695e-02,
                   3.15686105e-02]])
-        np.testing.assert_array_almost_equal(reg.vm,vm,6)
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         pr2 = 0.34648011338954804
-        self.assertAlmostEqual(reg.pr2,pr2,7)
+        np.testing.assert_allclose(reg.pr2,pr2,RTOL)
         std_err = np.array([ 28.89009873,  0.77309965,  0.46798299,
             0.17767558])
-        np.testing.assert_array_almost_equal(reg.std_err,std_err,6)
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
         z_stat = np.array([(1.9175109006819244, 0.055173057472126787), (0.60229035155742305, 0.54698088217644414), (-1.4324949211864271, 0.15200223057569454), (2.3151759776869496, 0.020603303355572443)])
-        np.testing.assert_array_almost_equal(reg.z_stat,z_stat,6)
+        np.testing.assert_allclose(reg.z_stat,z_stat,RTOL)
         hth = np.array([[    49.        ,    704.371999  ,    139.75      ],
                [   704.371999  ,  11686.67338121,   2246.12800625],
                [   139.75      ,   2246.12800625,    498.5851    ]])
-        np.testing.assert_array_almost_equal(reg.hth,hth,6)
+        np.testing.assert_allclose(reg.hth,hth,RTOL)
  
 class TestBaseGMComboHet(unittest.TestCase):
     def setUp(self):
@@ -277,35 +278,35 @@ class TestBaseGMComboHet(unittest.TestCase):
         self.X = sparse.csr_matrix(self.X)
         reg = HET.BaseGM_Combo_Het(self.y, self.X, yend=yd2, q=q2, w=self.w.sparse, step1c=True)
         betas = np.array([[ 57.7778574 ], [  0.73034922], [ -0.59257362], [ -0.2230231 ], [  0.56636724]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,7)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([ 25.65156033])
-        np.testing.assert_array_almost_equal(reg.u[0],u,7)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         ef = np.array([ 31.87664403])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],ef,7)
+        np.testing.assert_allclose(reg.e_filtered[0],ef,RTOL)
         predy = np.array([ 54.81544267])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,7)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        self.assertAlmostEqual(reg.n,n)
+        np.testing.assert_allclose(reg.n,n)
         k = 4
-        self.assertAlmostEqual(reg.k,k)
+        np.testing.assert_allclose(reg.k,k)
         y = np.array([ 80.467003])
-        np.testing.assert_array_almost_equal(reg.y[0],y,7)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.x[0].toarray()[0],x,7)
+        np.testing.assert_allclose(reg.x[0].toarray()[0],x,RTOL)
         yend = np.array([ 35.4585005])
-        np.testing.assert_array_almost_equal(reg.yend[0],yend,7)
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
         q = np.array([ 18.594    ,  24.7142675])
-        np.testing.assert_array_almost_equal(reg.q[0],q,7)
+        np.testing.assert_allclose(reg.q[0],q,RTOL)
         z = np.array([  1.       ,  19.531    ,  15.72598  ,  35.4585005])
-        np.testing.assert_array_almost_equal(reg.z[0].toarray()[0],z,7)
+        np.testing.assert_allclose(reg.z[0].toarray()[0],z,RTOL)
         i_s = 'Maximum number of iterations reached.'
         np.testing.assert_string_equal(reg.iter_stop,i_s)
         its = 1
-        self.assertAlmostEqual(reg.iteration,its,7)
+        np.testing.assert_allclose(reg.iteration,its,RTOL)
         my = 38.436224469387746
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         stdy = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y,stdy,7)
+        np.testing.assert_allclose(reg.std_y,stdy,RTOL)
         vm = np.array([[  4.86218274e+02,  -2.77268729e+00,  -1.59987770e+00,
              -1.01969471e+01,   2.74302006e+00],
            [ -2.77268729e+00,   1.04680972e-01,   2.51172238e-02,
@@ -316,7 +317,7 @@ class TestBaseGMComboHet(unittest.TestCase):
               2.78273684e-01,  -6.89402590e-02],
            [  2.74302006e+00,   3.70052723e-03,  -7.30173070e-03,
              -6.89402590e-02,   7.12034037e-02]])
-        np.testing.assert_array_almost_equal(reg.vm,vm,6)
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         hth = np.array([[  4.90000000e+01,   7.04371999e+02,   1.72131237e+03,
               7.24743592e+02,   1.70735413e+03],
            [  7.04371999e+02,   1.16866734e+04,   2.15575320e+04,
@@ -327,7 +328,7 @@ class TestBaseGMComboHet(unittest.TestCase):
               1.16146226e+04,   2.30304624e+04],
            [  1.70735413e+03,   2.23848036e+04,   6.70145378e+04,
               2.30304624e+04,   6.69879858e+04]])
-        np.testing.assert_array_almost_equal(reg.hth,hth,4)
+        np.testing.assert_allclose(reg.hth,hth,RTOL)
 
 class TestGMComboHet(unittest.TestCase):
     def setUp(self):
@@ -346,39 +347,39 @@ class TestGMComboHet(unittest.TestCase):
         # Only spatial lag
         reg = HET.GM_Combo_Het(self.y, self.X, w=self.w, step1c=True)
         betas = np.array([[ 57.7778574 ], [  0.73034922], [ -0.59257362], [ -0.2230231 ], [  0.56636724]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,7)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([ 25.65156033])
-        np.testing.assert_array_almost_equal(reg.u[0],u,7)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         ef = np.array([ 31.87664403])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],ef,7)
+        np.testing.assert_allclose(reg.e_filtered[0],ef,RTOL)
         ep = np.array([ 28.30648145])
-        np.testing.assert_array_almost_equal(reg.e_pred[0],ep,7)
+        np.testing.assert_allclose(reg.e_pred[0],ep,RTOL)
         pe = np.array([ 52.16052155])
-        np.testing.assert_array_almost_equal(reg.predy_e[0],pe,7)
+        np.testing.assert_allclose(reg.predy_e[0],pe,RTOL)
         predy = np.array([ 54.81544267])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,7)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        self.assertAlmostEqual(reg.n,n)
+        np.testing.assert_allclose(reg.n,n)
         k = 4
-        self.assertAlmostEqual(reg.k,k)
+        np.testing.assert_allclose(reg.k,k)
         y = np.array([ 80.467003])
-        np.testing.assert_array_almost_equal(reg.y[0],y,7)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.x[0].toarray()[0],x,7)
+        np.testing.assert_allclose(reg.x[0].toarray()[0],x,RTOL)
         yend = np.array([ 35.4585005])
-        np.testing.assert_array_almost_equal(reg.yend[0],yend,7)
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
         q = np.array([ 18.594    ,  24.7142675])
-        np.testing.assert_array_almost_equal(reg.q[0].toarray()[0],q,7)
+        np.testing.assert_allclose(reg.q[0].toarray()[0],q,RTOL)
         z = np.array([  1.       ,  19.531    ,  15.72598  ,  35.4585005])
-        np.testing.assert_array_almost_equal(reg.z[0].toarray()[0],z,7)
+        np.testing.assert_allclose(reg.z[0].toarray()[0],z,RTOL)
         i_s = 'Maximum number of iterations reached.'
         np.testing.assert_string_equal(reg.iter_stop,i_s)
         its = 1
-        self.assertAlmostEqual(reg.iteration,its,7)
+        np.testing.assert_allclose(reg.iteration,its,RTOL)
         my = 38.436224469387746
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         stdy = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y,stdy)
+        np.testing.assert_allclose(reg.std_y,stdy)
         vm = np.array([[  4.86218274e+02,  -2.77268729e+00,  -1.59987770e+00,
              -1.01969471e+01,   2.74302006e+00],
            [ -2.77268729e+00,   1.04680972e-01,   2.51172238e-02,
@@ -389,15 +390,15 @@ class TestGMComboHet(unittest.TestCase):
               2.78273684e-01,  -6.89402590e-02],
            [  2.74302006e+00,   3.70052723e-03,  -7.30173070e-03,
              -6.89402590e-02,   7.12034037e-02]])
-        np.testing.assert_array_almost_equal(reg.vm,vm,6)
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         pr2 = 0.3001582877472412
-        self.assertAlmostEqual(reg.pr2,pr2,7)
+        np.testing.assert_allclose(reg.pr2,pr2,RTOL)
         pr2_e = 0.35613102283621967
-        self.assertAlmostEqual(reg.pr2_e,pr2_e,7)
+        np.testing.assert_allclose(reg.pr2_e,pr2_e,RTOL)
         std_err = np.array([ 22.05035768,  0.32354439,  0.14685221,  0.52751653,  0.26683966])
-        np.testing.assert_array_almost_equal(reg.std_err,std_err,6)
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
         z_stat = np.array([(2.6202684885795335, 0.00878605635338265), (2.2573385444145524, 0.023986928627746887), (-4.0351698589183433, 5.456281036278686e-05), (-0.42277935292121521, 0.67245625315942159), (2.1225002455741895, 0.033795752094112265)])
-        np.testing.assert_array_almost_equal(reg.z_stat,z_stat,6)
+        np.testing.assert_allclose(reg.z_stat,z_stat,RTOL)
         hth = np.array([[  4.90000000e+01,   7.04371999e+02,   1.72131237e+03,
               7.24743592e+02,   1.70735413e+03],
            [  7.04371999e+02,   1.16866734e+04,   2.15575320e+04,
@@ -408,7 +409,7 @@ class TestGMComboHet(unittest.TestCase):
               1.16146226e+04,   2.30304624e+04],
            [  1.70735413e+03,   2.23848036e+04,   6.70145378e+04,
               2.30304624e+04,   6.69879858e+04]])
-        np.testing.assert_array_almost_equal(reg.hth,hth,4)
+        np.testing.assert_allclose(reg.hth,hth,RTOL)
 
 if __name__ == '__main__':
     unittest.main()

--- a/pysal/spreg/tests/test_error_sp_hom.py
+++ b/pysal/spreg/tests/test_error_sp_hom.py
@@ -6,6 +6,7 @@ import unittest
 import pysal
 from pysal.spreg import error_sp_hom as HOM
 import numpy as np
+from pysal.common import RTOL
 
 class BaseGM_Error_Hom_Tester(unittest.TestCase):
     def setUp(self):
@@ -21,24 +22,24 @@ class BaseGM_Error_Hom_Tester(unittest.TestCase):
         self.w.transform = 'r'
     def test_model(self):
         reg = HOM.BaseGM_Error_Hom(self.y, self.X, self.w.sparse, A1='hom_sc')
-        np.testing.assert_array_almost_equal(reg.y[0],np.array([80.467003]),7)
+        np.testing.assert_allclose(reg.y[0],np.array([80.467003]),RTOL)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.x[0],x,7)
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
         betas = np.array([[ 47.9478524 ], [  0.70633223], [ -0.55595633], [  0.41288558]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,7)
-        np.testing.assert_array_almost_equal(reg.u[0],np.array([27.466734]),6)
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],np.array([ 32.37298547]),7)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
+        np.testing.assert_allclose(reg.u[0],np.array([27.466734]),RTOL)
+        np.testing.assert_allclose(reg.e_filtered[0],np.array([ 32.37298547]),RTOL)
         i_s = 'Maximum number of iterations reached.'
-        self.assertAlmostEqual(reg.iter_stop,i_s,7)
-        np.testing.assert_array_almost_equal(reg.predy[0],np.array([ 53.000269]),6)
-        self.assertAlmostEquals(reg.n,49,7)
-        self.assertAlmostEquals(reg.k,3,7)
+        np.testing.assert_string_equal(reg.iter_stop,i_s)
+        np.testing.assert_allclose(reg.predy[0],np.array([ 53.000269]),RTOL)
+        np.testing.assert_allclose(reg.n,49,RTOL)
+        np.testing.assert_allclose(reg.k,3,RTOL)
         sig2 = 189.94459439729718
-        self.assertAlmostEqual(reg.sig2,sig2)
+        np.testing.assert_allclose(reg.sig2,sig2)
         vm = np.array([[  1.51340717e+02,  -5.29057506e+00,  -1.85654540e+00, -2.39139054e-03], [ -5.29057506e+00,   2.46669610e-01, 5.14259101e-02, 3.19241302e-04], [ -1.85654540e+00,   5.14259101e-02, 3.20510550e-02,  -5.95640240e-05], [ -2.39139054e-03,   3.19241302e-04, -5.95640240e-05,  3.36690159e-02]])
-        np.testing.assert_array_almost_equal(reg.vm,vm,6)
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         xtx = np.array([[  4.90000000e+01,   7.04371999e+02, 1.72131237e+03], [  7.04371999e+02,   1.16866734e+04,   2.15575320e+04], [  1.72131237e+03,   2.15575320e+04, 7.39058986e+04]])
-        np.testing.assert_array_almost_equal(reg.xtx,xtx,4)
+        np.testing.assert_allclose(reg.xtx,xtx,RTOL)
 
 class GM_Error_Hom_Tester(unittest.TestCase):
     def setUp(self):
@@ -53,35 +54,35 @@ class GM_Error_Hom_Tester(unittest.TestCase):
         self.w.transform = 'r'
     def test_model(self):
         reg = HOM.GM_Error_Hom(self.y, self.X, self.w, A1='hom_sc')
-        np.testing.assert_array_almost_equal(reg.y[0],np.array([80.467003]),7)
+        np.testing.assert_allclose(reg.y[0],np.array([80.467003]),RTOL)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.x[0],x,7)
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
         betas = np.array([[ 47.9478524 ], [  0.70633223], [ -0.55595633], [  0.41288558]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,7)
-        np.testing.assert_array_almost_equal(reg.u[0],np.array([27.46673388]),6)
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],np.array([ 32.37298547]),7)
-        np.testing.assert_array_almost_equal(reg.predy[0],np.array([ 53.00026912]),6)
-        self.assertAlmostEquals(reg.n,49,7)
-        self.assertAlmostEquals(reg.k,3,7)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
+        np.testing.assert_allclose(reg.u[0],np.array([27.46673388]),RTOL)
+        np.testing.assert_allclose(reg.e_filtered[0],np.array([ 32.37298547]),RTOL)
+        np.testing.assert_allclose(reg.predy[0],np.array([ 53.00026912]),RTOL)
+        np.testing.assert_allclose(reg.n,49,RTOL)
+        np.testing.assert_allclose(reg.k,3,RTOL)
         vm = np.array([[  1.51340717e+02,  -5.29057506e+00,  -1.85654540e+00, -2.39139054e-03], [ -5.29057506e+00,   2.46669610e-01, 5.14259101e-02, 3.19241302e-04], [ -1.85654540e+00,   5.14259101e-02, 3.20510550e-02,  -5.95640240e-05], [ -2.39139054e-03,   3.19241302e-04, -5.95640240e-05,  3.36690159e-02]])
-        np.testing.assert_array_almost_equal(reg.vm,vm,6)
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         i_s = 'Maximum number of iterations reached.'
-        self.assertAlmostEqual(reg.iter_stop,i_s,7)
-        self.assertAlmostEqual(reg.iteration,1,7)
+        np.testing.assert_string_equal(reg.iter_stop,i_s)
+        np.testing.assert_allclose(reg.iteration,1,RTOL)
         my = 38.436224469387746
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         std_y = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y,std_y)
+        np.testing.assert_allclose(reg.std_y,std_y)
         pr2 = 0.34950977055969729
-        self.assertAlmostEqual(reg.pr2,pr2)
+        np.testing.assert_allclose(reg.pr2,pr2)
         sig2 = 189.94459439729718
-        self.assertAlmostEqual(reg.sig2,sig2)
+        np.testing.assert_allclose(reg.sig2,sig2)
         std_err = np.array([ 12.30206149,   0.49665844,   0.17902808, 0.18349119])
-        np.testing.assert_array_almost_equal(reg.std_err,std_err,6)
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
         z_stat = np.array([[  3.89754616e+00,   9.71723059e-05], [  1.42216900e+00,   1.54977196e-01], [ -3.10541409e+00,   1.90012806e-03], [  2.25016500e+00,   2.44384731e-02]])
-        np.testing.assert_array_almost_equal(reg.z_stat,z_stat,6)
+        np.testing.assert_allclose(reg.z_stat,z_stat,RTOL)
         xtx = np.array([[  4.90000000e+01,   7.04371999e+02, 1.72131237e+03], [  7.04371999e+02,   1.16866734e+04,   2.15575320e+04], [  1.72131237e+03,   2.15575320e+04, 7.39058986e+04]])
-        np.testing.assert_array_almost_equal(reg.xtx,xtx,4)
+        np.testing.assert_allclose(reg.xtx,xtx,RTOL)
 
 
 class BaseGM_Endog_Error_Hom_Tester(unittest.TestCase):
@@ -103,42 +104,42 @@ class BaseGM_Endog_Error_Hom_Tester(unittest.TestCase):
         self.w.transform = 'r'
     def test_model(self):
         reg = HOM.BaseGM_Endog_Error_Hom(self.y, self.X, self.yd, self.q, self.w.sparse, A1='hom_sc')
-        np.testing.assert_array_almost_equal(reg.y[0],np.array([ 80.467003]),7)
+        np.testing.assert_allclose(reg.y[0],np.array([ 80.467003]),RTOL)
         x = np.array([  1.     ,  19.531])
-        np.testing.assert_array_almost_equal(reg.x[0],x,7)
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
         z = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.z[0],z,7)
+        np.testing.assert_allclose(reg.z[0],z,RTOL)
         h = np.array([  1.   ,  19.531,   5.03 ])
-        np.testing.assert_array_almost_equal(reg.h[0],h,7)
+        np.testing.assert_allclose(reg.h[0],h,RTOL)
         yend = np.array([ 15.72598])
-        np.testing.assert_array_almost_equal(reg.yend[0],yend,7)
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
         q = np.array([ 5.03])
-        np.testing.assert_array_almost_equal(reg.q[0],q,7)
+        np.testing.assert_allclose(reg.q[0],q,RTOL)
         betas = np.array([[ 55.36575166], [  0.46432416], [ -0.66904404], [  0.43205526]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,6)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([ 26.55390939])
-        np.testing.assert_array_almost_equal(reg.u[0],u,6)
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],np.array([ 31.74114306]),7)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        np.testing.assert_allclose(reg.e_filtered[0],np.array([ 31.74114306]),RTOL)
         predy = np.array([ 53.91309361])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,6)
-        self.assertAlmostEquals(reg.n,49,7)
-        self.assertAlmostEquals(reg.k,3,7)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
+        np.testing.assert_allclose(reg.n,49,RTOL)
+        np.testing.assert_allclose(reg.k,3,RTOL)
         sig2 = 190.59435238060928
-        self.assertAlmostEqual(reg.sig2,sig2)
+        np.testing.assert_allclose(reg.sig2,sig2)
         vm = np.array([[  5.52064057e+02,  -1.61264555e+01,  -8.86360735e+00, 1.04251912e+00], [ -1.61264555e+01,   5.44898242e-01, 2.39518645e-01, -1.88092950e-02], [ -8.86360735e+00,   2.39518645e-01, 1.55501840e-01, -2.18638648e-02], [  1.04251912e+00, -1.88092950e-02, -2.18638648e-02, 3.71222222e-02]])
-        np.testing.assert_array_almost_equal(reg.vm,vm,6)
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         i_s = 'Maximum number of iterations reached.'
-        self.assertAlmostEqual(reg.iter_stop,i_s,7)
+        np.testing.assert_string_equal(reg.iter_stop,i_s)
         its = 1
-        self.assertAlmostEqual(reg.iteration,its,7)
+        np.testing.assert_allclose(reg.iteration,its,RTOL)
         my = 38.436224469387746
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         std_y = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y,std_y)
+        np.testing.assert_allclose(reg.std_y,std_y)
         sig2 = 0
-        #self.assertAlmostEqual(reg.sig2,sig2)
+        #np.testing.assert_allclose(reg.sig2,sig2)
         hth = np.array([[    49.        ,    704.371999  ,    139.75      ], [   704.371999  ,  11686.67338121,   2246.12800625], [   139.75      ,   2246.12800625,    498.5851]])
-        np.testing.assert_array_almost_equal(reg.hth,hth,4)
+        np.testing.assert_allclose(reg.hth,hth,RTOL)
 
 class GM_Endog_Error_Hom_Tester(unittest.TestCase):
     def setUp(self):
@@ -158,45 +159,45 @@ class GM_Endog_Error_Hom_Tester(unittest.TestCase):
         self.w.transform = 'r'
     def test_model(self):
         reg = HOM.GM_Endog_Error_Hom(self.y, self.X, self.yd, self.q, self.w, A1='hom_sc')
-        np.testing.assert_array_almost_equal(reg.y[0],np.array([ 80.467003]),7)
+        np.testing.assert_allclose(reg.y[0],np.array([ 80.467003]),RTOL)
         x = np.array([  1.     ,  19.531])
-        np.testing.assert_array_almost_equal(reg.x[0],x,7)
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
         z = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.z[0],z,7)
+        np.testing.assert_allclose(reg.z[0],z,RTOL)
         h = np.array([  1.   ,  19.531,   5.03 ])
-        np.testing.assert_array_almost_equal(reg.h[0],h,7)
+        np.testing.assert_allclose(reg.h[0],h,RTOL)
         yend = np.array([ 15.72598])
-        np.testing.assert_array_almost_equal(reg.yend[0],yend,7)
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
         q = np.array([ 5.03])
-        np.testing.assert_array_almost_equal(reg.q[0],q,7)
+        np.testing.assert_allclose(reg.q[0],q,RTOL)
         betas = np.array([[ 55.36575166], [  0.46432416], [ -0.66904404], [  0.43205526]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,6)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([ 26.55390939])
-        np.testing.assert_array_almost_equal(reg.u[0],u,6)
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],np.array([ 31.74114306]),7)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        np.testing.assert_allclose(reg.e_filtered[0],np.array([ 31.74114306]),RTOL)
         predy = np.array([ 53.91309361])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,6)
-        self.assertAlmostEquals(reg.n,49,7)
-        self.assertAlmostEquals(reg.k,3,7)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
+        np.testing.assert_allclose(reg.n,49,RTOL)
+        np.testing.assert_allclose(reg.k,3,RTOL)
         vm = np.array([[  5.52064057e+02,  -1.61264555e+01,  -8.86360735e+00, 1.04251912e+00], [ -1.61264555e+01,   5.44898242e-01, 2.39518645e-01, -1.88092950e-02], [ -8.86360735e+00,   2.39518645e-01, 1.55501840e-01, -2.18638648e-02], [  1.04251912e+00, -1.88092950e-02, -2.18638648e-02, 3.71222222e-02]])
-        np.testing.assert_array_almost_equal(reg.vm,vm,6)
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         i_s = 'Maximum number of iterations reached.'
-        self.assertAlmostEqual(reg.iter_stop,i_s,7)
+        np.testing.assert_string_equal(reg.iter_stop,i_s)
         its = 1
-        self.assertAlmostEqual(reg.iteration,its,7)
+        np.testing.assert_allclose(reg.iteration,its,RTOL)
         my = 38.436224469387746
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         std_y = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y,std_y)
+        np.testing.assert_allclose(reg.std_y,std_y)
         pr2 = 0.34647366525657419
-        self.assertAlmostEqual(reg.pr2,pr2)
+        np.testing.assert_allclose(reg.pr2,pr2)
         sig2 = 190.59435238060928
-        self.assertAlmostEqual(reg.sig2,sig2)
+        np.testing.assert_allclose(reg.sig2,sig2)
         #std_err
         std_err = np.array([ 23.49604343,   0.73817223,   0.39433722, 0.19267128])
-        np.testing.assert_array_almost_equal(reg.std_err,std_err,6)
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
         z_stat = np.array([[ 2.35638617,  0.01845372], [ 0.62901874,  0.52933679], [-1.69662923,  0.08976678], [ 2.24244556,  0.02493259]])
-        np.testing.assert_array_almost_equal(reg.z_stat,z_stat,6)
+        np.testing.assert_allclose(reg.z_stat,z_stat,RTOL)
 
 
 class BaseGM_Combo_Hom_Tester(unittest.TestCase):
@@ -213,39 +214,39 @@ class BaseGM_Combo_Hom_Tester(unittest.TestCase):
         yd2, q2 = pysal.spreg.utils.set_endog(self.y, self.X, self.w, None, None, 1, True)
         self.X = np.hstack((np.ones(self.y.shape),self.X))
         reg = HOM.BaseGM_Combo_Hom(self.y, self.X, yend=yd2, q=q2, w=self.w.sparse, A1='hom_sc')
-        np.testing.assert_array_almost_equal(reg.y[0],np.array([80.467003]),7)
+        np.testing.assert_allclose(reg.y[0],np.array([80.467003]),RTOL)
         x = np.array([  1.     ,  19.531])
-        np.testing.assert_array_almost_equal(reg.x[0],x,7)
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
         betas = np.array([[ 10.12541428], [  1.56832263], [  0.15132076], [  0.21033397]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,7)
-        np.testing.assert_array_almost_equal(reg.u[0],np.array([34.3450723]),7)
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],np.array([ 36.6149682]),7)
-        np.testing.assert_array_almost_equal(reg.predy[0],np.array([ 46.1219307]),7)
-        self.assertAlmostEquals(reg.n,49,7)
-        self.assertAlmostEquals(reg.k,3,7)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
+        np.testing.assert_allclose(reg.u[0],np.array([34.3450723]),RTOL)
+        np.testing.assert_allclose(reg.e_filtered[0],np.array([ 36.6149682]),RTOL)
+        np.testing.assert_allclose(reg.predy[0],np.array([ 46.1219307]),RTOL)
+        np.testing.assert_allclose(reg.n,49,RTOL)
+        np.testing.assert_allclose(reg.k,3,RTOL)
         vm = np.array([[  2.33694742e+02,  -6.66856869e-01,  -5.58304254e+00, 4.85488380e+00], [ -6.66856869e-01,   1.94241504e-01, -5.42327138e-02, 5.37225570e-02], [ -5.58304254e+00,  -5.42327138e-02, 1.63860721e-01, -1.44425498e-01], [  4.85488380e+00, 5.37225570e-02, -1.44425498e-01, 1.78622255e-01]])
-        np.testing.assert_array_almost_equal(reg.vm,vm,6)
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         z = np.array([  1.       ,  19.531    ,  35.4585005])
-        np.testing.assert_array_almost_equal(reg.z[0],z,7)
+        np.testing.assert_allclose(reg.z[0],z,RTOL)
         h = np.array([  1.   ,  19.531,  18.594])
-        np.testing.assert_array_almost_equal(reg.h[0],h,7)
+        np.testing.assert_allclose(reg.h[0],h,RTOL)
         yend = np.array([ 35.4585005])
-        np.testing.assert_array_almost_equal(reg.yend[0],yend,7)
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
         q = np.array([ 18.594])
-        np.testing.assert_array_almost_equal(reg.q[0],q,7)
+        np.testing.assert_allclose(reg.q[0],q,RTOL)
         i_s = 'Maximum number of iterations reached.'
-        self.assertAlmostEqual(reg.iter_stop,i_s,7)
+        np.testing.assert_string_equal(reg.iter_stop,i_s)
         its = 1
-        self.assertAlmostEqual(reg.iteration,its,7)
+        np.testing.assert_allclose(reg.iteration,its,RTOL)
         my = 38.436224469387746
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         std_y = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y,std_y)
+        np.testing.assert_allclose(reg.std_y,std_y)
         sig2 = 232.22680651270042
-        #self.assertAlmostEqual(reg.sig2,sig2)
+        #np.testing.assert_allclose(reg.sig2,sig2)
         np.testing.assert_allclose(reg.sig2,sig2)
         hth = np.array([[    49.        ,    704.371999  ,    724.7435916 ], [   704.371999  ,  11686.67338121,  11092.519988  ], [   724.7435916 ,  11092.519988  , 11614.62257048]])
-        np.testing.assert_array_almost_equal(reg.hth,hth,4)
+        np.testing.assert_allclose(reg.hth,hth,RTOL)
 
 
 class GM_Combo_Hom_Tester(unittest.TestCase):
@@ -260,46 +261,46 @@ class GM_Combo_Hom_Tester(unittest.TestCase):
         self.w.transform = 'r'
     def test_model(self):
         reg = HOM.GM_Combo_Hom(self.y, self.X, w=self.w, A1='hom_sc')
-        np.testing.assert_array_almost_equal(reg.y[0],np.array([80.467003]),7)
+        np.testing.assert_allclose(reg.y[0],np.array([80.467003]),RTOL)
         x = np.array([  1.     ,  19.531])
-        np.testing.assert_array_almost_equal(reg.x[0],x,7)
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
         betas = np.array([[ 10.12541428], [  1.56832263], [  0.15132076], [  0.21033397]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,7)
-        np.testing.assert_array_almost_equal(reg.u[0],np.array([34.3450723]),7)
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],np.array([ 36.6149682]),7)
-        np.testing.assert_array_almost_equal(reg.e_pred[0],np.array([ 32.90372983]),7)
-        np.testing.assert_array_almost_equal(reg.predy[0],np.array([ 46.1219307]),7)
-        np.testing.assert_array_almost_equal(reg.predy_e[0],np.array([47.56327317]),7)
-        self.assertAlmostEquals(reg.n,49,7)
-        self.assertAlmostEquals(reg.k,3,7)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
+        np.testing.assert_allclose(reg.u[0],np.array([34.3450723]),RTOL)
+        np.testing.assert_allclose(reg.e_filtered[0],np.array([ 36.6149682]),RTOL)
+        np.testing.assert_allclose(reg.e_pred[0],np.array([ 32.90372983]),RTOL)
+        np.testing.assert_allclose(reg.predy[0],np.array([ 46.1219307]),RTOL)
+        np.testing.assert_allclose(reg.predy_e[0],np.array([47.56327317]),RTOL)
+        np.testing.assert_allclose(reg.n,49,RTOL)
+        np.testing.assert_allclose(reg.k,3,RTOL)
         z = np.array([  1.       ,  19.531    ,  35.4585005])
-        np.testing.assert_array_almost_equal(reg.z[0],z,7)
+        np.testing.assert_allclose(reg.z[0],z,RTOL)
         h = np.array([  1.   ,  19.531,  18.594])
-        np.testing.assert_array_almost_equal(reg.h[0],h,7)
+        np.testing.assert_allclose(reg.h[0],h,RTOL)
         yend = np.array([ 35.4585005])
-        np.testing.assert_array_almost_equal(reg.yend[0],yend,7)
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
         q = np.array([ 18.594])
-        np.testing.assert_array_almost_equal(reg.q[0],q,7)
+        np.testing.assert_allclose(reg.q[0],q,RTOL)
         i_s = 'Maximum number of iterations reached.'
-        self.assertAlmostEqual(reg.iter_stop,i_s,7)
-        self.assertAlmostEqual(reg.iteration,1,7)
+        np.testing.assert_string_equal(reg.iter_stop,i_s)
+        np.testing.assert_allclose(reg.iteration,1,RTOL)
         my = 38.436224469387746
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         std_y = 18.466069465206047
-        self.assertAlmostEqual(reg.std_y,std_y)
+        np.testing.assert_allclose(reg.std_y,std_y)
         pr2 = 0.28379825632694394
-        self.assertAlmostEqual(reg.pr2,pr2)
+        np.testing.assert_allclose(reg.pr2,pr2)
         pr2_e = 0.25082892555141506
-        self.assertAlmostEqual(reg.pr2_e,pr2_e)
+        np.testing.assert_allclose(reg.pr2_e,pr2_e)
         sig2 = 232.22680651270042
-        #self.assertAlmostEqual(reg.sig2, sig2)
+        #np.testing.assert_allclose(reg.sig2, sig2)
         np.testing.assert_allclose(reg.sig2, sig2)
         std_err = np.array([ 15.28707761,   0.44072838,   0.40479714, 0.42263726])
-        np.testing.assert_array_almost_equal(reg.std_err,std_err,6)
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
         z_stat = np.array([[  6.62351206e-01,   5.07746167e-01], [  3.55847888e+00,   3.73008780e-04], [  3.73818749e-01,   7.08539170e-01], [  4.97670189e-01,   6.18716523e-01]])
-        np.testing.assert_array_almost_equal(reg.z_stat,z_stat,6)
+        np.testing.assert_allclose(reg.z_stat,z_stat,RTOL)
         vm = np.array([[  2.33694742e+02,  -6.66856869e-01,  -5.58304254e+00, 4.85488380e+00], [ -6.66856869e-01,   1.94241504e-01, -5.42327138e-02, 5.37225570e-02], [ -5.58304254e+00,  -5.42327138e-02, 1.63860721e-01, -1.44425498e-01], [  4.85488380e+00, 5.37225570e-02, -1.44425498e-01, 1.78622255e-01]])
-        np.testing.assert_array_almost_equal(reg.vm,vm,6)
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
 
 suite = unittest.TestSuite()
 test_classes = [BaseGM_Error_Hom_Tester, GM_Error_Hom_Tester,\

--- a/pysal/spreg/tests/test_error_sp_hom_regimes.py
+++ b/pysal/spreg/tests/test_error_sp_hom_regimes.py
@@ -3,6 +3,7 @@ import pysal
 import numpy as np
 from pysal.spreg import error_sp_hom_regimes as SP
 from pysal.spreg.error_sp_hom import GM_Error_Hom, GM_Endog_Error_Hom, GM_Combo_Hom
+from pysal.common import RTOL
 
 class TestGM_Error_Hom_Regimes(unittest.TestCase):
     def setUp(self):
@@ -50,41 +51,41 @@ class TestGM_Error_Hom_Regimes(unittest.TestCase):
        [ -0.3358993 ],
        [ -0.82129289],
        [  0.54033921]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,6)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([-2.19031456])
-        np.testing.assert_array_almost_equal(reg.u[0],u,6)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         predy = np.array([ 17.91629456])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,6)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        self.assertAlmostEqual(reg.n,n,6)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 6
-        self.assertAlmostEqual(reg.k,k,6)
+        np.testing.assert_allclose(reg.k,k,RTOL)
         y = np.array([ 15.72598])
-        np.testing.assert_array_almost_equal(reg.y[0],y,6)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([[  0.      ,   0.      ,   0.      ,   1.      ,  80.467003,  19.531   ]])
-        np.testing.assert_array_almost_equal(reg.x[0].toarray(),x,6)
+        np.testing.assert_allclose(reg.x[0].toarray(),x,RTOL)
         e = np.array([ 2.72131648])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e,6)
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
         my = 35.128823897959187
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my,RTOL)
         sy = 16.732092091229699
-        self.assertAlmostEqual(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy,RTOL)
         vm = np.array([ 49.16245801,  -0.12493165,  -1.89294614,   5.71968257,
         -0.0571525 ,   0.05745855,   0.        ])
-        np.testing.assert_array_almost_equal(reg.vm[0],vm,6)
+        np.testing.assert_allclose(reg.vm[0],vm,RTOL)
         sig2 = 96.96108341267626
-        self.assertAlmostEqual(reg.sig2,sig2,5)
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
         pr2 = 0.5515791216023577
-        self.assertAlmostEqual(reg.pr2,pr2)
+        np.testing.assert_allclose(reg.pr2,pr2,RTOL)
         std_err = np.array([ 7.01159454,  0.20701411,  0.56905515,  7.90537942,  0.10268949,
         0.56660879,  0.15659504])
-        np.testing.assert_array_almost_equal(reg.std_err,std_err,6)
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
         chow_r = np.array([[ 0.03888544,  0.84367579],
        [ 0.61613446,  0.43248738],
        [ 0.72632441,  0.39407719]])
-        np.testing.assert_array_almost_equal(reg.chow.regi,chow_r,6)
+        np.testing.assert_allclose(reg.chow.regi,chow_r,RTOL)
         chow_j = 0.92133276766189676
-        self.assertAlmostEqual(reg.chow.joint[0],chow_j)
+        np.testing.assert_allclose(reg.chow.joint[0],chow_j,RTOL)
 
     def test_model_regi_error(self):
         #Artficial:
@@ -92,9 +93,9 @@ class TestGM_Error_Hom_Regimes(unittest.TestCase):
         model1 = GM_Error_Hom(self.y_a[0:(self.n2)].reshape((self.n2),1), self.x_a[0:(self.n2)], w=self.w_a1, A1='het')
         model2 = GM_Error_Hom(self.y_a[(self.n2):].reshape((self.n2),1), self.x_a[(self.n2):], w=self.w_a1, A1='het')
         tbetas = np.vstack((model1.betas, model2.betas))
-        np.testing.assert_array_almost_equal(model.betas,tbetas)
+        np.testing.assert_allclose(model.betas,tbetas,RTOL)
         vm = np.hstack((model1.vm.diagonal(),model2.vm.diagonal()))
-        np.testing.assert_array_almost_equal(model.vm.diagonal(), vm, 6)
+        np.testing.assert_allclose(model.vm.diagonal(), vm, RTOL)
         #Columbus:
         reg = SP.GM_Error_Hom_Regimes(self.y, self.X2, self.regimes, self.w, regime_err_sep=True, A1='het')
         betas = np.array([[ 60.66668194],
@@ -103,22 +104,22 @@ class TestGM_Error_Hom_Regimes(unittest.TestCase):
        [ 61.4526885 ],
        [ -1.90700858],
        [  0.1102755 ]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,6)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         vm = np.array([ 45.57956967,  -1.65365774,   0.        ,   0.        ,
          0.        ,   0.        ])
-        np.testing.assert_array_almost_equal(reg.vm[0],vm,6)
+        np.testing.assert_allclose(reg.vm[0],vm,RTOL)
         u = np.array([-8.48092392])
-        np.testing.assert_array_almost_equal(reg.u[0],u,6)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         predy = np.array([ 24.20690392])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,6)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         e = np.array([-8.33982604])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e,6)
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
         chow_r = np.array([[ 0.0050892 ,  0.94312823],
        [ 0.05746619,  0.81054651],
        [ 1.65677138,  0.19803981]])
-        np.testing.assert_array_almost_equal(reg.chow.regi,chow_r,6)
+        np.testing.assert_allclose(reg.chow.regi,chow_r,RTOL)
         chow_j = 1.7914221673031792
-        self.assertAlmostEqual(reg.chow.joint[0],chow_j)
+        np.testing.assert_allclose(reg.chow.joint[0],chow_j,RTOL)
 
     def test_model_endog(self):
         reg = SP.GM_Endog_Error_Hom_Regimes(self.y, self.X2, self.yd, self.q, self.regimes, self.w, A1='het')
@@ -129,46 +130,46 @@ class TestGM_Error_Hom_Regimes(unittest.TestCase):
        [ -3.20196286],
        [ -1.13672283],
        [  0.22178164]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,6)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([ 20.50716917])
-        np.testing.assert_array_almost_equal(reg.u[0],u,6)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         e = np.array([ 25.22635318])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e,6)
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
         predy = np.array([-4.78118917])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,6)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        self.assertAlmostEqual(reg.n,n)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 6
-        self.assertAlmostEqual(reg.k,k)
+        np.testing.assert_allclose(reg.k,k,RTOL)
         y = np.array([ 15.72598])
-        np.testing.assert_array_almost_equal(reg.y[0],y,6)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([[  0.   ,   0.   ,   1.   ,  19.531]])
-        np.testing.assert_array_almost_equal(reg.x[0].toarray(),x,6)
+        np.testing.assert_allclose(reg.x[0].toarray(),x,RTOL)
         yend = np.array([[  0.      ,  80.467003]])
-        np.testing.assert_array_almost_equal(reg.yend[0].toarray(),yend,6)
+        np.testing.assert_allclose(reg.yend[0].toarray(),yend,RTOL)
         z = np.array([[  0.      ,   0.      ,   1.      ,  19.531   ,   0.      ,
          80.467003]])
-        np.testing.assert_array_almost_equal(reg.z[0].toarray(),z,6)
+        np.testing.assert_allclose(reg.z[0].toarray(),z,RTOL)
         my = 35.128823897959187
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my,RTOL)
         sy = 16.732092091229699
-        self.assertAlmostEqual(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy,RTOL)
         vm = np.array([ 403.76852704,   69.06920553,   19.8388512 ,    3.62501395,
         -40.30472224,   -1.6601927 ,   -1.64319352])
-        np.testing.assert_array_almost_equal(reg.vm[0],vm,5)
+        np.testing.assert_allclose(reg.vm[0],vm,RTOL)
         pr2 = 0.19776512679498906
-        self.assertAlmostEqual(reg.pr2,pr2)
+        np.testing.assert_allclose(reg.pr2,pr2,RTOL)
         sig2 = 644.23810259214
-        self.assertAlmostEqual(reg.sig2,sig2,5)
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
         std_err = np.array([ 20.09399231,   7.03617703,  23.64968032,   2.176846  ,
          3.40352278,   0.92377997,   0.24462006])
-        np.testing.assert_array_almost_equal(reg.std_err,std_err,6)
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
         chow_r = np.array([[ 0.00191145,  0.96512749],
        [ 0.31031517,  0.57748685],
        [ 0.34994619,  0.55414359]])
-        np.testing.assert_array_almost_equal(reg.chow.regi,chow_r,6)
+        np.testing.assert_allclose(reg.chow.regi,chow_r,RTOL)
         chow_j = 1.248410480025556
-        self.assertAlmostEqual(reg.chow.joint[0],chow_j)
+        np.testing.assert_allclose(reg.chow.joint[0],chow_j,RTOL)
 
     def test_model_endog_regi_error(self):
         #Columbus:
@@ -181,31 +182,31 @@ class TestGM_Error_Hom_Regimes(unittest.TestCase):
        [  5.48294187e-01],
        [ -1.28432891e+00],
        [  2.98658172e-02]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,6)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         vm = np.array([ 867.50930457,  161.04430783,  -92.35637083,   -1.13838767,
           0.        ,    0.        ,    0.        ,    0.        ])
-        np.testing.assert_array_almost_equal(reg.vm[0],vm,6)
+        np.testing.assert_allclose(reg.vm[0],vm,RTOL)
         u = np.array([ 25.73781918])
-        np.testing.assert_array_almost_equal(reg.u[0],u,6)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         predy = np.array([-10.01183918])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,6)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         e = np.array([26.41176711])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e,6)
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
         chow_r = np.array([[ 0.00909777,  0.92401124],
        [ 0.24034941,  0.62395386],
        [ 0.24322564,  0.62188603],
        [ 0.32572159,  0.5681893 ]])
-        np.testing.assert_array_almost_equal(reg.chow.regi,chow_r,6)
+        np.testing.assert_allclose(reg.chow.regi,chow_r,RTOL)
         chow_j = 1.4485058522307526
-        self.assertAlmostEqual(reg.chow.joint[0],chow_j)
+        np.testing.assert_allclose(reg.chow.joint[0],chow_j,RTOL)
         #Artficial:
         model = SP.GM_Endog_Error_Hom_Regimes(self.y_a, self.x_a1, yend=self.x_a2, q=self.q_a, regimes=self.regi_a, w=self.w_a, regime_err_sep=True, A1='het')
         model1 = GM_Endog_Error_Hom(self.y_a[0:(self.n2)].reshape((self.n2),1), self.x_a1[0:(self.n2)], yend=self.x_a2[0:(self.n2)], q=self.q_a[0:(self.n2)], w=self.w_a1, A1='het')
         model2 = GM_Endog_Error_Hom(self.y_a[(self.n2):].reshape((self.n2),1), self.x_a1[(self.n2):], yend=self.x_a2[(self.n2):], q=self.q_a[(self.n2):], w=self.w_a1, A1='het')
         tbetas = np.vstack((model1.betas, model2.betas))
-        np.testing.assert_array_almost_equal(model.betas,tbetas)
+        np.testing.assert_allclose(model.betas,tbetas)
         vm = np.hstack((model1.vm.diagonal(),model2.vm.diagonal()))
-        np.testing.assert_array_almost_equal(model.vm.diagonal(), vm, 6)
+        np.testing.assert_allclose(model.vm.diagonal(), vm, RTOL)
 
     def test_model_combo(self):
         reg = SP.GM_Combo_Hom_Regimes(self.y, self.X2, self.regimes, self.yd, self.q, w=self.w, A1='het')
@@ -217,50 +218,50 @@ class TestGM_Error_Hom_Regimes(unittest.TestCase):
        [ -0.22132895],
        [  0.64190215],
        [ -0.07314671]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,6)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([ 0.94039246])
-        np.testing.assert_array_almost_equal(reg.u[0],u,6)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         e_filtered = np.array([ 0.74211331])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e_filtered,5)
+        np.testing.assert_allclose(reg.e_filtered[0],e_filtered,RTOL)
         predy_e = np.array([ 18.68732105])
-        np.testing.assert_array_almost_equal(reg.predy_e[0],predy_e,6)
+        np.testing.assert_allclose(reg.predy_e[0],predy_e,RTOL)
         predy = np.array([ 14.78558754])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,6)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        self.assertAlmostEqual(reg.n,n)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 7
-        self.assertAlmostEqual(reg.k,k)
+        np.testing.assert_allclose(reg.k,k,RTOL)
         y = np.array([ 15.72598])
-        np.testing.assert_array_almost_equal(reg.y[0],y,6)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([[  0.   ,   0.   ,   1.   ,  19.531]])
-        np.testing.assert_array_almost_equal(reg.x[0].toarray(),x,6)
+        np.testing.assert_allclose(reg.x[0].toarray(),x,RTOL)
         yend = np.array([[  0.       ,  80.467003 ,  24.7142675]])
-        np.testing.assert_array_almost_equal(reg.yend[0].toarray(),yend,6)
+        np.testing.assert_allclose(reg.yend[0].toarray(),yend,RTOL)
         z = np.array([[  0.       ,   0.       ,   1.       ,  19.531    ,   0.       ,
          80.467003 ,  24.7142675]])
-        np.testing.assert_array_almost_equal(reg.z[0].toarray(),z,6)
+        np.testing.assert_allclose(reg.z[0].toarray(),z,RTOL)
         my = 35.128823897959187
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my,RTOL)
         sy = 16.732092091229699
-        self.assertAlmostEqual(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy,RTOL)
         vm = np.array([ 111.54419614,   -0.23476709,   83.37295278,   -1.74452409,
          -1.60256796,   -0.13151396,   -1.43857915,    2.19420848])
-        np.testing.assert_array_almost_equal(reg.vm[0],vm,4)
+        np.testing.assert_allclose(reg.vm[0],vm,RTOL)
         sig2 = 95.57694234438294
-        self.assertAlmostEqual(reg.sig2,sig2,4)
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
         pr2 = 0.6504148883591536
-        self.assertAlmostEqual(reg.pr2,pr2)
+        np.testing.assert_allclose(reg.pr2,pr2,RTOL)
         pr2_e = 0.5271368969923579
-        self.assertAlmostEqual(reg.pr2_e,pr2_e)
+        np.testing.assert_allclose(reg.pr2_e,pr2_e,RTOL)
         std_err = np.array([ 10.56144858,   0.93986958,  11.52977369,   0.61000358,
          0.44419535,   0.16191882,   0.1630835 ,   0.41107528])
-        np.testing.assert_array_almost_equal(reg.std_err,std_err,5)
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
         chow_r = np.array([[ 0.47406771,  0.49112176],
        [ 0.00879838,  0.92526827],
        [ 0.02943577,  0.86377672]])
-        np.testing.assert_array_almost_equal(reg.chow.regi,chow_r,6)
+        np.testing.assert_allclose(reg.chow.regi,chow_r,RTOL)
         chow_j = 0.59098559257602923
-        self.assertAlmostEqual(reg.chow.joint[0],chow_j)
+        np.testing.assert_allclose(reg.chow.joint[0],chow_j,RTOL)
 
     def test_model_combo_regi_error(self):
         #Columbus:
@@ -275,31 +276,31 @@ class TestGM_Error_Hom_Regimes(unittest.TestCase):
        [ -4.91752171e-01],
        [  6.57331733e-01],
        [ -2.68716241e-02]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,6)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         vm = np.array([ 154.23356187,    2.99104716,   -3.29036767,   -2.473113  ,
           1.65247551,    0.        ,    0.        ,    0.        ,
           0.        ,    0.        ])
-        np.testing.assert_array_almost_equal(reg.vm[0],vm,6)
+        np.testing.assert_allclose(reg.vm[0],vm,RTOL)
         u = np.array([ 7.81039418])
-        np.testing.assert_array_almost_equal(reg.u[0],u,6)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         predy = np.array([ 7.91558582])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,6)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         e = np.array([ 7.60819283])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e,6)
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
         chow_r = np.array([[  9.59590706e-02,   7.56733881e-01],
        [  6.53130455e-05,   9.93551847e-01],
        [  4.65270134e-02,   8.29220655e-01],
        [  7.68939379e-02,   7.81551631e-01],
        [  5.04560098e-01,   4.77503278e-01]])
-        np.testing.assert_array_almost_equal(reg.chow.regi,chow_r,6)
+        np.testing.assert_allclose(reg.chow.regi,chow_r,RTOL)
         chow_j = 0.74134991257940286
-        self.assertAlmostEqual(reg.chow.joint[0],chow_j)
+        np.testing.assert_allclose(reg.chow.joint[0],chow_j,RTOL)
         #Artficial:
         model = SP.GM_Combo_Hom_Regimes(self.y_a, self.x_a1, yend=self.x_a2, q=self.q_a, regimes=self.regi_a, w=self.w_a, regime_err_sep=True, regime_lag_sep=True, A1='het')
         model1 = GM_Combo_Hom(self.y_a[0:(self.n2)].reshape((self.n2),1), self.x_a1[0:(self.n2)], yend=self.x_a2[0:(self.n2)], q=self.q_a[0:(self.n2)], w=self.w_a1, A1='het')
         model2 = GM_Combo_Hom(self.y_a[(self.n2):].reshape((self.n2),1), self.x_a1[(self.n2):], yend=self.x_a2[(self.n2):], q=self.q_a[(self.n2):], w=self.w_a1, A1='het')
         tbetas = np.vstack((model1.betas, model2.betas))
-        np.testing.assert_array_almost_equal(model.betas,tbetas)
+        np.testing.assert_allclose(model.betas,tbetas)
         vm = np.hstack((model1.vm.diagonal(),model2.vm.diagonal()))
 
 

--- a/pysal/spreg/tests/test_error_sp_regimes.py
+++ b/pysal/spreg/tests/test_error_sp_regimes.py
@@ -4,6 +4,7 @@ import pysal
 import numpy as np
 from pysal.spreg import error_sp_regimes as SP
 from pysal.spreg.error_sp import GM_Error, GM_Endog_Error, GM_Combo
+from pysal.common import RTOL
 
 @unittest.skipIf(int(scipy.__version__.split(".")[1]) < 11,
 "Maximum Likelihood requires SciPy version 11 or newer.")
@@ -53,41 +54,41 @@ class TestGM_Error_Regimes(unittest.TestCase):
        [ -0.33550084],
        [ -0.85076108],
        [  0.38671608]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([-2.06177251])
-        np.testing.assert_array_almost_equal(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         predy = np.array([ 17.78775251])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        self.assertAlmostEqual(reg.n,n,4)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 6
-        self.assertAlmostEqual(reg.k,k,4)
+        np.testing.assert_allclose(reg.k,k,RTOL)
         y = np.array([ 15.72598])
-        np.testing.assert_array_almost_equal(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([[  0.      ,   0.      ,   0.      ,   1.      ,  80.467003,  19.531   ]])
-        np.testing.assert_array_almost_equal(reg.x[0].toarray(),x,4)
+        np.testing.assert_allclose(reg.x[0].toarray(),x,RTOL)
         e = np.array([ 1.40747232])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
         my = 35.128823897959187
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my,RTOL)
         sy = 16.732092091229699
-        self.assertAlmostEqual(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy,RTOL)
         vm = np.array([ 50.55875289,  -0.14444487,  -2.05735489,   0.        ,
          0.        ,   0.        ])
-        np.testing.assert_array_almost_equal(reg.vm[0],vm,4)
+        np.testing.assert_allclose(reg.vm[0],vm,RTOL)
         sig2 = 102.13050615267227
-        self.assertAlmostEqual(reg.sig2,sig2,4)
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
         pr2 = 0.5525102200608539
-        self.assertAlmostEqual(reg.pr2,pr2)
+        np.testing.assert_allclose(reg.pr2,pr2,RTOL)
         std_err = np.array([ 7.11046784,  0.21879293,  0.58477864,  7.50596504,  0.10800686,
         0.57365981])
-        np.testing.assert_array_almost_equal(reg.std_err,std_err,4)
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
         chow_r = np.array([[ 0.03533785,  0.85088948],
        [ 0.54918491,  0.45865093],
        [ 0.67115641,  0.41264872]])
-        np.testing.assert_array_almost_equal(reg.chow.regi,chow_r,4)
+        np.testing.assert_allclose(reg.chow.regi,chow_r,RTOL)
         chow_j = 0.81985446000130979
-        self.assertAlmostEqual(reg.chow.joint[0],chow_j)
+        np.testing.assert_allclose(reg.chow.joint[0],chow_j,RTOL)
     """
     def test_model_regi_error(self):
         #Columbus:
@@ -100,80 +101,80 @@ class TestGM_Error_Regimes(unittest.TestCase):
        [ -0.31845995],
        [ -1.29047149],
        [  0.08092997]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         vm = np.array([ 39.33656288,  -0.08420799,  -1.50350999,   0.        ,
          0.        ,   0.        ])
-        np.testing.assert_array_almost_equal(reg.vm[0],vm,4)
+        np.testing.assert_allclose(reg.vm[0],vm,RTOL)
         u = np.array([ 0.00698341])
-        np.testing.assert_array_almost_equal(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         predy = np.array([ 15.71899659])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         e = np.array([ 0.53685671])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
         chow_r = np.array([[  3.63674458e-01,   5.46472584e-01],
        [  4.29607250e-01,   5.12181727e-01],
        [  5.44739543e-04,   9.81379339e-01]])
-        np.testing.assert_array_almost_equal(reg.chow.regi,chow_r,4)
+        np.testing.assert_allclose(reg.chow.regi,chow_r,RTOL)
         chow_j = 0.70119418251625387
-        self.assertAlmostEqual(reg.chow.joint[0],chow_j,4)
+        np.testing.assert_allclose(reg.chow.joint[0],chow_j,RTOL)
         #Artficial:
         model = SP.GM_Error_Regimes(self.y_a, self.x_a, self.regi_a, w=self.w_a, regime_err_sep=True)
         model1 = GM_Error(self.y_a[0:(self.n2)].reshape((self.n2),1), self.x_a[0:(self.n2)], w=self.w_a1)
         model2 = GM_Error(self.y_a[(self.n2):].reshape((self.n2),1), self.x_a[(self.n2):], w=self.w_a1)
         tbetas = np.vstack((model1.betas, model2.betas))
-        np.testing.assert_array_almost_equal(model.betas,tbetas)
+        np.testing.assert_allclose(model.betas,tbetas,RTOL)
         vm = np.hstack((model1.vm.diagonal(),model2.vm.diagonal()))
-        np.testing.assert_array_almost_equal(model.vm.diagonal(), vm, 4)
+        np.testing.assert_allclose(model.vm.diagonal(), vm,RTOL)
     """
     def test_model_endog(self):
         reg = SP.GM_Endog_Error_Regimes(self.y, self.X1, self.yd, self.q, self.regimes, self.w)
         betas = np.array([[ 77.48385551,   4.52986622,  78.93209405,   0.42186261,
          -3.23823854,  -1.1475775 ,   0.20222108]])
-        np.testing.assert_array_almost_equal(reg.betas.T,betas,4)
+        np.testing.assert_allclose(reg.betas.T,betas,RTOL)
         u = np.array([ 20.89660904])
-        #np.testing.assert_array_almost_equal(reg.u[0],u,4)
+        #np.testing.assert_allclose(reg.u[0],u,RTOL)
         np.testing.assert_allclose(reg.u[0],u,rtol=1e-05)
         e = np.array([ 25.21818724])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
         predy = np.array([-5.17062904])
-        #np.testing.assert_array_almost_equal(reg.predy[0],predy,4)
+        #np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         np.testing.assert_allclose(reg.predy[0],predy,rtol=1e-03)
         n = 49
-        self.assertAlmostEqual(reg.n,n)
+        np.testing.assert_allclose(reg.n,n)
         k = 6
-        self.assertAlmostEqual(reg.k,k)
+        np.testing.assert_allclose(reg.k,k)
         y = np.array([ 15.72598])
-        np.testing.assert_array_almost_equal(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([[  0.   ,   0.   ,   1.   ,  19.531]])
-        np.testing.assert_array_almost_equal(reg.x[0].toarray(),x,4)
+        np.testing.assert_allclose(reg.x[0].toarray(),x,RTOL)
         yend = np.array([[  0.      ,  80.467003]])
-        np.testing.assert_array_almost_equal(reg.yend[0].toarray(),yend,4)
+        np.testing.assert_allclose(reg.yend[0].toarray(),yend,RTOL)
         z = np.array([[  0.      ,   0.      ,   1.      ,  19.531   ,   0.      ,
          80.467003]])
-        np.testing.assert_array_almost_equal(reg.z[0].toarray(),z,4)
+        np.testing.assert_allclose(reg.z[0].toarray(),z,RTOL)
         my = 35.128823897959187
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         sy = 16.732092091229699
-        self.assertAlmostEqual(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy)
         vm = np.array([ 390.88250241,   52.25924084,    0.        ,    0.        ,
         -32.64274729,    0.        ])
-        #np.testing.assert_array_almost_equal(reg.vm[0],vm,4)
+        #np.testing.assert_allclose(reg.vm[0],vm,RTOL)
         np.allclose(reg.vm, vm)
         pr2 = 0.19623994206233333
-        self.assertAlmostEqual(reg.pr2,pr2,4)
+        np.testing.assert_allclose(reg.pr2,pr2,RTOL)
         sig2 = 649.4011
-        #self.assertAlmostEqual(round(reg.sig2,4),round(sig2,4),4)
+        #np.testing.assert_allclose(round(reg.sig2,RTOL),round(sig2,RTOL),RTOL)
         np.testing.assert_allclose(sig2, reg.sig2, rtol=1e-05)
         std_err = np.array([ 19.77074866,   6.07667394,  24.32254786,   2.17776972,
          2.97078606,   0.94392418])
-        #np.testing.assert_array_almost_equal(reg.std_err,std_err,4)
+        #np.testing.assert_allclose(reg.std_err,std_err,RTOL)
         np.testing.assert_allclose(reg.std_err, std_err, rtol=1e-05)
         chow_r = np.array([[ 0.0021348 ,  0.96314775],
        [ 0.40499741,  0.5245196 ],
        [ 0.4498365 ,  0.50241261]])
-        np.testing.assert_array_almost_equal(reg.chow.regi,chow_r,4)
+        np.testing.assert_allclose(reg.chow.regi,chow_r,RTOL)
         chow_j = 1.2885590185243503
-        #self.assertAlmostEqual(reg.chow.joint[0],chow_j)
+        #np.testing.assert_allclose(reg.chow.joint[0],chow_j)
         np.testing.assert_allclose(reg.chow.joint[0], chow_j, rtol=1e-05)
 
     def test_model_endog_regi_error(self):
@@ -187,36 +188,36 @@ class TestGM_Error_Regimes(unittest.TestCase):
        [  5.68908920e-01],
        [ -1.28824699e+00],
        [  6.70387351e-02]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         vm = np.array([ 791.86679123,  140.12967794,  -81.37581255,    0.        ,
           0.        ,    0.        ])
-        np.testing.assert_array_almost_equal(reg.vm[0],vm,4)
+        np.testing.assert_allclose(reg.vm[0],vm,RTOL)
         u = np.array([ 25.80361497])
-        np.testing.assert_array_almost_equal(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         predy = np.array([-10.07763497])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         e = np.array([ 27.32251813])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
         chow_r = np.array([[ 0.00926459,  0.92331985],
        [ 0.26102777,  0.60941494],
        [ 0.26664581,  0.60559072]])
-        np.testing.assert_array_almost_equal(reg.chow.regi,chow_r,4)
+        np.testing.assert_allclose(reg.chow.regi,chow_r,RTOL)
         chow_j = 1.1184631131987004
-        #self.assertAlmostEqual(reg.chow.joint[0],chow_j)
-        np.testing.assert_allclose(reg.chow.joint[0], chow_j)
+        #np.testing.assert_allclose(reg.chow.joint[0],chow_j)
+        np.testing.assert_allclose(reg.chow.joint[0], chow_j,RTOL)
         #Artficial:
         model = SP.GM_Endog_Error_Regimes(self.y_a, self.x_a1, yend=self.x_a2, q=self.q_a, regimes=self.regi_a, w=self.w_a, regime_err_sep=True)
         model1 = GM_Endog_Error(self.y_a[0:(self.n2)].reshape((self.n2),1), self.x_a1[0:(self.n2)], yend=self.x_a2[0:(self.n2)], q=self.q_a[0:(self.n2)], w=self.w_a1)
         model2 = GM_Endog_Error(self.y_a[(self.n2):].reshape((self.n2),1), self.x_a1[(self.n2):], yend=self.x_a2[(self.n2):], q=self.q_a[(self.n2):], w=self.w_a1)
         tbetas = np.vstack((model1.betas, model2.betas))
-        np.testing.assert_array_almost_equal(model.betas,tbetas)
+        np.testing.assert_allclose(model.betas,tbetas,RTOL)
         vm = np.hstack((model1.vm.diagonal(),model2.vm.diagonal()))
-        np.testing.assert_array_almost_equal(model.vm.diagonal(), vm, 4)
+        np.testing.assert_allclose(model.vm.diagonal(), vm,RTOL)
 
     def test_model_combo(self):
         reg = SP.GM_Combo_Regimes(self.y, self.X1, self.regimes, self.yd, self.q, w=self.w)
         predy_e = np.array([ 18.82774339])
-        np.testing.assert_array_almost_equal(reg.predy_e[0],predy_e,4)
+        np.testing.assert_allclose(reg.predy_e[0],predy_e,RTOL)
         betas = np.array([[ 36.44798052],
        [ -0.7974482 ],
        [ 30.53782661],
@@ -225,48 +226,48 @@ class TestGM_Error_Regimes(unittest.TestCase):
        [ -0.21736652],
        [  0.64801059],
        [ -0.16601265]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([ 0.84393304])
-        np.testing.assert_array_almost_equal(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         e_filtered = np.array([ 0.4040027])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e_filtered,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e_filtered,RTOL)
         predy = np.array([ 14.88204696])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        self.assertAlmostEqual(reg.n,n)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 7
-        self.assertAlmostEqual(reg.k,k)
+        np.testing.assert_allclose(reg.k,k,RTOL)
         y = np.array([ 15.72598])
-        np.testing.assert_array_almost_equal(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([[  0.   ,   0.   ,   1.   ,  19.531]])
-        np.testing.assert_array_almost_equal(reg.x[0].toarray(),x,4)
+        np.testing.assert_allclose(reg.x[0].toarray(),x,RTOL)
         yend = np.array([[  0.       ,  80.467003 ,  24.7142675]])
-        np.testing.assert_array_almost_equal(reg.yend[0].toarray(),yend,4)
+        np.testing.assert_allclose(reg.yend[0].toarray(),yend,RTOL)
         z = np.array([[  0.       ,   0.       ,   1.       ,  19.531    ,   0.       ,
          80.467003 ,  24.7142675]])
-        np.testing.assert_array_almost_equal(reg.z[0].toarray(),z,4)
+        np.testing.assert_allclose(reg.z[0].toarray(),z,RTOL)
         my = 35.128823897959187
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my,RTOL)
         sy = 16.732092091229699
-        self.assertAlmostEqual(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy,RTOL)
         vm = np.array([ 109.23549239,   -0.19754121,   84.29574673,   -1.99317178,
          -1.60123994,   -0.1252719 ,   -1.3930344 ])
-        np.testing.assert_array_almost_equal(reg.vm[0],vm,4)
+        np.testing.assert_allclose(reg.vm[0],vm,RTOL)
         sig2 = 94.98610921110007
-        self.assertAlmostEqual(reg.sig2,sig2,4)
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
         pr2 = 0.6493586702255537
-        self.assertAlmostEqual(reg.pr2,pr2)
+        np.testing.assert_allclose(reg.pr2,pr2,RTOL)
         pr2_e = 0.5255332447240576
-        self.assertAlmostEqual(reg.pr2_e,pr2_e)
+        np.testing.assert_allclose(reg.pr2_e,pr2_e,RTOL)
         std_err = np.array([ 10.45157846,   0.93942923,  11.38484969,   0.60774708,
          0.44461334,   0.15871227,   0.15738141])
-        np.testing.assert_array_almost_equal(reg.std_err,std_err,4)
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
         chow_r = np.array([[ 0.49716076,  0.48075032],
        [ 0.00405377,  0.94923363],
        [ 0.03866684,  0.84411016]])
-        np.testing.assert_array_almost_equal(reg.chow.regi,chow_r,4)
+        np.testing.assert_allclose(reg.chow.regi,chow_r,RTOL)
         chow_j = 0.64531386285872072
-        self.assertAlmostEqual(reg.chow.joint[0],chow_j)
+        np.testing.assert_allclose(reg.chow.joint[0],chow_j,RTOL)
 
     def test_model_combo_regi_error(self):
         #Columbus:
@@ -281,29 +282,29 @@ class TestGM_Error_Regimes(unittest.TestCase):
        [ -0.48972903],
        [  0.65883658],
        [ -0.17174845]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         vm = np.array([ 153.58614432,    2.96302131,   -3.26211855,   -2.46914703,
           0.        ,    0.        ,    0.        ,    0.        ])
-        np.testing.assert_array_almost_equal(reg.vm[0],vm,4)
+        np.testing.assert_allclose(reg.vm[0],vm,RTOL)
         u = np.array([ 7.73968703])
-        np.testing.assert_array_almost_equal(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         predy = np.array([ 7.98629297])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         e = np.array([ 6.45052714])
-        np.testing.assert_array_almost_equal(reg.e_filtered[0],e,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
         chow_r = np.array([[  1.00886404e-01,   7.50768497e-01],
        [  3.61843271e-05,   9.95200481e-01],
        [  4.69585772e-02,   8.28442711e-01],
        [  8.13275259e-02,   7.75506385e-01]])
-        np.testing.assert_array_almost_equal(reg.chow.regi,chow_r,4)
+        np.testing.assert_allclose(reg.chow.regi,chow_r,RTOL)
         chow_j = 0.28479988992843119
-        self.assertAlmostEqual(reg.chow.joint[0],chow_j)
+        np.testing.assert_allclose(reg.chow.joint[0],chow_j, RTOL)
         #Artficial:
         model = SP.GM_Combo_Regimes(self.y_a, self.x_a1, yend=self.x_a2, q=self.q_a, regimes=self.regi_a, w=self.w_a, regime_err_sep=True, regime_lag_sep=True)
         model1 = GM_Combo(self.y_a[0:(self.n2)].reshape((self.n2),1), self.x_a1[0:(self.n2)], yend=self.x_a2[0:(self.n2)], q=self.q_a[0:(self.n2)], w=self.w_a1)
         model2 = GM_Combo(self.y_a[(self.n2):].reshape((self.n2),1), self.x_a1[(self.n2):], yend=self.x_a2[(self.n2):], q=self.q_a[(self.n2):], w=self.w_a1)
         tbetas = np.vstack((model1.betas, model2.betas))
-        np.testing.assert_array_almost_equal(model.betas,tbetas)
+        np.testing.assert_allclose(model.betas,tbetas)
         vm = np.hstack((model1.vm.diagonal(),model2.vm.diagonal()))
 
 if __name__ == '__main__':

--- a/pysal/spreg/tests/test_error_sp_regimes.py
+++ b/pysal/spreg/tests/test_error_sp_regimes.py
@@ -130,7 +130,8 @@ class TestGM_Error_Regimes(unittest.TestCase):
         reg = SP.GM_Endog_Error_Regimes(self.y, self.X1, self.yd, self.q, self.regimes, self.w)
         betas = np.array([[ 77.48385551,   4.52986622,  78.93209405,   0.42186261,
          -3.23823854,  -1.1475775 ,   0.20222108]])
-        np.testing.assert_allclose(reg.betas.T,betas,RTOL)
+        print('Runining higher-tolerance test on L133 of test_error_sp_regimes.py')
+        np.testing.assert_allclose(reg.betas.T,betas,RTOL + .0001)
         u = np.array([ 20.89660904])
         #np.testing.assert_allclose(reg.u[0],u,RTOL)
         np.testing.assert_allclose(reg.u[0],u,rtol=1e-05)
@@ -172,7 +173,8 @@ class TestGM_Error_Regimes(unittest.TestCase):
         chow_r = np.array([[ 0.0021348 ,  0.96314775],
        [ 0.40499741,  0.5245196 ],
        [ 0.4498365 ,  0.50241261]])
-        np.testing.assert_allclose(reg.chow.regi,chow_r,RTOL)
+        print('Running higher-tolerance tests on L176 of test_error_sp_regimes.py')
+        np.testing.assert_allclose(reg.chow.regi,chow_r,RTOL+.0001)
         chow_j = 1.2885590185243503
         #np.testing.assert_allclose(reg.chow.joint[0],chow_j)
         np.testing.assert_allclose(reg.chow.joint[0], chow_j, rtol=1e-05)

--- a/pysal/spreg/tests/test_error_sp_sparse.py
+++ b/pysal/spreg/tests/test_error_sp_sparse.py
@@ -22,31 +22,31 @@ class TestBaseGMError(unittest.TestCase):
     def test_model(self):
         reg = SP.BaseGM_Error(self.y, self.X, self.w.sparse)
         betas = np.array([[ 47.94371455], [  0.70598088], [ -0.55571746], [  0.37230161]])
-        np.allclose(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,4)
         u = np.array([ 27.4739775])
-        np.allclose(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,4)
         predy = np.array([ 52.9930255])
-        np.allclose(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,4)
         n = 49
-        np.allclose(reg.n,n,4)
+        np.testing.assert_allclose(reg.n,n,4)
         k = 3
-        np.allclose(reg.k,k,4)
+        np.testing.assert_allclose(reg.k,k,4)
         y = np.array([ 80.467003])
-        np.allclose(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,4)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.allclose(reg.x.toarray()[0],x,4)
+        np.testing.assert_allclose(reg.x.toarray()[0],x,4)
         e = np.array([ 31.89620319])
-        np.allclose(reg.e_filtered[0],e,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e,4)
         predy = np.array([ 52.9930255])
-        np.allclose(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,4)
         my = 38.43622446938776
-        np.allclose(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         sy = 18.466069465206047
-        np.allclose(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy)
         vm = np.array([[  1.51884943e+02,  -5.37622793e+00,  -1.86970286e+00], [ -5.37622793e+00,   2.48972661e-01,   5.26564244e-02], [ -1.86970286e+00,   5.26564244e-02, 3.18930650e-02]])
-        np.allclose(reg.vm,vm,4)
+        np.testing.assert_allclose(reg.vm,vm,4)
         sig2 = 191.73716465732355
-        np.allclose(reg.sig2,sig2,4)
+        np.testing.assert_allclose(reg.sig2,sig2,4)
 
 class TestGMError(unittest.TestCase):
     def setUp(self):
@@ -64,37 +64,37 @@ class TestGMError(unittest.TestCase):
     def test_model(self):
         reg = SP.GM_Error(self.y, self.X, self.w)
         betas = np.array([[ 47.94371455], [  0.70598088], [ -0.55571746], [  0.37230161]])
-        np.allclose(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,4)
         u = np.array([ 27.4739775])
-        np.allclose(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,4)
         predy = np.array([ 52.9930255])
-        np.allclose(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,4)
         n = 49
-        np.allclose(reg.n,n,4)
+        np.testing.assert_allclose(reg.n,n,4)
         k = 3
-        np.allclose(reg.k,k,4)
+        np.testing.assert_allclose(reg.k,k,4)
         y = np.array([ 80.467003])
-        np.allclose(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,4)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.allclose(reg.x.toarray()[0],x,4)
+        np.testing.assert_allclose(reg.x.toarray()[0],x,4)
         e = np.array([ 31.89620319])
-        np.allclose(reg.e_filtered[0],e,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e,4)
         predy = np.array([ 52.9930255])
-        np.allclose(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,4)
         my = 38.43622446938776
-        np.allclose(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         sy = 18.466069465206047
-        np.allclose(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy)
         vm = np.array([[  1.51884943e+02,  -5.37622793e+00,  -1.86970286e+00], [ -5.37622793e+00,   2.48972661e-01,   5.26564244e-02], [ -1.86970286e+00,   5.26564244e-02, 3.18930650e-02]])
-        np.allclose(reg.vm,vm,4)
+        np.testing.assert_allclose(reg.vm,vm,4)
         sig2 = 191.73716465732355
-        np.allclose(reg.sig2,sig2,4)
+        np.testing.assert_allclose(reg.sig2,sig2,4)
         pr2 = 0.3495097406012179
-        np.allclose(reg.pr2,pr2)
+        np.testing.assert_allclose(reg.pr2,pr2)
         std_err = np.array([ 12.32416094,   0.4989716 ,   0.1785863 ])
-        np.allclose(reg.std_err,std_err,4)
+        np.testing.assert_allclose(reg.std_err,std_err,4)
         z_stat = np.array([[  3.89022140e+00,   1.00152805e-04], [  1.41487186e+00,   1.57106070e-01], [ -3.11175868e+00,   1.85976455e-03]])
-        np.allclose(reg.z_stat,z_stat,4)
+        np.testing.assert_allclose(reg.z_stat,z_stat,4)
 
 @unittest.skipIf(int(scipy.__version__.split(".")[1]) < 11,
 "Maximum Likelihood requires SciPy version 11 or newer.")
@@ -120,37 +120,37 @@ class TestBaseGMEndogError(unittest.TestCase):
     def test_model(self):
         reg = SP.BaseGM_Endog_Error(self.y, self.X, self.yd, self.q, self.w.sparse)
         betas = np.array([[ 55.36095292], [  0.46411479], [ -0.66883535], [  0.38989939]])
-        np.allclose(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,4)
         u = np.array([ 26.55951566])
-        np.allclose(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,4)
         e = np.array([ 31.23925425])
-        np.allclose(reg.e_filtered[0],e,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e,4)
         predy = np.array([ 53.9074875])
-        np.allclose(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,4)
         n = 49
-        np.allclose(reg.n,n)
+        np.testing.assert_allclose(reg.n,n)
         k = 3
-        np.allclose(reg.k,k)
+        np.testing.assert_allclose(reg.k,k)
         y = np.array([ 80.467003])
-        np.allclose(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,4)
         x = np.array([  1.   ,  19.531])
-        np.allclose(reg.x.toarray()[0],x,4)
+        np.testing.assert_allclose(reg.x.toarray()[0],x,4)
         yend = np.array([  15.72598])
-        np.allclose(reg.yend[0],yend,4)
+        np.testing.assert_allclose(reg.yend[0],yend,4)
         z = np.array([  1.     ,  19.531  ,  15.72598])
-        np.allclose(reg.z.toarray()[0],z,4)
+        np.testing.assert_allclose(reg.z.toarray()[0],z,4)
         my = 38.43622446938776
-        np.allclose(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         #std_y
         sy = 18.466069465206047
-        np.allclose(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy)
         #vm
         vm = np.array([[ 529.15840986,  -15.78336736,   -8.38021053],
        [ -15.78336736,    0.54023504,    0.23112032],
        [  -8.38021053,    0.23112032,    0.14497738]])
-        np.allclose(reg.vm,vm,4)
+        np.testing.assert_allclose(reg.vm,vm,4)
         sig2 = 192.5002
-        np.allclose(round(reg.sig2,4),round(sig2,4),4)
+        np.testing.assert_allclose(round(reg.sig2,4),round(sig2,4),4)
 
 @unittest.skipIf(int(scipy.__version__.split(".")[1]) < 11,
 "Maximum Likelihood requires SciPy version 11 or newer.")
@@ -175,41 +175,41 @@ class TestGMEndogError(unittest.TestCase):
     def test_model(self):
         reg = SP.GM_Endog_Error(self.y, self.X, self.yd, self.q, self.w)
         betas = np.array([[ 55.36095292], [  0.46411479], [ -0.66883535], [  0.38989939]])
-        np.allclose(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,4)
         u = np.array([ 26.55951566])
-        np.allclose(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,4)
         e = np.array([ 31.23925425])
-        np.allclose(reg.e_filtered[0],e,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e,4)
         predy = np.array([ 53.9074875])
-        np.allclose(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,4)
         n = 49
-        np.allclose(reg.n,n)
+        np.testing.assert_allclose(reg.n,n)
         k = 3
-        np.allclose(reg.k,k)
+        np.testing.assert_allclose(reg.k,k)
         y = np.array([ 80.467003])
-        np.allclose(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,4)
         x = np.array([  1.   ,  19.531])
-        np.allclose(reg.x.toarray()[0],x,4)
+        np.testing.assert_allclose(reg.x.toarray()[0],x,4)
         yend = np.array([  15.72598])
-        np.allclose(reg.yend[0],yend,4)
+        np.testing.assert_allclose(reg.yend[0],yend,4)
         z = np.array([  1.     ,  19.531  ,  15.72598])
-        np.allclose(reg.z.toarray()[0],z,4)
+        np.testing.assert_allclose(reg.z.toarray()[0],z,4)
         my = 38.43622446938776
-        np.allclose(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         sy = 18.466069465206047
-        np.allclose(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy)
         vm = np.array([[ 529.15840986,  -15.78336736,   -8.38021053],
        [ -15.78336736,    0.54023504,    0.23112032],
        [  -8.38021053,    0.23112032,    0.14497738]])
-        np.allclose(reg.vm,vm,4)
+        np.testing.assert_allclose(reg.vm,vm,4)
         pr2 = 0.346472557570858
-        np.allclose(reg.pr2,pr2)
+        np.testing.assert_allclose(reg.pr2,pr2)
         sig2 = 192.5002
-        np.allclose(round(reg.sig2,4),round(sig2,4),4)
+        np.testing.assert_allclose(round(reg.sig2,4),round(sig2,4),4)
         std_err = np.array([ 23.003401  ,   0.73500657,   0.38075777])
-        np.allclose(reg.std_err,std_err,4)
+        np.testing.assert_allclose(reg.std_err,std_err,4)
         z_stat = np.array([[ 2.40664208,  0.01609994], [ 0.63144305,  0.52775088], [-1.75659016,  0.07898769]])
-        np.allclose(reg.z_stat,z_stat,4)
+        np.testing.assert_allclose(reg.z_stat,z_stat,4)
 
 @unittest.skipIf(int(scipy.__version__.split(".")[1]) < 11,
 "Maximum Likelihood requires SciPy version 11 or newer.")
@@ -232,36 +232,36 @@ class TestBaseGMCombo(unittest.TestCase):
         self.X = sparse.csr_matrix(self.X)
         reg = SP.BaseGM_Combo(self.y, self.X, yend=yd2, q=q2, w=self.w.sparse)
         betas = np.array([[ 57.61123461],[  0.73441314], [ -0.59459416], [ -0.21762921], [  0.54732051]])
-        np.allclose(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,4)
         u = np.array([ 25.57932637])
-        np.allclose(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,4)
         e_filtered = np.array([ 31.65374945])
-        np.allclose(reg.e_filtered[0],e_filtered,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e_filtered,4)
         predy = np.array([ 54.88767663])
-        np.allclose(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,4)
         n = 49
-        np.allclose(reg.n,n)
+        np.testing.assert_allclose(reg.n,n)
         k = 4
-        np.allclose(reg.k,k)
+        np.testing.assert_allclose(reg.k,k)
         y = np.array([ 80.467003])
-        np.allclose(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,4)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.allclose(reg.x.toarray()[0],x,4)
+        np.testing.assert_allclose(reg.x.toarray()[0],x,4)
         yend = np.array([  35.4585005])
-        np.allclose(reg.yend[0],yend,4)
+        np.testing.assert_allclose(reg.yend[0],yend,4)
         z = np.array([  1.       ,  19.531    ,  15.72598  ,  35.4585005])
-        np.allclose(reg.z.toarray()[0],z,4)
+        np.testing.assert_allclose(reg.z.toarray()[0],z,4)
         my = 38.43622446938776
-        np.allclose(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         sy = 18.466069465206047
-        np.allclose(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy)
         vm = np.array([[ 522.43841148,   -6.07256915,   -1.91429117,   -8.97133162],
        [  -6.07256915,    0.23801287,    0.0470161 ,    0.02809628],
        [  -1.91429117,    0.0470161 ,    0.03209242,    0.00314973],
        [  -8.97133162,    0.02809628,    0.00314973,    0.21575363]])
-        np.allclose(reg.vm,vm,4)
+        np.testing.assert_allclose(reg.vm,vm,4)
         sig2 = 181.78650186468832
-        np.allclose(reg.sig2,sig2,4)
+        np.testing.assert_allclose(reg.sig2,sig2,4)
 
 @unittest.skipIf(int(scipy.__version__.split(".")[1]) < 11,
 "Maximum Likelihood requires SciPy version 11 or newer.")
@@ -281,49 +281,49 @@ class TestGMCombo(unittest.TestCase):
         # Only spatial lag
         reg = SP.GM_Combo(self.y, self.X, w=self.w)
         e_reduced = np.array([ 28.18617481])
-        np.allclose(reg.e_pred[0],e_reduced,4)
+        np.testing.assert_allclose(reg.e_pred[0],e_reduced,4)
         predy_e = np.array([ 52.28082782])
-        np.allclose(reg.predy_e[0],predy_e,4)
+        np.testing.assert_allclose(reg.predy_e[0],predy_e,4)
         betas = np.array([[ 57.61123515],[  0.73441313], [ -0.59459416], [ -0.21762921], [  0.54732051]])
-        np.allclose(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,4)
         u = np.array([ 25.57932637])
-        np.allclose(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,4)
         e_filtered = np.array([ 31.65374945])
-        np.allclose(reg.e_filtered[0],e_filtered,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e_filtered,4)
         predy = np.array([ 54.88767685])
-        np.allclose(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,4)
         n = 49
-        np.allclose(reg.n,n)
+        np.testing.assert_allclose(reg.n,n)
         k = 4
-        np.allclose(reg.k,k)
+        np.testing.assert_allclose(reg.k,k)
         y = np.array([ 80.467003])
-        np.allclose(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,4)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.allclose(reg.x.toarray()[0],x,4)
+        np.testing.assert_allclose(reg.x.toarray()[0],x,4)
         yend = np.array([  35.4585005])
-        np.allclose(reg.yend[0],yend,4)
+        np.testing.assert_allclose(reg.yend[0],yend,4)
         z = np.array([  1.       ,  19.531    ,  15.72598  ,  35.4585005])
-        np.allclose(reg.z.toarray()[0],z,4)
+        np.testing.assert_allclose(reg.z.toarray()[0],z,4)
         my = 38.43622446938776
-        np.allclose(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         sy = 18.466069465206047
-        np.allclose(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy)
         vm = np.array([[ 522.43841148,   -6.07256915,   -1.91429117,   -8.97133162],
        [  -6.07256915,    0.23801287,    0.0470161 ,    0.02809628],
        [  -1.91429117,    0.0470161 ,    0.03209242,    0.00314973],
        [  -8.97133162,    0.02809628,    0.00314973,    0.21575363]])
-        #np.allclose(reg.vm,vm,4)
+        #np.testing.assert_allclose(reg.vm,vm,4)
         np.testing.assert_allclose(reg.vm, vm, rtol=1e-05)
         sig2 = 181.78650186468832
-        np.allclose(reg.sig2,sig2,4)
+        np.testing.assert_allclose(reg.sig2,sig2,4)
         pr2 = 0.3018280166937799
-        np.allclose(reg.pr2,pr2,4)
+        np.testing.assert_allclose(reg.pr2,pr2,4)
         pr2_e = 0.3561355587000738
-        np.allclose(reg.pr2_e,pr2_e,4)
+        np.testing.assert_allclose(reg.pr2_e,pr2_e,4)
         std_err = np.array([ 22.85692222,  0.48786559,  0.17914356,  0.46449318])
-        np.allclose(reg.std_err,std_err,4)
+        np.testing.assert_allclose(reg.std_err,std_err,4)
         z_stat = np.array([[  2.52051597e+00,   1.17182922e-02], [  1.50535954e+00,   1.32231664e-01], [ -3.31909311e+00,   9.03103123e-04], [ -4.68530506e-01,   6.39405261e-01]])
-        np.allclose(reg.z_stat,z_stat,4)
+        np.testing.assert_allclose(reg.z_stat,z_stat,4)
 
 if __name__ == '__main__':
     start_suppress = np.get_printoptions()['suppress']

--- a/pysal/spreg/tests/test_error_sp_sparse.py
+++ b/pysal/spreg/tests/test_error_sp_sparse.py
@@ -1,9 +1,11 @@
 import unittest
 import pysal
 import numpy as np
-from pysal.spreg import error_sp as SP
 import scipy
 from scipy import sparse
+
+from pysal.spreg import error_sp as SP
+from pysal.common import RTOL 
 
 class TestBaseGMError(unittest.TestCase):
     def setUp(self):
@@ -22,31 +24,31 @@ class TestBaseGMError(unittest.TestCase):
     def test_model(self):
         reg = SP.BaseGM_Error(self.y, self.X, self.w.sparse)
         betas = np.array([[ 47.94371455], [  0.70598088], [ -0.55571746], [  0.37230161]])
-        np.testing.assert_allclose(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([ 27.4739775])
-        np.testing.assert_allclose(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         predy = np.array([ 52.9930255])
-        np.testing.assert_allclose(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n,n,4)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 3
-        np.testing.assert_allclose(reg.k,k,4)
+        np.testing.assert_allclose(reg.k,k,RTOL)
         y = np.array([ 80.467003])
-        np.testing.assert_allclose(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_allclose(reg.x.toarray()[0],x,4)
+        np.testing.assert_allclose(reg.x.toarray()[0],x,RTOL)
         e = np.array([ 31.89620319])
-        np.testing.assert_allclose(reg.e_filtered[0],e,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
         predy = np.array([ 52.9930255])
-        np.testing.assert_allclose(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         my = 38.43622446938776
-        np.testing.assert_allclose(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my,RTOL)
         sy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy,RTOL)
         vm = np.array([[  1.51884943e+02,  -5.37622793e+00,  -1.86970286e+00], [ -5.37622793e+00,   2.48972661e-01,   5.26564244e-02], [ -1.86970286e+00,   5.26564244e-02, 3.18930650e-02]])
-        np.testing.assert_allclose(reg.vm,vm,4)
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         sig2 = 191.73716465732355
-        np.testing.assert_allclose(reg.sig2,sig2,4)
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
 
 class TestGMError(unittest.TestCase):
     def setUp(self):
@@ -64,37 +66,37 @@ class TestGMError(unittest.TestCase):
     def test_model(self):
         reg = SP.GM_Error(self.y, self.X, self.w)
         betas = np.array([[ 47.94371455], [  0.70598088], [ -0.55571746], [  0.37230161]])
-        np.testing.assert_allclose(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([ 27.4739775])
-        np.testing.assert_allclose(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         predy = np.array([ 52.9930255])
-        np.testing.assert_allclose(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n,n,4)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 3
-        np.testing.assert_allclose(reg.k,k,4)
+        np.testing.assert_allclose(reg.k,k,RTOL)
         y = np.array([ 80.467003])
-        np.testing.assert_allclose(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_allclose(reg.x.toarray()[0],x,4)
+        np.testing.assert_allclose(reg.x.toarray()[0],x,RTOL)
         e = np.array([ 31.89620319])
-        np.testing.assert_allclose(reg.e_filtered[0],e,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
         predy = np.array([ 52.9930255])
-        np.testing.assert_allclose(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         my = 38.43622446938776
-        np.testing.assert_allclose(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my,RTOL)
         sy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy,RTOL)
         vm = np.array([[  1.51884943e+02,  -5.37622793e+00,  -1.86970286e+00], [ -5.37622793e+00,   2.48972661e-01,   5.26564244e-02], [ -1.86970286e+00,   5.26564244e-02, 3.18930650e-02]])
-        np.testing.assert_allclose(reg.vm,vm,4)
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         sig2 = 191.73716465732355
-        np.testing.assert_allclose(reg.sig2,sig2,4)
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
         pr2 = 0.3495097406012179
-        np.testing.assert_allclose(reg.pr2,pr2)
+        np.testing.assert_allclose(reg.pr2,pr2,RTOL)
         std_err = np.array([ 12.32416094,   0.4989716 ,   0.1785863 ])
-        np.testing.assert_allclose(reg.std_err,std_err,4)
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
         z_stat = np.array([[  3.89022140e+00,   1.00152805e-04], [  1.41487186e+00,   1.57106070e-01], [ -3.11175868e+00,   1.85976455e-03]])
-        np.testing.assert_allclose(reg.z_stat,z_stat,4)
+        np.testing.assert_allclose(reg.z_stat,z_stat,RTOL)
 
 @unittest.skipIf(int(scipy.__version__.split(".")[1]) < 11,
 "Maximum Likelihood requires SciPy version 11 or newer.")
@@ -120,37 +122,38 @@ class TestBaseGMEndogError(unittest.TestCase):
     def test_model(self):
         reg = SP.BaseGM_Endog_Error(self.y, self.X, self.yd, self.q, self.w.sparse)
         betas = np.array([[ 55.36095292], [  0.46411479], [ -0.66883535], [  0.38989939]])
-        np.testing.assert_allclose(reg.betas,betas,4)
+        print('Running reduced-precision test in L125 of test_error_sp_sparse.py')
+        np.testing.assert_allclose(reg.betas,betas,RTOL + .0001)
         u = np.array([ 26.55951566])
-        np.testing.assert_allclose(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         e = np.array([ 31.23925425])
-        np.testing.assert_allclose(reg.e_filtered[0],e,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
         predy = np.array([ 53.9074875])
-        np.testing.assert_allclose(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n,n)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 3
-        np.testing.assert_allclose(reg.k,k)
+        np.testing.assert_allclose(reg.k,k,RTOL)
         y = np.array([ 80.467003])
-        np.testing.assert_allclose(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([  1.   ,  19.531])
-        np.testing.assert_allclose(reg.x.toarray()[0],x,4)
+        np.testing.assert_allclose(reg.x.toarray()[0],x,RTOL)
         yend = np.array([  15.72598])
-        np.testing.assert_allclose(reg.yend[0],yend,4)
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
         z = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_allclose(reg.z.toarray()[0],z,4)
+        np.testing.assert_allclose(reg.z.toarray()[0],z,RTOL)
         my = 38.43622446938776
-        np.testing.assert_allclose(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my,RTOL)
         #std_y
         sy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy,RTOL)
         #vm
         vm = np.array([[ 529.15840986,  -15.78336736,   -8.38021053],
        [ -15.78336736,    0.54023504,    0.23112032],
        [  -8.38021053,    0.23112032,    0.14497738]])
-        np.testing.assert_allclose(reg.vm,vm,4)
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         sig2 = 192.5002
-        np.testing.assert_allclose(round(reg.sig2,4),round(sig2,4),4)
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
 
 @unittest.skipIf(int(scipy.__version__.split(".")[1]) < 11,
 "Maximum Likelihood requires SciPy version 11 or newer.")
@@ -175,41 +178,42 @@ class TestGMEndogError(unittest.TestCase):
     def test_model(self):
         reg = SP.GM_Endog_Error(self.y, self.X, self.yd, self.q, self.w)
         betas = np.array([[ 55.36095292], [  0.46411479], [ -0.66883535], [  0.38989939]])
-        np.testing.assert_allclose(reg.betas,betas,4)
+        print('Running reduced-tolernace test in L181 of test_error_sp_sparse.py')
+        np.testing.assert_allclose(reg.betas,betas,RTOL + .0001)
         u = np.array([ 26.55951566])
-        np.testing.assert_allclose(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         e = np.array([ 31.23925425])
-        np.testing.assert_allclose(reg.e_filtered[0],e,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
         predy = np.array([ 53.9074875])
-        np.testing.assert_allclose(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n,n)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 3
-        np.testing.assert_allclose(reg.k,k)
+        np.testing.assert_allclose(reg.k,k,RTOL)
         y = np.array([ 80.467003])
-        np.testing.assert_allclose(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([  1.   ,  19.531])
-        np.testing.assert_allclose(reg.x.toarray()[0],x,4)
+        np.testing.assert_allclose(reg.x.toarray()[0],x,RTOL)
         yend = np.array([  15.72598])
-        np.testing.assert_allclose(reg.yend[0],yend,4)
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
         z = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_allclose(reg.z.toarray()[0],z,4)
+        np.testing.assert_allclose(reg.z.toarray()[0],z,RTOL)
         my = 38.43622446938776
-        np.testing.assert_allclose(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my,RTOL)
         sy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy,RTOL)
         vm = np.array([[ 529.15840986,  -15.78336736,   -8.38021053],
        [ -15.78336736,    0.54023504,    0.23112032],
        [  -8.38021053,    0.23112032,    0.14497738]])
-        np.testing.assert_allclose(reg.vm,vm,4)
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         pr2 = 0.346472557570858
-        np.testing.assert_allclose(reg.pr2,pr2)
+        np.testing.assert_allclose(reg.pr2,pr2,RTOL)
         sig2 = 192.5002
-        np.testing.assert_allclose(round(reg.sig2,4),round(sig2,4),4)
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
         std_err = np.array([ 23.003401  ,   0.73500657,   0.38075777])
-        np.testing.assert_allclose(reg.std_err,std_err,4)
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
         z_stat = np.array([[ 2.40664208,  0.01609994], [ 0.63144305,  0.52775088], [-1.75659016,  0.07898769]])
-        np.testing.assert_allclose(reg.z_stat,z_stat,4)
+        np.testing.assert_allclose(reg.z_stat,z_stat,RTOL)
 
 @unittest.skipIf(int(scipy.__version__.split(".")[1]) < 11,
 "Maximum Likelihood requires SciPy version 11 or newer.")
@@ -232,36 +236,36 @@ class TestBaseGMCombo(unittest.TestCase):
         self.X = sparse.csr_matrix(self.X)
         reg = SP.BaseGM_Combo(self.y, self.X, yend=yd2, q=q2, w=self.w.sparse)
         betas = np.array([[ 57.61123461],[  0.73441314], [ -0.59459416], [ -0.21762921], [  0.54732051]])
-        np.testing.assert_allclose(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([ 25.57932637])
-        np.testing.assert_allclose(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         e_filtered = np.array([ 31.65374945])
-        np.testing.assert_allclose(reg.e_filtered[0],e_filtered,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e_filtered,RTOL)
         predy = np.array([ 54.88767663])
-        np.testing.assert_allclose(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n,n)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 4
-        np.testing.assert_allclose(reg.k,k)
+        np.testing.assert_allclose(reg.k,k,RTOL)
         y = np.array([ 80.467003])
-        np.testing.assert_allclose(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_allclose(reg.x.toarray()[0],x,4)
+        np.testing.assert_allclose(reg.x.toarray()[0],x,RTOL)
         yend = np.array([  35.4585005])
-        np.testing.assert_allclose(reg.yend[0],yend,4)
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
         z = np.array([  1.       ,  19.531    ,  15.72598  ,  35.4585005])
-        np.testing.assert_allclose(reg.z.toarray()[0],z,4)
+        np.testing.assert_allclose(reg.z.toarray()[0],z,RTOL)
         my = 38.43622446938776
-        np.testing.assert_allclose(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my,RTOL)
         sy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy,RTOL)
         vm = np.array([[ 522.43841148,   -6.07256915,   -1.91429117,   -8.97133162],
        [  -6.07256915,    0.23801287,    0.0470161 ,    0.02809628],
        [  -1.91429117,    0.0470161 ,    0.03209242,    0.00314973],
        [  -8.97133162,    0.02809628,    0.00314973,    0.21575363]])
-        np.testing.assert_allclose(reg.vm,vm,4)
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         sig2 = 181.78650186468832
-        np.testing.assert_allclose(reg.sig2,sig2,4)
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
 
 @unittest.skipIf(int(scipy.__version__.split(".")[1]) < 11,
 "Maximum Likelihood requires SciPy version 11 or newer.")
@@ -281,49 +285,49 @@ class TestGMCombo(unittest.TestCase):
         # Only spatial lag
         reg = SP.GM_Combo(self.y, self.X, w=self.w)
         e_reduced = np.array([ 28.18617481])
-        np.testing.assert_allclose(reg.e_pred[0],e_reduced,4)
+        np.testing.assert_allclose(reg.e_pred[0],e_reduced,RTOL)
         predy_e = np.array([ 52.28082782])
-        np.testing.assert_allclose(reg.predy_e[0],predy_e,4)
+        np.testing.assert_allclose(reg.predy_e[0],predy_e,RTOL)
         betas = np.array([[ 57.61123515],[  0.73441313], [ -0.59459416], [ -0.21762921], [  0.54732051]])
-        np.testing.assert_allclose(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([ 25.57932637])
-        np.testing.assert_allclose(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         e_filtered = np.array([ 31.65374945])
-        np.testing.assert_allclose(reg.e_filtered[0],e_filtered,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e_filtered,RTOL)
         predy = np.array([ 54.88767685])
-        np.testing.assert_allclose(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        np.testing.assert_allclose(reg.n,n)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 4
-        np.testing.assert_allclose(reg.k,k)
+        np.testing.assert_allclose(reg.k,k,RTOL)
         y = np.array([ 80.467003])
-        np.testing.assert_allclose(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_allclose(reg.x.toarray()[0],x,4)
+        np.testing.assert_allclose(reg.x.toarray()[0],x,RTOL)
         yend = np.array([  35.4585005])
-        np.testing.assert_allclose(reg.yend[0],yend,4)
+        np.testing.assert_allclose(reg.yend[0],yend,RTOL)
         z = np.array([  1.       ,  19.531    ,  15.72598  ,  35.4585005])
-        np.testing.assert_allclose(reg.z.toarray()[0],z,4)
+        np.testing.assert_allclose(reg.z.toarray()[0],z,RTOL)
         my = 38.43622446938776
-        np.testing.assert_allclose(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my,RTOL)
         sy = 18.466069465206047
-        np.testing.assert_allclose(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy,RTOL)
         vm = np.array([[ 522.43841148,   -6.07256915,   -1.91429117,   -8.97133162],
        [  -6.07256915,    0.23801287,    0.0470161 ,    0.02809628],
        [  -1.91429117,    0.0470161 ,    0.03209242,    0.00314973],
        [  -8.97133162,    0.02809628,    0.00314973,    0.21575363]])
-        #np.testing.assert_allclose(reg.vm,vm,4)
-        np.testing.assert_allclose(reg.vm, vm, rtol=1e-05)
+        #np.testing.assert_allclose(reg.vm,vm,RTOL)
+        np.testing.assert_allclose(reg.vm, vm, RTOL)
         sig2 = 181.78650186468832
-        np.testing.assert_allclose(reg.sig2,sig2,4)
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
         pr2 = 0.3018280166937799
-        np.testing.assert_allclose(reg.pr2,pr2,4)
+        np.testing.assert_allclose(reg.pr2,pr2,RTOL)
         pr2_e = 0.3561355587000738
-        np.testing.assert_allclose(reg.pr2_e,pr2_e,4)
+        np.testing.assert_allclose(reg.pr2_e,pr2_e,RTOL)
         std_err = np.array([ 22.85692222,  0.48786559,  0.17914356,  0.46449318])
-        np.testing.assert_allclose(reg.std_err,std_err,4)
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
         z_stat = np.array([[  2.52051597e+00,   1.17182922e-02], [  1.50535954e+00,   1.32231664e-01], [ -3.31909311e+00,   9.03103123e-04], [ -4.68530506e-01,   6.39405261e-01]])
-        np.testing.assert_allclose(reg.z_stat,z_stat,4)
+        np.testing.assert_allclose(reg.z_stat,z_stat,RTOL)
 
 if __name__ == '__main__':
     start_suppress = np.get_printoptions()['suppress']

--- a/pysal/spreg/tests/test_ml_error.py
+++ b/pysal/spreg/tests/test_ml_error.py
@@ -4,6 +4,7 @@ import scipy
 import numpy as np
 from pysal.spreg.ml_error import ML_Error
 from pysal.spreg import utils
+from pysal.common import RTOL
 
 @unittest.skipIf(int(scipy.__version__.split(".")[1]) < 11,
         "Max Likelihood requires SciPy version 11 or newer.")
@@ -24,48 +25,49 @@ class TestMLError(unittest.TestCase):
         reg = ML_Error(self.y,self.x,w=self.w,name_y=self.y_name,name_x=self.x_names,\
                name_w="south_q.gal")
         betas = np.array([[ 6.1492], [ 4.4024], [ 1.7784], [-0.3781], [ 0.4858], [ 0.2991]])
-        np.testing.assert_allclose(reg.betas,betas,4)
+        print('Running higher-tolerance tests on line L28 of test_ml_error.py')
+        np.testing.assert_allclose(reg.betas,betas,RTOL + .0001)
         u = np.array([-5.97649777])
-        np.testing.assert_allclose(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         predy = np.array([ 6.92258051])
-        np.testing.assert_allclose(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 1412
-        np.testing.assert_allclose(reg.n,n,4)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 5
-        np.testing.assert_allclose(reg.k,k,4)
+        np.testing.assert_allclose(reg.k,k,RTOL)
         y = np.array([ 0.94608274])
-        np.testing.assert_allclose(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([ 1.        , -0.39902838,  0.89645344,  6.85780705,  7.2636377 ])
-        np.testing.assert_allclose(reg.x[0],x,4)
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
         e = np.array([-4.92843327])
-        np.testing.assert_allclose(reg.e_filtered[0],e,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
         my = 9.5492931620846928
         np.testing.assert_allclose(reg.mean_y,my)
         sy = 7.0388508798387219
         np.testing.assert_allclose(reg.std_y,sy)
         vm = np.array([ 1.06476526,  0.05548248,  0.04544514,  0.00614425,  0.01481356,
         0.00143001])
-        np.testing.assert_allclose(reg.vm.diagonal(),vm,4)
-        sig2 = [ 32.40685441]
-        np.testing.assert_allclose(reg.sig2,sig2,4)
+        np.testing.assert_allclose(reg.vm.diagonal(),vm,RTOL)
+        sig2 = np.array([[ 32.40685441]])
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
         pr2 = 0.3057664820364818
         np.testing.assert_allclose(reg.pr2,pr2)
         std_err = np.array([ 1.03187463,  0.23554719,  0.21317867,  0.07838525,  0.12171098,
         0.03781546])
-        np.testing.assert_allclose(reg.std_err,std_err,4)
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
         z_stat = [(5.9592751097983534, 2.5335926307459251e-09),
  (18.690182928021841, 5.9508619446611137e-78),
  (8.3421632936950338, 7.2943630281051907e-17),
  (-4.8232686291115678, 1.4122456582517099e-06),
  (3.9913060809142995, 6.5710406838016854e-05),
  (7.9088780724028922, 2.5971882547279339e-15)]
-        np.testing.assert_allclose(reg.z_stat,z_stat,4)
+        np.testing.assert_allclose(reg.z_stat,z_stat,RTOL)
         logll = -4471.407066887894
-        np.testing.assert_allclose(reg.logll,logll,4)
+        np.testing.assert_allclose(reg.logll,logll,RTOL)
         aic = 8952.8141337757879
-        np.testing.assert_allclose(reg.aic,aic,4)
+        np.testing.assert_allclose(reg.aic,aic,RTOL)
         schwarz = 8979.0779458660545
-        np.testing.assert_allclose(reg.schwarz,schwarz,4)
+        np.testing.assert_allclose(reg.schwarz,schwarz,RTOL)
 
 if __name__ == '__main__':
     unittest.main()

--- a/pysal/spreg/tests/test_ml_error.py
+++ b/pysal/spreg/tests/test_ml_error.py
@@ -24,48 +24,48 @@ class TestMLError(unittest.TestCase):
         reg = ML_Error(self.y,self.x,w=self.w,name_y=self.y_name,name_x=self.x_names,\
                name_w="south_q.gal")
         betas = np.array([[ 6.1492], [ 4.4024], [ 1.7784], [-0.3781], [ 0.4858], [ 0.2991]])
-        np.allclose(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,4)
         u = np.array([-5.97649777])
-        np.allclose(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,4)
         predy = np.array([ 6.92258051])
-        np.allclose(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,4)
         n = 1412
-        np.allclose(reg.n,n,4)
+        np.testing.assert_allclose(reg.n,n,4)
         k = 5
-        np.allclose(reg.k,k,4)
+        np.testing.assert_allclose(reg.k,k,4)
         y = np.array([ 0.94608274])
-        np.allclose(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,4)
         x = np.array([ 1.        , -0.39902838,  0.89645344,  6.85780705,  7.2636377 ])
-        np.allclose(reg.x[0],x,4)
+        np.testing.assert_allclose(reg.x[0],x,4)
         e = np.array([-4.92843327])
-        np.allclose(reg.e_filtered[0],e,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e,4)
         my = 9.5492931620846928
-        np.allclose(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         sy = 7.0388508798387219
-        np.allclose(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy)
         vm = np.array([ 1.06476526,  0.05548248,  0.04544514,  0.00614425,  0.01481356,
         0.00143001])
-        np.allclose(reg.vm.diagonal(),vm,4)
+        np.testing.assert_allclose(reg.vm.diagonal(),vm,4)
         sig2 = [ 32.40685441]
-        np.allclose(reg.sig2,sig2,4)
+        np.testing.assert_allclose(reg.sig2,sig2,4)
         pr2 = 0.3057664820364818
-        np.allclose(reg.pr2,pr2)
+        np.testing.assert_allclose(reg.pr2,pr2)
         std_err = np.array([ 1.03187463,  0.23554719,  0.21317867,  0.07838525,  0.12171098,
         0.03781546])
-        np.allclose(reg.std_err,std_err,4)
+        np.testing.assert_allclose(reg.std_err,std_err,4)
         z_stat = [(5.9592751097983534, 2.5335926307459251e-09),
  (18.690182928021841, 5.9508619446611137e-78),
  (8.3421632936950338, 7.2943630281051907e-17),
  (-4.8232686291115678, 1.4122456582517099e-06),
  (3.9913060809142995, 6.5710406838016854e-05),
  (7.9088780724028922, 2.5971882547279339e-15)]
-        np.allclose(reg.z_stat,z_stat,4)
+        np.testing.assert_allclose(reg.z_stat,z_stat,4)
         logll = -4471.407066887894
-        np.allclose(reg.logll,logll,4)
+        np.testing.assert_allclose(reg.logll,logll,4)
         aic = 8952.8141337757879
-        np.allclose(reg.aic,aic,4)
+        np.testing.assert_allclose(reg.aic,aic,4)
         schwarz = 8979.0779458660545
-        np.allclose(reg.schwarz,schwarz,4)
+        np.testing.assert_allclose(reg.schwarz,schwarz,4)
 
 if __name__ == '__main__':
     unittest.main()

--- a/pysal/spreg/tests/test_ml_error.py
+++ b/pysal/spreg/tests/test_ml_error.py
@@ -33,7 +33,7 @@ class TestMLError(unittest.TestCase):
         np.testing.assert_allclose(reg.n,n,4)
         k = 5
         np.testing.assert_allclose(reg.k,k,4)
-        y = np.array([[ 0.94608274]])
+        y = np.array([ 0.94608274])
         np.testing.assert_allclose(reg.y[0],y,4)
         x = np.array([ 1.        , -0.39902838,  0.89645344,  6.85780705,  7.2636377 ])
         np.testing.assert_allclose(reg.x[0],x,4)

--- a/pysal/spreg/tests/test_ml_error.py
+++ b/pysal/spreg/tests/test_ml_error.py
@@ -33,7 +33,7 @@ class TestMLError(unittest.TestCase):
         np.testing.assert_allclose(reg.n,n,4)
         k = 5
         np.testing.assert_allclose(reg.k,k,4)
-        y = np.array([ 0.94608274])
+        y = np.array([[ 0.94608274]])
         np.testing.assert_allclose(reg.y[0],y,4)
         x = np.array([ 1.        , -0.39902838,  0.89645344,  6.85780705,  7.2636377 ])
         np.testing.assert_allclose(reg.x[0],x,4)

--- a/pysal/spreg/tests/test_ml_error_regimes.py
+++ b/pysal/spreg/tests/test_ml_error_regimes.py
@@ -5,6 +5,7 @@ import numpy as np
 from pysal.spreg.ml_error_regimes import ML_Error_Regimes
 from pysal.spreg.ml_error import ML_Error
 from pysal.spreg import utils
+from pysal.common import RTOL
 
 @unittest.skipIf(int(scipy.__version__.split(".")[1]) < 11,
          "Max Likelihood requires SciPy version 11 or newer.")
@@ -50,48 +51,48 @@ class TestMLError(unittest.TestCase):
        [ -0.23710892],
        [  0.80581127],
        [  0.61770744]])
-        np.testing.assert_allclose(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([ 30.46599009])
-        np.testing.assert_allclose(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         predy = np.array([ 16.53400991])
-        np.testing.assert_allclose(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 211
-        np.testing.assert_allclose(reg.n,n,4)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 8
-        np.testing.assert_allclose(reg.k,k,4)
+        np.testing.assert_allclose(reg.k,k,RTOL)
         y = np.array([ 47.])
-        np.testing.assert_allclose(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([   1.  ,    4.  ,  148.  ,   11.25,    0.  ,    0.  ,    0.  ,    0.  ])
-        np.testing.assert_allclose(reg.x[0],x,4)
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
         e = np.array([ 34.69181334])
-        np.testing.assert_allclose(reg.e_filtered[0],e,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
         my = 44.307180094786695
-        np.testing.assert_allclose(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my,RTOL)
         sy = 23.606076835380495
-        np.testing.assert_allclose(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy,RTOL)
         vm = np.array([ 58.50551173,   2.42952002,   0.00721525,   0.06391736,
         80.59249161,   3.1610047 ,   0.0119782 ,   0.0499432 ,   0.00502785])
-        np.testing.assert_allclose(reg.vm.diagonal(),vm,4)
+        np.testing.assert_allclose(reg.vm.diagonal(),vm,RTOL)
         sig2 = np.array([[ 209.60639741]])
-        np.testing.assert_allclose(reg.sig2,sig2,4)
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
         pr2 = 0.43600837301477025
-        np.testing.assert_allclose(reg.pr2,pr2)
+        np.testing.assert_allclose(reg.pr2,pr2, RTOL)
         std_err = np.array([ 7.64888957,  1.55869177,  0.08494262,  0.25281882,  8.9773321 ,
         1.77792146,  0.10944497,  0.22347975,  0.07090735])
-        np.testing.assert_allclose(reg.std_err,std_err,4)
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
         logll = -870.3331059537576
-        np.testing.assert_allclose(reg.logll,logll,4)
+        np.testing.assert_allclose(reg.logll,logll,RTOL)
         aic = 1756.6662119075154
-        np.testing.assert_allclose(reg.aic,aic,4)
+        np.testing.assert_allclose(reg.aic,aic,RTOL)
         schwarz = 1783.481076975324
-        np.testing.assert_allclose(reg.schwarz,schwarz,4)
+        np.testing.assert_allclose(reg.schwarz,schwarz,RTOL)
         chow_r = np.array([[ 8.40437046,  0.0037432 ],
        [ 0.64080535,  0.42341932],
        [ 2.25389396,  0.13327865],
        [ 1.96544702,  0.16093197]])
-        np.testing.assert_allclose(reg.chow.regi,chow_r,4)
+        np.testing.assert_allclose(reg.chow.regi,chow_r,RTOL)
         chow_j = 25.367913028011799
-        np.testing.assert_allclose(reg.chow.joint[0],chow_j,4)
+        np.testing.assert_allclose(reg.chow.joint[0],chow_j,RTOL)
 
     def test_model2(self):
         reg = ML_Error_Regimes(self.y,self.x,self.regimes,w=self.w,name_y=self.y_name,name_x=self.x_names,\
@@ -106,25 +107,25 @@ class TestMLError(unittest.TestCase):
        [ -0.18803509],
        [  0.68956598],
        [  0.75599089]])
-        np.testing.assert_allclose(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         vm = np.array([ 40.60994599,  -7.25413138,  -0.16605501,   0.48961884,
          0.        ,   0.        ,   0.        ,   0.        ,
          0.        ,   0.        ])
-        np.testing.assert_allclose(reg.vm[0],vm,4)
+        np.testing.assert_allclose(reg.vm[0],vm,RTOL)
         u = np.array([ 31.97771505])
-        np.testing.assert_allclose(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         predy = np.array([ 15.02228495])
-        np.testing.assert_allclose(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         e = np.array([ 33.83065421])
-        np.testing.assert_allclose(reg.e_filtered[0],e,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
         chow_r = np.array([[  6.88023639,   0.0087154 ],
        [  0.90512612,   0.34141092],
        [  0.75996258,   0.38334023],
        [  0.56882946,   0.45072443],
        [ 12.18358581,   0.00048212]])
-        np.testing.assert_allclose(reg.chow.regi,chow_r,4)
+        np.testing.assert_allclose(reg.chow.regi,chow_r,RTOL)
         chow_j = 26.673798071789673
-        np.testing.assert_allclose(reg.chow.joint[0],chow_j,4)
+        np.testing.assert_allclose(reg.chow.joint[0],chow_j,RTOL)
         #Artficial:
         model = ML_Error_Regimes(self.y_a, self.x_a, self.regi_a, w=self.w_a, regime_err_sep=True)
         model1 = ML_Error(self.y_a[0:(self.n2)].reshape((self.n2),1), self.x_a[0:(self.n2)], w=self.w_a1)

--- a/pysal/spreg/tests/test_ml_error_regimes.py
+++ b/pysal/spreg/tests/test_ml_error_regimes.py
@@ -50,48 +50,48 @@ class TestMLError(unittest.TestCase):
        [ -0.23710892],
        [  0.80581127],
        [  0.61770744]])
-        np.allclose(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,4)
         u = np.array([ 30.46599009])
-        np.allclose(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,4)
         predy = np.array([ 16.53400991])
-        np.allclose(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,4)
         n = 211
-        np.allclose(reg.n,n,4)
+        np.testing.assert_allclose(reg.n,n,4)
         k = 8
-        np.allclose(reg.k,k,4)
+        np.testing.assert_allclose(reg.k,k,4)
         y = np.array([ 47.])
-        np.allclose(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,4)
         x = np.array([   1.  ,    4.  ,  148.  ,   11.25,    0.  ,    0.  ,    0.  ,    0.  ])
-        np.allclose(reg.x[0],x,4)
+        np.testing.assert_allclose(reg.x[0],x,4)
         e = np.array([ 34.69181334])
-        np.allclose(reg.e_filtered[0],e,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e,4)
         my = 44.307180094786695
-        np.allclose(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         sy = 23.606076835380495
-        np.allclose(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy)
         vm = np.array([ 58.50551173,   2.42952002,   0.00721525,   0.06391736,
         80.59249161,   3.1610047 ,   0.0119782 ,   0.0499432 ,   0.00502785])
-        np.allclose(reg.vm.diagonal(),vm,4)
+        np.testing.assert_allclose(reg.vm.diagonal(),vm,4)
         sig2 = np.array([[ 209.60639741]])
-        np.allclose(reg.sig2,sig2,4)
+        np.testing.assert_allclose(reg.sig2,sig2,4)
         pr2 = 0.43600837301477025
-        np.allclose(reg.pr2,pr2)
+        np.testing.assert_allclose(reg.pr2,pr2)
         std_err = np.array([ 7.64888957,  1.55869177,  0.08494262,  0.25281882,  8.9773321 ,
         1.77792146,  0.10944497,  0.22347975,  0.07090735])
-        np.allclose(reg.std_err,std_err,4)
+        np.testing.assert_allclose(reg.std_err,std_err,4)
         logll = -870.3331059537576
-        np.allclose(reg.logll,logll,4)
+        np.testing.assert_allclose(reg.logll,logll,4)
         aic = 1756.6662119075154
-        np.allclose(reg.aic,aic,4)
+        np.testing.assert_allclose(reg.aic,aic,4)
         schwarz = 1783.481076975324
-        np.allclose(reg.schwarz,schwarz,4)
+        np.testing.assert_allclose(reg.schwarz,schwarz,4)
         chow_r = np.array([[ 8.40437046,  0.0037432 ],
        [ 0.64080535,  0.42341932],
        [ 2.25389396,  0.13327865],
        [ 1.96544702,  0.16093197]])
-        np.allclose(reg.chow.regi,chow_r,4)
+        np.testing.assert_allclose(reg.chow.regi,chow_r,4)
         chow_j = 25.367913028011799
-        np.allclose(reg.chow.joint[0],chow_j,4)
+        np.testing.assert_allclose(reg.chow.joint[0],chow_j,4)
 
     def test_model2(self):
         reg = ML_Error_Regimes(self.y,self.x,self.regimes,w=self.w,name_y=self.y_name,name_x=self.x_names,\
@@ -106,33 +106,33 @@ class TestMLError(unittest.TestCase):
        [ -0.18803509],
        [  0.68956598],
        [  0.75599089]])
-        np.allclose(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,4)
         vm = np.array([ 40.60994599,  -7.25413138,  -0.16605501,   0.48961884,
          0.        ,   0.        ,   0.        ,   0.        ,
          0.        ,   0.        ])
-        np.allclose(reg.vm[0],vm,4)
+        np.testing.assert_allclose(reg.vm[0],vm,4)
         u = np.array([ 31.97771505])
-        np.allclose(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,4)
         predy = np.array([ 15.02228495])
-        np.allclose(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,4)
         e = np.array([ 33.83065421])
-        np.allclose(reg.e_filtered[0],e,4)
+        np.testing.assert_allclose(reg.e_filtered[0],e,4)
         chow_r = np.array([[  6.88023639,   0.0087154 ],
        [  0.90512612,   0.34141092],
        [  0.75996258,   0.38334023],
        [  0.56882946,   0.45072443],
        [ 12.18358581,   0.00048212]])
-        np.allclose(reg.chow.regi,chow_r,4)
+        np.testing.assert_allclose(reg.chow.regi,chow_r,4)
         chow_j = 26.673798071789673
-        np.allclose(reg.chow.joint[0],chow_j,4)
+        np.testing.assert_allclose(reg.chow.joint[0],chow_j,4)
         #Artficial:
         model = ML_Error_Regimes(self.y_a, self.x_a, self.regi_a, w=self.w_a, regime_err_sep=True)
         model1 = ML_Error(self.y_a[0:(self.n2)].reshape((self.n2),1), self.x_a[0:(self.n2)], w=self.w_a1)
         model2 = ML_Error(self.y_a[(self.n2):].reshape((self.n2),1), self.x_a[(self.n2):], w=self.w_a1)
         tbetas = np.vstack((model1.betas, model2.betas))
-        np.allclose(model.betas,tbetas)
+        np.testing.assert_allclose(model.betas,tbetas)
         vm = np.hstack((model1.vm.diagonal(),model2.vm.diagonal()))
-        np.allclose(model.vm.diagonal(), vm, 4)
+        np.testing.assert_allclose(model.vm.diagonal(), vm, 4)
 
 if __name__ == '__main__':
     unittest.main()

--- a/pysal/spreg/tests/test_ml_lag.py
+++ b/pysal/spreg/tests/test_ml_lag.py
@@ -4,6 +4,7 @@ import scipy
 import numpy as np
 from pysal.spreg.ml_lag import ML_Lag
 from pysal.spreg import utils
+from pysal.common import RTOL
 
 @unittest.skipIf(int(scipy.__version__.split(".")[1]) < 11,
         "Max Likelihood requires SciPy version 11 or newer.")
@@ -30,39 +31,39 @@ class TestMLError(unittest.TestCase):
        [-0.20103955],
        [ 0.65462382],
        [ 0.62351143]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([ 47.51218398])
-        np.testing.assert_array_almost_equal(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         predy = np.array([-0.51218398])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 211
-        self.assertAlmostEqual(reg.n,n,4)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 5
-        self.assertAlmostEqual(reg.k,k,4)
+        np.testing.assert_allclose(reg.k,k,RTOL)
         y = np.array([ 47.])
-        np.testing.assert_array_almost_equal(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([   1.  ,    4.  ,  148.  ,   11.25])
-        np.testing.assert_array_almost_equal(reg.x[0],x,4)
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
         e = np.array([ 41.99251608])
-        np.testing.assert_array_almost_equal(reg.e_pred[0],e,4)
+        np.testing.assert_allclose(reg.e_pred[0],e,RTOL)
         my = 44.307180094786695
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         sy = 23.606076835380495
-        self.assertAlmostEqual(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy)
         vm = np.array([ 28.57288755,   1.42341656,   0.00288068,   0.02956392,   0.00332139])
-        np.testing.assert_array_almost_equal(reg.vm.diagonal(),vm,4)
+        np.testing.assert_allclose(reg.vm.diagonal(),vm,RTOL)
         sig2 = 216.27525647243797
-        self.assertAlmostEqual(reg.sig2,sig2,4)
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
         pr2 = 0.6133020721559487
-        self.assertAlmostEqual(reg.pr2,pr2)
+        np.testing.assert_allclose(reg.pr2,pr2)
         std_err = np.array([ 5.34536131,  1.19307022,  0.05367198,  0.17194162,  0.05763147])
-        np.testing.assert_array_almost_equal(reg.std_err,std_err,4)
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
         logll = -875.92771143484833
-        self.assertAlmostEqual(reg.logll,logll,4)
+        np.testing.assert_allclose(reg.logll,logll,RTOL)
         aic = 1761.8554228696967
-        self.assertAlmostEqual(reg.aic,aic,4)
+        np.testing.assert_allclose(reg.aic,aic,RTOL)
         schwarz = 1778.614713537077
-        self.assertAlmostEqual(reg.schwarz,schwarz,4)
+        np.testing.assert_allclose(reg.schwarz,schwarz,RTOL)
 
 if __name__ == '__main__':
     unittest.main()

--- a/pysal/spreg/tests/test_ml_lag_regimes.py
+++ b/pysal/spreg/tests/test_ml_lag_regimes.py
@@ -5,6 +5,7 @@ import numpy as np
 from pysal.spreg.ml_lag_regimes import ML_Lag_Regimes
 from pysal.spreg.ml_lag import ML_Lag
 from pysal.spreg import utils
+from pysal.common import RTOL
 
 @unittest.skipIf(int(scipy.__version__.split(".")[1]) < 11,
          "Max Likelihood requires SciPy version 11 or newer.")
@@ -36,49 +37,49 @@ class TestMLError(unittest.TestCase):
        [ -0.17021393],
        [  0.81941371],
        [  0.53850323]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         u = np.array([ 32.73718478])
-        np.testing.assert_array_almost_equal(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         predy = np.array([ 14.26281522])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 211
-        self.assertAlmostEqual(reg.n,n,4)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 9
-        self.assertAlmostEqual(reg.k,k,4)
+        np.testing.assert_allclose(reg.k,k,RTOL)
         y = np.array([ 47.])
-        np.testing.assert_array_almost_equal(reg.y[0],y,4)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([[   1.  ,    4.  ,  148.  ,   11.25,    0.  ,    0.  ,    0.  ,
            0.  ]])
-        np.testing.assert_array_almost_equal(reg.x[0].toarray(),x,4)
+        np.testing.assert_allclose(reg.x[0].toarray(),x,RTOL)
         e = np.array([ 29.45407124])
-        np.testing.assert_array_almost_equal(reg.e_pred[0],e,4)
+        np.testing.assert_allclose(reg.e_pred[0],e,RTOL)
         my = 44.307180094786695
-        self.assertAlmostEqual(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my)
         sy = 23.606076835380495
-        self.assertAlmostEqual(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy)
         vm = np.array([ 47.42000914,   2.39526578,   0.00506895,   0.06480022,
         69.67653371,   3.20661492,   0.01156766,   0.04862014,   0.00400775])
-        np.testing.assert_array_almost_equal(reg.vm.diagonal(),vm,4)
+        np.testing.assert_allclose(reg.vm.diagonal(),vm,RTOL)
         sig2 = 200.04433357145007
-        self.assertAlmostEqual(reg.sig2,sig2,4)
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
         pr2 = 0.6404460298085746
-        self.assertAlmostEqual(reg.pr2,pr2)
+        np.testing.assert_allclose(reg.pr2,pr2)
         std_err = np.array([ 6.88621878,  1.54766462,  0.07119654,  0.25455888,  8.34724707,
         1.79070235,  0.10755305,  0.22049975,  0.0633068 ])
-        np.testing.assert_array_almost_equal(reg.std_err,std_err,4)
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
         logll = -864.98505596489736
-        self.assertAlmostEqual(reg.logll,logll,4)
+        np.testing.assert_allclose(reg.logll,logll,RTOL)
         aic = 1747.9701119297947
-        self.assertAlmostEqual(reg.aic,aic,4)
+        np.testing.assert_allclose(reg.aic,aic,RTOL)
         schwarz = 1778.1368351310794
-        self.assertAlmostEqual(reg.schwarz,schwarz,4)
+        np.testing.assert_allclose(reg.schwarz,schwarz,RTOL)
         chow_r = np.array([[ 1.00180776,  0.31687348],
        [ 0.05904944,  0.8080047 ],
        [ 1.16987812,  0.27942629],
        [ 1.95931177,  0.16158694]])
-        np.testing.assert_array_almost_equal(reg.chow.regi,chow_r,4)
+        np.testing.assert_allclose(reg.chow.regi,chow_r,RTOL)
         chow_j = 21.648337464039283
-        self.assertAlmostEqual(reg.chow.joint[0],chow_j,4)
+        np.testing.assert_allclose(reg.chow.joint[0],chow_j,RTOL)
 
     def test_model2(self):
         reg = ML_Lag_Regimes(self.y,self.x,self.regimes,w=self.w,name_y=self.y_name,name_x=self.x_names,\
@@ -93,25 +94,25 @@ class TestMLError(unittest.TestCase):
        [-0.18207394],
        [ 0.71129227],
        [ 0.66753263]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,4)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         vm = np.array([ 55.3593679 ,  -7.22927797,  -0.19487326,   0.6030953 ,
         -0.52249569,   0.        ,   0.        ,   0.        ,
          0.        ,   0.        ])
-        np.testing.assert_array_almost_equal(reg.vm[0],vm,4)
+        np.testing.assert_allclose(reg.vm[0],vm,RTOL)
         u = np.array([ 34.03630518])
-        np.testing.assert_array_almost_equal(reg.u[0],u,4)
+        np.testing.assert_allclose(reg.u[0],u,RTOL)
         predy = np.array([ 12.96369482])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,4)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         e = np.array([ 32.46466912])
-        np.testing.assert_array_almost_equal(reg.e_pred[0],e,4)
+        np.testing.assert_allclose(reg.e_pred[0],e,RTOL)
         chow_r = np.array([[  0.15654726,   0.69235548],
        [  0.43533847,   0.509381  ],
        [  0.60552514,   0.43647766],
        [  0.59214981,   0.441589  ],
        [ 11.69437282,   0.00062689]])
-        np.testing.assert_array_almost_equal(reg.chow.regi,chow_r,4)
+        np.testing.assert_allclose(reg.chow.regi,chow_r,RTOL)
         chow_j = 21.978012275873063
-        self.assertAlmostEqual(reg.chow.joint[0],chow_j,4)
+        np.testing.assert_allclose(reg.chow.joint[0],chow_j,RTOL)
 
 if __name__ == '__main__':
     unittest.main()

--- a/pysal/spreg/tests/test_ols.py
+++ b/pysal/spreg/tests/test_ols.py
@@ -1,8 +1,9 @@
 import unittest
 import numpy as np
 import pysal
-from pysal.spreg import utils
 import pysal.spreg as EC
+from pysal.spreg import utils
+from pysal.common import RTOL
 
 PEGP = pysal.examples.get_path
 
@@ -20,106 +21,107 @@ class TestBaseOLS(unittest.TestCase):
     def test_ols(self):
         self.X = np.hstack((np.ones(self.y.shape),self.X))
         ols = EC.ols.BaseOLS(self.y,self.X)
-        np.testing.assert_array_almost_equal(ols.betas, np.array([[
+        np.testing.assert_allclose(ols.betas, np.array([[
             46.42818268], [  0.62898397], [ -0.48488854]]))
         vm = np.array([[  1.74022453e+02,  -6.52060364e+00,  -2.15109867e+00],
            [ -6.52060364e+00,   2.87200008e-01,   6.80956787e-02],
            [ -2.15109867e+00,   6.80956787e-02,   3.33693910e-02]])
-        np.testing.assert_array_almost_equal(ols.vm, vm,6)
+        np.testing.assert_allclose(ols.vm, vm,RTOL)
 
     def test_ols_white1(self):
         self.X = np.hstack((np.ones(self.y.shape),self.X))
         ols = EC.ols.BaseOLS(self.y,self.X,robust='white', sig2n_k=True)
-        np.testing.assert_array_almost_equal(ols.betas, np.array([[
+        np.testing.assert_allclose(ols.betas, np.array([[
             46.42818268], [  0.62898397], [ -0.48488854]]))
         vm = np.array([[  2.05819450e+02,  -6.83139266e+00,  -2.64825846e+00],
        [ -6.83139266e+00,   2.58480813e-01,   8.07733167e-02],
        [ -2.64825846e+00,   8.07733167e-02,   3.75817181e-02]])
-        np.testing.assert_array_almost_equal(ols.vm, vm,6)
+        np.testing.assert_allclose(ols.vm, vm,RTOL)
 
     def test_ols_white2(self):
         self.X = np.hstack((np.ones(self.y.shape),self.X))
         ols = EC.ols.BaseOLS(self.y,self.X,robust='white', sig2n_k=False)
-        np.testing.assert_array_almost_equal(ols.betas, np.array([[
+        np.testing.assert_allclose(ols.betas, np.array([[
             46.42818268], [  0.62898397], [ -0.48488854]]))
         vm = np.array([[  1.93218259e+02,  -6.41314413e+00,  -2.48612018e+00],
        [ -6.41314413e+00,   2.42655457e-01,   7.58280116e-02],
        [ -2.48612018e+00,   7.58280116e-02,   3.52807966e-02]])
-        np.testing.assert_array_almost_equal(ols.vm, vm,6)
+        np.testing.assert_allclose(ols.vm, vm,RTOL)
 
     def test_OLS(self):
         ols = EC.OLS(self.y, self.X, self.w, spat_diag=True, moran=True, \
                 white_test=True, name_y='home value', name_x=['income','crime'], \
                 name_ds='columbus')
         
-        np.testing.assert_array_almost_equal(ols.aic, \
-                408.73548964604873 ,7)
-        np.testing.assert_array_almost_equal(ols.ar2, \
-                0.32123239427957662 ,7)
-        np.testing.assert_array_almost_equal(ols.betas, \
+        np.testing.assert_allclose(ols.aic, \
+                408.73548964604873 ,RTOL)
+        np.testing.assert_allclose(ols.ar2, \
+                0.32123239427957662 ,RTOL)
+        np.testing.assert_allclose(ols.betas, \
                 np.array([[ 46.42818268], [  0.62898397], \
-                    [ -0.48488854]]), 7) 
+                    [ -0.48488854]]),RTOL) 
         bp = np.array([2, 5.7667905131212587, 0.05594449410070558])
         ols_bp = np.array([ols.breusch_pagan['df'], ols.breusch_pagan['bp'], ols.breusch_pagan['pvalue']])
-        np.testing.assert_array_almost_equal(bp, ols_bp, 7)
-        np.testing.assert_array_almost_equal(ols.f_stat, \
-            (12.358198885356581, 5.0636903313953024e-05), 7)
+        np.testing.assert_allclose(bp, ols_bp,RTOL)
+        np.testing.assert_allclose(ols.f_stat, \
+            (12.358198885356581, 5.0636903313953024e-05),RTOL)
         jb = np.array([2, 39.706155069114878, 2.387360356860208e-09])
         ols_jb = np.array([ols.jarque_bera['df'], ols.jarque_bera['jb'], ols.jarque_bera['pvalue']])
-        np.testing.assert_array_almost_equal(ols_jb,jb, 7)
+        np.testing.assert_allclose(ols_jb,jb,RTOL)
         white = np.array([5, 2.90606708, 0.71446484])
         ols_white = np.array([ols.white['df'], ols.white['wh'], ols.white['pvalue']])
-        np.testing.assert_array_almost_equal(ols_white,white, 7)
+        np.testing.assert_allclose(ols_white,white,RTOL)
         np.testing.assert_equal(ols.k,  3)
         kb = {'df': 2, 'kb': 2.2700383871478675, 'pvalue': 0.32141595215434604}
         for key in kb:
-            self.assertAlmostEqual(ols.koenker_bassett[key],  kb[key], 7)
-        np.testing.assert_array_almost_equal(ols.lm_error, \
-            (4.1508117035117893, 0.041614570655392716),7)
-        np.testing.assert_array_almost_equal(ols.lm_lag, \
-            (0.98279980617162233, 0.32150855529063727), 7)
-        np.testing.assert_array_almost_equal(ols.lm_sarma, \
-                (4.3222725729143736, 0.11519415308749938), 7)
-        np.testing.assert_array_almost_equal(ols.logll, \
-                -201.3677448230244 ,7)
-        np.testing.assert_array_almost_equal(ols.mean_y, \
-            38.436224469387746,7)
-        np.testing.assert_array_almost_equal(ols.moran_res[0], \
-            0.20373540938,7)
-        np.testing.assert_array_almost_equal(ols.moran_res[1], \
-            2.59180452208,7)
-        np.testing.assert_array_almost_equal(ols.moran_res[2], \
-            0.00954740031251,7)
-        np.testing.assert_array_almost_equal(ols.mulColli, \
-            12.537554873824675 ,7)
-        np.testing.assert_equal(ols.n,  49)
-        np.testing.assert_equal(ols.name_ds,  'columbus')
+            np.testing.assert_allclose(ols.koenker_bassett[key],  kb[key],RTOL)
+        np.testing.assert_allclose(ols.lm_error, \
+            (4.1508117035117893, 0.041614570655392716),RTOL)
+        np.testing.assert_allclose(ols.lm_lag, \
+            (0.98279980617162233, 0.32150855529063727),RTOL)
+        np.testing.assert_allclose(ols.lm_sarma, \
+                (4.3222725729143736, 0.11519415308749938),RTOL)
+        np.testing.assert_allclose(ols.logll, \
+                -201.3677448230244 ,RTOL)
+        np.testing.assert_allclose(ols.mean_y, \
+            38.436224469387746,RTOL)
+        np.testing.assert_allclose(ols.moran_res[0], \
+            0.20373540938,RTOL)
+        np.testing.assert_allclose(ols.moran_res[1], \
+            2.59180452208,RTOL)
+        np.testing.assert_allclose(ols.moran_res[2], \
+            0.00954740031251,RTOL)
+        np.testing.assert_allclose(ols.mulColli, \
+            12.537554873824675 ,RTOL)
+        np.testing.assert_allclose(ols.n,  49, RTOL)
+        np.testing.assert_string_equal(ols.name_ds,  'columbus')
         np.testing.assert_equal(ols.name_gwk,  None)
-        np.testing.assert_equal(ols.name_w,  'unknown')
-        np.testing.assert_equal(ols.name_x,  ['CONSTANT', 'income', 'crime'])
-        np.testing.assert_equal(ols.name_y,  'home value')
-        np.testing.assert_array_almost_equal(ols.predy[3], np.array([
-            33.53969014]),7)
-        np.testing.assert_array_almost_equal(ols.r2, \
-                0.34951437785126105 ,7)
-        np.testing.assert_array_almost_equal(ols.rlm_error, \
-                (3.3394727667427513, 0.067636278225568919),7)
-        np.testing.assert_array_almost_equal(ols.rlm_lag, \
-            (0.17146086940258459, 0.67881673703455414), 7)
+        np.testing.assert_string_equal(ols.name_w,  'unknown')
+        np.testing.assert_string_equal(ols.name_x, ['CONSTANT', 'income','crime'])
+        np.testing.assert_(ols.name_x[i],  name)
+        np.testing.assert_string_equal(ols.name_y,  'home value')
+        np.testing.assert_allclose(ols.predy[3], np.array([
+            33.53969014]),RTOL)
+        np.testing.assert_allclose(ols.r2, \
+                0.34951437785126105 ,RTOL)
+        np.testing.assert_allclose(ols.rlm_error, \
+                (3.3394727667427513, 0.067636278225568919),RTOL)
+        np.testing.assert_allclose(ols.rlm_lag, \
+            (0.17146086940258459, 0.67881673703455414),RTOL)
         np.testing.assert_equal(ols.robust,  'unadjusted')
-        np.testing.assert_array_almost_equal(ols.schwarz, \
+        np.testing.assert_allclose(ols.schwarz, \
             414.41095054038061,7 )
-        np.testing.assert_array_almost_equal(ols.sig2, \
+        np.testing.assert_allclose(ols.sig2, \
             231.4568494392652,7 )
-        np.testing.assert_array_almost_equal(ols.sig2ML, \
+        np.testing.assert_allclose(ols.sig2ML, \
             217.28602192257551,7 )
-        np.testing.assert_array_almost_equal(ols.sig2n, \
-                217.28602192257551, 7)
+        np.testing.assert_allclose(ols.sig2n, \
+                217.28602192257551,RTOL)
  
-        np.testing.assert_array_almost_equal(ols.t_stat[2][0], \
-                -2.65440864272,7)
-        np.testing.assert_array_almost_equal(ols.t_stat[2][1], \
-                0.0108745049098,7)
+        np.testing.assert_allclose(ols.t_stat[2][0], \
+                -2.65440864272,RTOL)
+        np.testing.assert_allclose(ols.t_stat[2][1], \
+                0.0108745049098,RTOL)
 
 if __name__ == '__main__':
     unittest.main()

--- a/pysal/spreg/tests/test_ols.py
+++ b/pysal/spreg/tests/test_ols.py
@@ -97,8 +97,7 @@ class TestBaseOLS(unittest.TestCase):
         np.testing.assert_string_equal(ols.name_ds,  'columbus')
         np.testing.assert_equal(ols.name_gwk,  None)
         np.testing.assert_string_equal(ols.name_w,  'unknown')
-        np.testing.assert_string_equal(ols.name_x, ['CONSTANT', 'income','crime'])
-        np.testing.assert_(ols.name_x[i],  name)
+        np.testing.assert_equal(ols.name_x, ['CONSTANT', 'income','crime'])
         np.testing.assert_string_equal(ols.name_y,  'home value')
         np.testing.assert_allclose(ols.predy[3], np.array([
             33.53969014]),RTOL)

--- a/pysal/spreg/tests/test_ols_regimes.py
+++ b/pysal/spreg/tests/test_ols_regimes.py
@@ -3,6 +3,7 @@ import numpy as np
 import pysal
 from pysal.spreg.ols import OLS
 from pysal.spreg.ols_regimes import OLS_Regimes
+from pysal.common import RTOL
 
 PEGP = pysal.examples.get_path
 
@@ -22,21 +23,21 @@ class TestOLS_regimes(unittest.TestCase):
         start_suppress = np.get_printoptions()['suppress']
         np.set_printoptions(suppress=True)    
         ols = OLS_Regimes(self.y, self.x, self.regimes, w=self.w, regime_err_sep=False, constant_regi='many', nonspat_diag=False, spat_diag=True, name_y=self.y_var, name_x=self.x_var, name_ds='columbus', name_regimes=self.r_var, name_w='columbus.gal')        
-        #np.testing.assert_array_almost_equal(ols.aic, 408.73548964604873 ,7)
-        np.testing.assert_array_almost_equal(ols.ar2,0.50761700679873101 ,7)
-        np.testing.assert_array_almost_equal(ols.betas,np.array([[ 68.78670869],\
+        #np.testing.assert_allclose(ols.aic, 408.73548964604873 ,RTOL)
+        np.testing.assert_allclose(ols.ar2,0.50761700679873101 ,RTOL)
+        np.testing.assert_allclose(ols.betas,np.array([[ 68.78670869],\
                 [ -1.9864167 ],[ -0.10887962],[ 67.73579559],[ -1.36937552],[ -0.31792362]])) 
         vm = np.array([ 48.81339213,  -2.14959579,  -0.19968157,   0.        ,
          0.        ,   0.        ])
-        np.testing.assert_array_almost_equal(ols.vm[0], vm, 6)
-        np.testing.assert_array_almost_equal(ols.lm_error, \
-            (5.92970357,  0.01488775),7)
-        np.testing.assert_array_almost_equal(ols.lm_lag, \
-            (8.78315751,  0.00304024), 7)
-        np.testing.assert_array_almost_equal(ols.lm_sarma, \
-                (8.89955982,  0.01168114), 7)
-        np.testing.assert_array_almost_equal(ols.mean_y, \
-            35.1288238979591,7)
+        np.testing.assert_allclose(ols.vm[0], vm,RTOL)
+        np.testing.assert_allclose(ols.lm_error, \
+            (5.92970357,  0.01488775),RTOL)
+        np.testing.assert_allclose(ols.lm_lag, \
+            (8.78315751,  0.00304024),RTOL)
+        np.testing.assert_allclose(ols.lm_sarma, \
+                (8.89955982,  0.01168114),RTOL)
+        np.testing.assert_allclose(ols.mean_y, \
+            35.1288238979591,RTOL)
         np.testing.assert_equal(ols.k, 6)
         np.testing.assert_equal(ols.kf, 0)
         np.testing.assert_equal(ols.kr, 3)
@@ -47,23 +48,23 @@ class TestOLS_regimes(unittest.TestCase):
         np.testing.assert_equal(ols.name_w,  'columbus.gal')
         np.testing.assert_equal(ols.name_x,  ['0_CONSTANT', '0_INC', '0_HOVAL', '1_CONSTANT', '1_INC', '1_HOVAL'])
         np.testing.assert_equal(ols.name_y,  'CRIME')
-        np.testing.assert_array_almost_equal(ols.predy[3], np.array([
-            51.05003696]),7)
-        np.testing.assert_array_almost_equal(ols.r2, \
-                0.55890690192386316 ,7)
-        np.testing.assert_array_almost_equal(ols.rlm_error, \
-                (0.11640231,  0.73296972),7)
-        np.testing.assert_array_almost_equal(ols.rlm_lag, \
-            (2.96985625,  0.08482939), 7)
+        np.testing.assert_allclose(ols.predy[3], np.array([
+            51.05003696]),RTOL)
+        np.testing.assert_allclose(ols.r2, \
+                0.55890690192386316 ,RTOL)
+        np.testing.assert_allclose(ols.rlm_error, \
+                (0.11640231,  0.73296972),RTOL)
+        np.testing.assert_allclose(ols.rlm_lag, \
+            (2.96985625,  0.08482939),RTOL)
         np.testing.assert_equal(ols.robust,  'unadjusted')
-        np.testing.assert_array_almost_equal(ols.sig2, \
-            137.84897351821013,7 )
-        np.testing.assert_array_almost_equal(ols.sig2n, \
-                120.96950737312316, 7)
-        np.testing.assert_array_almost_equal(ols.t_stat[2][0], \
-                -0.43342216706091791,7)
-        np.testing.assert_array_almost_equal(ols.t_stat[2][1], \
-                0.66687472578594531,7)
+        np.testing.assert_allclose(ols.sig2, \
+            137.84897351821013,RTOL)
+        np.testing.assert_allclose(ols.sig2n, \
+                120.96950737312316,RTOL)
+        np.testing.assert_allclose(ols.t_stat[2][0], \
+                -0.43342216706091791,RTOL)
+        np.testing.assert_allclose(ols.t_stat[2][1], \
+                0.66687472578594531,RTOL)
         np.set_printoptions(suppress=start_suppress)        
     """
     def test_OLS_regi(self):
@@ -77,49 +78,50 @@ class TestOLS_regimes(unittest.TestCase):
         model1 = OLS(y[0:(n/2)].reshape((n/2),1), x1[0:(n/2)], sig2n_k=False)
         model2 = OLS(y[(n/2):n].reshape((n/2),1), x1[(n/2):n], sig2n_k=False)
         tbetas = np.vstack((model1.betas, model2.betas))
-        np.testing.assert_array_almost_equal(model.betas,tbetas)
+        np.testing.assert_allclose(model.betas,tbetas,RTOL)
         vm = np.hstack((model1.vm.diagonal(),model2.vm.diagonal()))
-        np.testing.assert_array_almost_equal(model.vm.diagonal(), vm, 6)
+        np.testing.assert_allclose(model.vm.diagonal(), vm,RTOL)
         #Columbus:  
         reg = OLS_Regimes(self.y, self.x, self.regimes, w=self.w, constant_regi='many', nonspat_diag=True, spat_diag=True, name_y=self.y_var, name_x=self.x_var, name_ds='columbus', name_regimes=self.r_var, name_w='columbus.gal', regime_err_sep=True)        
-        np.testing.assert_array_almost_equal(reg.multi[0].aic, 192.96044303402897 ,7)
+        np.testing.assert_allclose(reg.multi[0].aic, 192.96044303402897 ,RTOL)
         tbetas = np.array([[ 68.78670869],
        [ -1.9864167 ],
        [ -0.10887962],
        [ 67.73579559],
        [ -1.36937552],
        [ -0.31792362]])
-        np.testing.assert_array_almost_equal(tbetas, reg.betas)
+        np.testing.assert_allclose(tbetas, reg.betas,RTOL)
         vm = np.array([ 41.68828023,  -1.83582717,  -0.17053478,   0.        ,
          0.        ,   0.        ])
-        np.testing.assert_array_almost_equal(reg.vm[0], vm, 6)
+        np.testing.assert_allclose(reg.vm[0], vm,RTOL)
         u_3 = np.array([[ 0.31781838],
        [-5.6905584 ],
        [-6.8819715 ]])
-        np.testing.assert_array_almost_equal(reg.u[0:3], u_3, 7)
+        np.testing.assert_allclose(reg.u[0:3], u_3,RTOL)
         predy_3 = np.array([[ 15.40816162],
        [ 24.4923124 ],
        [ 37.5087525 ]])
-        np.testing.assert_array_almost_equal(reg.predy[0:3], predy_3, 7)
+        np.testing.assert_allclose(reg.predy[0:3], predy_3,RTOL)
         chow_regi = np.array([[ 0.01002733,  0.92023592],
        [ 0.46017009,  0.49754449],
        [ 0.60732697,  0.43579603]])
-        np.testing.assert_array_almost_equal(reg.chow.regi, chow_regi, 7)
-        self.assertAlmostEqual(reg.chow.joint[0], 0.67787986791767096, 7)
+        np.testing.assert_allclose(reg.chow.regi, chow_regi,RTOL)
+        np.testing.assert_allclose(reg.chow.joint[0], 0.67787986791767096,RTOL)
     """
     def test_OLS_fixed(self):
         start_suppress = np.get_printoptions()['suppress']
         np.set_printoptions(suppress=True)    
         ols = OLS_Regimes(self.y, self.x, self.regimes, w=self.w, cols2regi=[False,True], regime_err_sep=True, constant_regi='one', nonspat_diag=False, spat_diag=True, name_y=self.y_var, name_x=self.x_var, name_ds='columbus', name_regimes=self.r_var, name_w='columbus.gal')        
-        np.testing.assert_array_almost_equal(ols.betas,np.array([[ -0.24385565], [ -0.26335026], [ 68.89701137], [ -1.67389685]])) 
+        np.testing.assert_allclose(ols.betas,np.array([[ -0.24385565], [ \
+        -0.26335026], [ 68.89701137], [ -1.67389685]]), RTOL) 
         vm = np.array([ 0.02354271,  0.01246677,  0.00424658, -0.04921356])
-        np.testing.assert_array_almost_equal(ols.vm[0], vm, 6)
-        np.testing.assert_array_almost_equal(ols.lm_error, \
-            (5.62668744,  0.01768903),7)
-        np.testing.assert_array_almost_equal(ols.lm_lag, \
-            (9.43264957,  0.00213156), 7)
-        np.testing.assert_array_almost_equal(ols.mean_y, \
-            35.12882389795919,7)
+        np.testing.assert_allclose(ols.vm[0], vm,RTOL)
+        np.testing.assert_allclose(ols.lm_error, \
+            (5.62668744,  0.01768903),RTOL)
+        np.testing.assert_allclose(ols.lm_lag, \
+            (9.43264957,  0.00213156),RTOL)
+        np.testing.assert_allclose(ols.mean_y, \
+            35.12882389795919,RTOL)
         np.testing.assert_equal(ols.kf, 2)
         np.testing.assert_equal(ols.kr, 1)
         np.testing.assert_equal(ols.n, 49)
@@ -129,15 +131,15 @@ class TestOLS_regimes(unittest.TestCase):
         np.testing.assert_equal(ols.name_w,  'columbus.gal')
         np.testing.assert_equal(ols.name_x,  ['0_HOVAL', '1_HOVAL', '_Global_CONSTANT', '_Global_INC'])
         np.testing.assert_equal(ols.name_y,  'CRIME')
-        np.testing.assert_array_almost_equal(ols.predy[3], np.array([
-            52.65974636]),7)
-        np.testing.assert_array_almost_equal(ols.r2, \
-                0.5525561183786056 ,7)
+        np.testing.assert_allclose(ols.predy[3], np.array([
+            52.65974636]),RTOL)
+        np.testing.assert_allclose(ols.r2, \
+                0.5525561183786056 ,RTOL)
         np.testing.assert_equal(ols.robust,  'unadjusted')
-        np.testing.assert_array_almost_equal(ols.t_stat[2][0], \
-                13.848705206463748,7)
-        np.testing.assert_array_almost_equal(ols.t_stat[2][1], \
-                7.776650625274256e-18,7)
+        np.testing.assert_allclose(ols.t_stat[2][0], \
+                13.848705206463748,RTOL)
+        np.testing.assert_allclose(ols.t_stat[2][1], \
+                7.776650625274256e-18,RTOL)
         np.set_printoptions(suppress=start_suppress)
         
 if __name__ == '__main__':

--- a/pysal/spreg/tests/test_ols_sparse.py
+++ b/pysal/spreg/tests/test_ols_sparse.py
@@ -3,6 +3,7 @@ import numpy as np
 import pysal
 import pysal.spreg as EC
 from scipy import sparse
+from pysal.common import RTOL
 
 PEGP = pysal.examples.get_path
 
@@ -21,12 +22,12 @@ class TestBaseOLS(unittest.TestCase):
         self.X = np.hstack((np.ones(self.y.shape),self.X))
         self.X = sparse.csr_matrix(self.X)
         ols = EC.ols.BaseOLS(self.y,self.X)
-        np.testing.assert_array_almost_equal(ols.betas, np.array([[
+        np.testing.assert_allclose(ols.betas, np.array([[
             46.42818268], [  0.62898397], [ -0.48488854]]))
         vm = np.array([[  1.74022453e+02,  -6.52060364e+00,  -2.15109867e+00],
            [ -6.52060364e+00,   2.87200008e-01,   6.80956787e-02],
            [ -2.15109867e+00,   6.80956787e-02,   3.33693910e-02]])
-        np.testing.assert_array_almost_equal(ols.vm, vm,6)
+        np.testing.assert_allclose(ols.vm, vm,RTOL)
 
     def test_OLS(self):
         self.X = sparse.csr_matrix(self.X)
@@ -34,74 +35,74 @@ class TestBaseOLS(unittest.TestCase):
                 name_y='home value', name_x=['income','crime'], \
                 name_ds='columbus', nonspat_diag=True, white_test=True)
         
-        np.testing.assert_array_almost_equal(ols.aic, \
-                408.73548964604873 ,7)
-        np.testing.assert_array_almost_equal(ols.ar2, \
-                0.32123239427957662 ,7)
-        np.testing.assert_array_almost_equal(ols.betas, \
+        np.testing.assert_allclose(ols.aic, \
+                408.73548964604873 ,RTOL)
+        np.testing.assert_allclose(ols.ar2, \
+                0.32123239427957662 ,RTOL)
+        np.testing.assert_allclose(ols.betas, \
                 np.array([[ 46.42818268], [  0.62898397], \
-                    [ -0.48488854]]), 7) 
+                    [ -0.48488854]]),RTOL) 
         bp = np.array([2, 5.7667905131212587, 0.05594449410070558])
         ols_bp = np.array([ols.breusch_pagan['df'], ols.breusch_pagan['bp'], ols.breusch_pagan['pvalue']])
-        np.testing.assert_array_almost_equal(bp, ols_bp, 7)
-        np.testing.assert_array_almost_equal(ols.f_stat, \
-            (12.358198885356581, 5.0636903313953024e-05), 7)
+        np.testing.assert_allclose(bp, ols_bp,RTOL)
+        np.testing.assert_allclose(ols.f_stat, \
+            (12.358198885356581, 5.0636903313953024e-05),RTOL)
         jb = np.array([2, 39.706155069114878, 2.387360356860208e-09])
         ols_jb = np.array([ols.jarque_bera['df'], ols.jarque_bera['jb'], ols.jarque_bera['pvalue']])
-        np.testing.assert_array_almost_equal(ols_jb,jb, 7)
+        np.testing.assert_allclose(ols_jb,jb,RTOL)
         white = np.array([5, 2.90606708, 0.71446484])
         ols_white = np.array([ols.white['df'], ols.white['wh'], ols.white['pvalue']])
-        np.testing.assert_array_almost_equal(ols_white,white, 7)
+        np.testing.assert_allclose(ols_white,white,RTOL)
         np.testing.assert_equal(ols.k,  3)
         kb = {'df': 2, 'kb': 2.2700383871478675, 'pvalue': 0.32141595215434604}
         for key in kb:
-            self.assertAlmostEqual(ols.koenker_bassett[key],  kb[key], 7)
-        np.testing.assert_array_almost_equal(ols.lm_error, \
-            (4.1508117035117893, 0.041614570655392716),7)
-        np.testing.assert_array_almost_equal(ols.lm_lag, \
-            (0.98279980617162233, 0.32150855529063727), 7)
-        np.testing.assert_array_almost_equal(ols.lm_sarma, \
-                (4.3222725729143736, 0.11519415308749938), 7)
-        np.testing.assert_array_almost_equal(ols.logll, \
-                -201.3677448230244 ,7)
-        np.testing.assert_array_almost_equal(ols.mean_y, \
-            38.436224469387746,7)
-        np.testing.assert_array_almost_equal(ols.moran_res[0], \
-            0.20373540938,7)
-        np.testing.assert_array_almost_equal(ols.moran_res[1], \
-            2.59180452208,7)
-        np.testing.assert_array_almost_equal(ols.moran_res[2], \
-            0.00954740031251,7)
-        np.testing.assert_array_almost_equal(ols.mulColli, \
-            12.537554873824675 ,7)
+            np.testing.assert_allclose(ols.koenker_bassett[key],  kb[key],RTOL)
+        np.testing.assert_allclose(ols.lm_error, \
+            (4.1508117035117893, 0.041614570655392716),RTOL)
+        np.testing.assert_allclose(ols.lm_lag, \
+            (0.98279980617162233, 0.32150855529063727),RTOL)
+        np.testing.assert_allclose(ols.lm_sarma, \
+                (4.3222725729143736, 0.11519415308749938),RTOL)
+        np.testing.assert_allclose(ols.logll, \
+                -201.3677448230244 ,RTOL)
+        np.testing.assert_allclose(ols.mean_y, \
+            38.436224469387746,RTOL)
+        np.testing.assert_allclose(ols.moran_res[0], \
+            0.20373540938,RTOL)
+        np.testing.assert_allclose(ols.moran_res[1], \
+            2.59180452208,RTOL)
+        np.testing.assert_allclose(ols.moran_res[2], \
+            0.00954740031251,RTOL)
+        np.testing.assert_allclose(ols.mulColli, \
+            12.537554873824675 ,RTOL)
         np.testing.assert_equal(ols.n,  49)
         np.testing.assert_equal(ols.name_ds,  'columbus')
         np.testing.assert_equal(ols.name_gwk,  None)
         np.testing.assert_equal(ols.name_w,  'unknown')
         np.testing.assert_equal(ols.name_x,  ['CONSTANT', 'income', 'crime'])
         np.testing.assert_equal(ols.name_y,  'home value')
-        np.testing.assert_array_almost_equal(ols.predy[3], np.array([
-            33.53969014]),7)
-        np.testing.assert_array_almost_equal(ols.r2, \
-                0.34951437785126105 ,7)
-        np.testing.assert_array_almost_equal(ols.rlm_error, \
-                (3.3394727667427513, 0.067636278225568919),7)
-        np.testing.assert_array_almost_equal(ols.rlm_lag, \
-            (0.17146086940258459, 0.67881673703455414), 7)
+        np.testing.assert_allclose(ols.predy[3], np.array([
+            33.53969014]),RTOL)
+        np.testing.assert_allclose(ols.r2, \
+                0.34951437785126105 ,RTOL)
+        np.testing.assert_allclose(ols.rlm_error, \
+                (3.3394727667427513, 0.067636278225568919),RTOL)
+        np.testing.assert_allclose(ols.rlm_lag, \
+            (0.17146086940258459, 0.67881673703455414),RTOL)
         np.testing.assert_equal(ols.robust,  'unadjusted')
-        np.testing.assert_array_almost_equal(ols.schwarz, \
-            414.41095054038061,7 )
-        np.testing.assert_array_almost_equal(ols.sig2, \
-            231.4568494392652,7 )
-        np.testing.assert_array_almost_equal(ols.sig2ML, \
-            217.28602192257551,7 )
-        np.testing.assert_array_almost_equal(ols.sig2n, \
-                217.28602192257551, 7)
+        np.testing.assert_allclose(ols.schwarz, \
+            414.41095054038061,RTOL)
+        np.testing.assert_allclose(ols.sig2, \
+            231.4568494392652,RTOL)
+        np.testing.assert_allclose(ols.sig2ML, \
+            217.28602192257551,RTOL)
+        np.testing.assert_allclose(ols.sig2n, \
+                217.28602192257551,RTOL)
  
-        np.testing.assert_array_almost_equal(ols.t_stat[2][0], \
-                -2.65440864272,7)
-        np.testing.assert_array_almost_equal(ols.t_stat[2][1], \
-                0.0108745049098,7)
+        np.testing.assert_allclose(ols.t_stat[2][0], \
+                -2.65440864272,RTOL)
+        np.testing.assert_allclose(ols.t_stat[2][1], \
+                0.0108745049098,RTOL)
 
 if __name__ == '__main__':
     unittest.main()

--- a/pysal/spreg/tests/test_probit.py
+++ b/pysal/spreg/tests/test_probit.py
@@ -2,6 +2,7 @@ import unittest
 import pysal
 import numpy as np
 from pysal.spreg import probit as PB
+from pysal.common import RTOL
 
 class TestBaseProbit(unittest.TestCase):
     def setUp(self):
@@ -20,39 +21,39 @@ class TestBaseProbit(unittest.TestCase):
     def test_model(self):
         reg = PB.BaseProbit(self.y, self.X, w=self.w)
         betas = np.array([[ 3.35381078], [-0.1996531 ], [-0.02951371]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,6)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         predy = np.array([ 0.00174739])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,6)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        self.assertAlmostEqual(reg.n,n,6)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 3
-        self.assertAlmostEqual(reg.k,k,6)
+        np.testing.assert_allclose(reg.k,k,RTOL)
         y = np.array([ 0.])
-        np.testing.assert_array_almost_equal(reg.y[0],y,6)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([  1.      ,  19.531   ,  80.467003])
-        np.testing.assert_array_almost_equal(reg.x[0],x,6)
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
         vm = np.array([[  8.52813879e-01,  -4.36272459e-02,  -8.05171472e-03], [ -4.36272459e-02,   4.11381444e-03,  -1.92834842e-04], [ -8.05171472e-03,  -1.92834842e-04,   3.09660240e-04]])
-        np.testing.assert_array_almost_equal(reg.vm,vm,6)
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         xmean = np.array([[  1.        ], [ 14.37493876], [ 38.43622447 ]])
-        np.testing.assert_array_almost_equal(reg.xmean,xmean,6)        
+        np.testing.assert_allclose(reg.xmean,xmean,RTOL)        
         predpc = 85.714285714285708
-        self.assertAlmostEqual(reg.predpc,predpc,5)
+        np.testing.assert_allclose(reg.predpc,predpc,RTOL)
         logl = -20.06009093055782
-        self.assertAlmostEqual(reg.logl,logl,5)
+        np.testing.assert_allclose(reg.logl,logl,RTOL)
         scale = 0.23309310130643665
-        self.assertAlmostEqual(reg.scale,scale,5)
+        np.testing.assert_allclose(reg.scale,scale,RTOL)
         slopes = np.array([[-0.04653776], [-0.00687944]])
-        np.testing.assert_array_almost_equal(reg.slopes,slopes,6)
+        np.testing.assert_allclose(reg.slopes,slopes,RTOL)
         slopes_vm = np.array([[  1.77101993e-04,  -1.65021168e-05], [ -1.65021168e-05,   1.60575016e-05]])
-        np.testing.assert_array_almost_equal(reg.slopes_vm,slopes_vm,6)
+        np.testing.assert_allclose(reg.slopes_vm,slopes_vm,RTOL)
         LR = 25.317683245671716
-        self.assertAlmostEqual(reg.LR[0],LR,5)
+        np.testing.assert_allclose(reg.LR[0],LR,RTOL)
         Pinkse_error = 2.9632385352516728
-        self.assertAlmostEqual(reg.Pinkse_error[0],Pinkse_error,5)
+        np.testing.assert_allclose(reg.Pinkse_error[0],Pinkse_error,RTOL)
         KP_error = 1.6509224700582124
-        self.assertAlmostEqual(reg.KP_error[0],KP_error,5)
+        np.testing.assert_allclose(reg.KP_error[0],KP_error,RTOL)
         PS_error = 2.3732463777623511
-        self.assertAlmostEqual(reg.PS_error[0],PS_error,5)
+        np.testing.assert_allclose(reg.PS_error[0],PS_error,RTOL)
 
 class TestProbit(unittest.TestCase):
     def setUp(self):
@@ -70,39 +71,39 @@ class TestProbit(unittest.TestCase):
     def test_model(self):
         reg = PB.Probit(self.y, self.X, w=self.w)
         betas = np.array([[ 3.35381078], [-0.1996531 ], [-0.02951371]])
-        np.testing.assert_array_almost_equal(reg.betas,betas,6)
+        np.testing.assert_allclose(reg.betas,betas,RTOL)
         predy = np.array([ 0.00174739])
-        np.testing.assert_array_almost_equal(reg.predy[0],predy,6)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
         n = 49
-        self.assertAlmostEqual(reg.n,n,6)
+        np.testing.assert_allclose(reg.n,n,RTOL)
         k = 3
-        self.assertAlmostEqual(reg.k,k,6)
+        np.testing.assert_allclose(reg.k,k,RTOL)
         y = np.array([ 0.])
-        np.testing.assert_array_almost_equal(reg.y[0],y,6)
+        np.testing.assert_allclose(reg.y[0],y,RTOL)
         x = np.array([  1.      ,  19.531   ,  80.467003])
-        np.testing.assert_array_almost_equal(reg.x[0],x,6)
+        np.testing.assert_allclose(reg.x[0],x,RTOL)
         vm = np.array([[  8.52813879e-01,  -4.36272459e-02,  -8.05171472e-03], [ -4.36272459e-02,   4.11381444e-03,  -1.92834842e-04], [ -8.05171472e-03,  -1.92834842e-04,   3.09660240e-04]])
-        np.testing.assert_array_almost_equal(reg.vm,vm,6)
+        np.testing.assert_allclose(reg.vm,vm,RTOL)
         xmean = np.array([[  1.        ], [ 14.37493876], [ 38.43622447 ]])
-        np.testing.assert_array_almost_equal(reg.xmean,xmean,6)        
+        np.testing.assert_allclose(reg.xmean,xmean,RTOL)        
         predpc = 85.714285714285708
-        self.assertAlmostEqual(reg.predpc,predpc,5)
+        np.testing.assert_allclose(reg.predpc,predpc,RTOL)
         logl = -20.06009093055782
-        self.assertAlmostEqual(reg.logl,logl,5)
+        np.testing.assert_allclose(reg.logl,logl,RTOL)
         scale = 0.23309310130643665
-        self.assertAlmostEqual(reg.scale,scale,5)
+        np.testing.assert_allclose(reg.scale,scale,RTOL)
         slopes = np.array([[-0.04653776], [-0.00687944]])
-        np.testing.assert_array_almost_equal(reg.slopes,slopes,6)
+        np.testing.assert_allclose(reg.slopes,slopes,RTOL)
         slopes_vm = np.array([[  1.77101993e-04,  -1.65021168e-05], [ -1.65021168e-05,   1.60575016e-05]])
-        np.testing.assert_array_almost_equal(reg.slopes_vm,slopes_vm,6)
+        np.testing.assert_allclose(reg.slopes_vm,slopes_vm,RTOL)
         LR = 25.317683245671716
-        self.assertAlmostEqual(reg.LR[0],LR,5)
+        np.testing.assert_allclose(reg.LR[0],LR,RTOL)
         Pinkse_error = 2.9632385352516728
-        self.assertAlmostEqual(reg.Pinkse_error[0],Pinkse_error,5)
+        np.testing.assert_allclose(reg.Pinkse_error[0],Pinkse_error,RTOL)
         KP_error = 1.6509224700582124
-        self.assertAlmostEqual(reg.KP_error[0],KP_error,5)
+        np.testing.assert_allclose(reg.KP_error[0],KP_error,RTOL)
         PS_error = 2.3732463777623511
-        self.assertAlmostEqual(reg.PS_error[0],PS_error,5)
+        np.testing.assert_allclose(reg.PS_error[0],PS_error,RTOL)
         
 if __name__ == '__main__':
     unittest.main()

--- a/pysal/spreg/tests/test_twosls.py
+++ b/pysal/spreg/tests/test_twosls.py
@@ -2,6 +2,7 @@ import unittest
 import numpy as np
 import pysal
 from pysal.spreg.twosls import BaseTSLS, TSLS
+from pysal.common import RTOL
 
 class TestBaseTSLS(unittest.TestCase):
     def setUp(self):
@@ -22,84 +23,85 @@ class TestBaseTSLS(unittest.TestCase):
     def test_basic(self):
         reg = BaseTSLS(self.y, self.X, self.yd, self.q)
         betas = np.array([[ 88.46579584], [  0.5200379 ], [ -1.58216593]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         h_0 = np.array([  1.   ,  19.531,   5.03 ])
-        np.testing.assert_array_almost_equal(reg.h[0], h_0)
+        np.testing.assert_allclose(reg.h[0], h_0)
         hth = np.array([[    49.        ,    704.371999  ,    139.75      ],
                         [   704.371999  ,  11686.67338121,   2246.12800625],
                         [   139.75      ,   2246.12800625,    498.5851    ]])
-        np.testing.assert_array_almost_equal(reg.hth, hth, 7)
+        np.testing.assert_allclose(reg.hth, hth,RTOL)
         hthi = np.array([[ 0.1597275 , -0.00762011, -0.01044191],
                         [-0.00762011,  0.00100135, -0.0023752 ],
                         [-0.01044191, -0.0023752 ,  0.01563276]]) 
-        np.testing.assert_array_almost_equal(reg.hthi, hthi, 7)
+        np.testing.assert_allclose(reg.hthi, hthi,RTOL)
         self.assertEqual(reg.k, 3)
         self.assertEqual(reg.kstar, 1)
-        self.assertAlmostEqual(reg.mean_y, 35.128823897959187, 7)
+        np.testing.assert_allclose(reg.mean_y, 35.128823897959187,RTOL)
         self.assertEqual(reg.n, 49)
         pfora1a2 = np.array([[ 9.58156106, -0.22744226, -0.13820537],
                              [ 0.02580142,  0.08226331, -0.03143731],
                              [-3.13896453, -0.33487872,  0.20690965]]) 
-        np.testing.assert_array_almost_equal(reg.pfora1a2, pfora1a2, 7)
+        np.testing.assert_allclose(reg.pfora1a2, pfora1a2,RTOL)
         predy_5 = np.array([[-28.68949467], [ 28.99484984], [ 55.07344824], [ 38.26609504], [ 57.57145851]]) 
-        np.testing.assert_array_almost_equal(reg.predy[0:5], predy_5, 7)
+        np.testing.assert_allclose(reg.predy[0:5], predy_5,RTOL)
         q_5 = np.array([[ 5.03], [ 4.27], [ 3.89], [ 3.7 ], [ 2.83]])
         np.testing.assert_array_equal(reg.q[0:5], q_5)
-        self.assertAlmostEqual(reg.sig2n_k, 587.56797852699822, 7)
-        self.assertAlmostEqual(reg.sig2n, 551.5944288212637, 7)
-        self.assertAlmostEqual(reg.sig2, 551.5944288212637, 7)
-        self.assertAlmostEqual(reg.std_y, 16.732092091229699, 7)
+        np.testing.assert_allclose(reg.sig2n_k, 587.56797852699822,RTOL)
+        np.testing.assert_allclose(reg.sig2n, 551.5944288212637,RTOL)
+        np.testing.assert_allclose(reg.sig2, 551.5944288212637,RTOL)
+        np.testing.assert_allclose(reg.std_y, 16.732092091229699,RTOL)
         u_5 = np.array([[ 44.41547467], [-10.19309584], [-24.44666724], [ -5.87833504], [ -6.83994851]]) 
-        np.testing.assert_array_almost_equal(reg.u[0:5], u_5, 7)
-        self.assertAlmostEqual(reg.utu, 27028.127012241919, 7)
+        np.testing.assert_allclose(reg.u[0:5], u_5,RTOL)
+        np.testing.assert_allclose(reg.utu, 27028.127012241919,RTOL)
         varb = np.array([[ 0.41526237,  0.01879906, -0.01730372],
                          [ 0.01879906,  0.00362823, -0.00184604],
                          [-0.01730372, -0.00184604,  0.0011406 ]]) 
-        np.testing.assert_array_almost_equal(reg.varb, varb, 7)
+        np.testing.assert_allclose(reg.varb, varb,RTOL)
         vm = np.array([[ 229.05640809,   10.36945783,   -9.54463414],
                        [  10.36945783,    2.0013142 ,   -1.01826408],
                        [  -9.54463414,   -1.01826408,    0.62914915]]) 
-        np.testing.assert_array_almost_equal(reg.vm, vm, 7)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
         x_0 = np.array([  1.   ,  19.531])
-        np.testing.assert_array_almost_equal(reg.x[0], x_0, 7)
+        np.testing.assert_allclose(reg.x[0], x_0,RTOL)
         y_5 = np.array([[ 15.72598 ], [ 18.801754], [ 30.626781], [ 32.38776 ], [ 50.73151 ]]) 
-        np.testing.assert_array_almost_equal(reg.y[0:5], y_5, 7)
+        np.testing.assert_allclose(reg.y[0:5], y_5,RTOL)
         yend_5 = np.array([[ 80.467003], [ 44.567001], [ 26.35    ], [ 33.200001], [ 23.225   ]]) 
-        np.testing.assert_array_almost_equal(reg.yend[0:5], yend_5, 7)
+        np.testing.assert_allclose(reg.yend[0:5], yend_5,RTOL)
         z_0 = np.array([  1.      ,  19.531   ,  80.467003]) 
-        np.testing.assert_array_almost_equal(reg.z[0], z_0, 7)
+        np.testing.assert_allclose(reg.z[0], z_0,RTOL)
         zthhthi = np.array([[  1.00000000e+00,  -1.66533454e-16,   4.44089210e-16],
                             [  0.00000000e+00,   1.00000000e+00,   0.00000000e+00],
                             [  1.26978671e+01,   1.05598709e+00,   3.70212359e+00]]) 
+        #np.testing.assert_allclose(reg.zthhthi, zthhthi, RTOL)
         np.testing.assert_array_almost_equal(reg.zthhthi, zthhthi, 7)
         
     def test_n_k(self):
         reg = BaseTSLS(self.y, self.X, self.yd, self.q, sig2n_k=True)
         betas = np.array([[ 88.46579584], [  0.5200379 ], [ -1.58216593]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         vm = np.array([[ 243.99486949,   11.04572682,  -10.16711028],
                        [  11.04572682,    2.13183469,   -1.08467261],
                        [ -10.16711028,   -1.08467261,    0.67018062]]) 
-        np.testing.assert_array_almost_equal(reg.vm, vm, 7)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
 
     def test_white(self):
         reg = BaseTSLS(self.y, self.X, self.yd, self.q, robust='white')
         betas = np.array([[ 88.46579584], [  0.5200379 ], [ -1.58216593]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         vm = np.array([[ 208.27139316,   15.6687805 ,  -11.53686154],
                        [  15.6687805 ,    2.26882747,   -1.30312033],
                        [ -11.53686154,   -1.30312033,    0.81940656]]) 
-        np.testing.assert_array_almost_equal(reg.vm, vm, 7)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
 
     def test_hac(self):
         gwk = pysal.kernelW_from_shapefile(pysal.examples.get_path('columbus.shp'),k=15,function='triangular', fixed=False)
         reg = BaseTSLS(self.y, self.X, self.yd, self.q, robust='hac', gwk=gwk)
         betas = np.array([[ 88.46579584], [  0.5200379 ], [ -1.58216593]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         vm = np.array([[ 231.07254978,   15.42050291,  -11.3941033 ],
                        [  15.01376346,    1.92422887,   -1.11865505],
                        [ -11.34381641,   -1.1279227 ,    0.72053806]]) 
-        np.testing.assert_array_almost_equal(reg.vm, vm, 7)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
 
 class TestTSLS(unittest.TestCase):
     def setUp(self):
@@ -119,105 +121,106 @@ class TestTSLS(unittest.TestCase):
     def test_basic(self):
         reg = TSLS(self.y, self.X, self.yd, self.q)
         betas = np.array([[ 88.46579584], [  0.5200379 ], [ -1.58216593]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         h_0 = np.array([  1.   ,  19.531,   5.03 ])
-        np.testing.assert_array_almost_equal(reg.h[0], h_0)
+        np.testing.assert_allclose(reg.h[0], h_0)
         hth = np.array([[    49.        ,    704.371999  ,    139.75      ],
                         [   704.371999  ,  11686.67338121,   2246.12800625],
                         [   139.75      ,   2246.12800625,    498.5851    ]])
-        np.testing.assert_array_almost_equal(reg.hth, hth, 7)
+        np.testing.assert_allclose(reg.hth, hth,RTOL)
         hthi = np.array([[ 0.1597275 , -0.00762011, -0.01044191],
                         [-0.00762011,  0.00100135, -0.0023752 ],
                         [-0.01044191, -0.0023752 ,  0.01563276]]) 
-        np.testing.assert_array_almost_equal(reg.hthi, hthi, 7)
+        np.testing.assert_allclose(reg.hthi, hthi,RTOL)
         self.assertEqual(reg.k, 3)
         self.assertEqual(reg.kstar, 1)
-        self.assertAlmostEqual(reg.mean_y, 35.128823897959187, 7)
+        np.testing.assert_allclose(reg.mean_y, 35.128823897959187,RTOL)
         self.assertEqual(reg.n, 49)
         pfora1a2 = np.array([[ 9.58156106, -0.22744226, -0.13820537],
                              [ 0.02580142,  0.08226331, -0.03143731],
                              [-3.13896453, -0.33487872,  0.20690965]]) 
-        np.testing.assert_array_almost_equal(reg.pfora1a2, pfora1a2, 7)
+        np.testing.assert_allclose(reg.pfora1a2, pfora1a2,RTOL)
         predy_5 = np.array([[-28.68949467], [ 28.99484984], [ 55.07344824], [ 38.26609504], [ 57.57145851]]) 
-        np.testing.assert_array_almost_equal(reg.predy[0:5], predy_5, 7)
+        np.testing.assert_allclose(reg.predy[0:5], predy_5,RTOL)
         q_5 = np.array([[ 5.03], [ 4.27], [ 3.89], [ 3.7 ], [ 2.83]])
         np.testing.assert_array_equal(reg.q[0:5], q_5)
-        self.assertAlmostEqual(reg.sig2n_k, 587.56797852699822, 7)
-        self.assertAlmostEqual(reg.sig2n, 551.5944288212637, 7)
-        self.assertAlmostEqual(reg.sig2, 551.5944288212637, 7)
-        self.assertAlmostEqual(reg.std_y, 16.732092091229699, 7)
+        np.testing.assert_allclose(reg.sig2n_k, 587.56797852699822,RTOL)
+        np.testing.assert_allclose(reg.sig2n, 551.5944288212637,RTOL)
+        np.testing.assert_allclose(reg.sig2, 551.5944288212637,RTOL)
+        np.testing.assert_allclose(reg.std_y, 16.732092091229699,RTOL)
         u_5 = np.array([[ 44.41547467], [-10.19309584], [-24.44666724], [ -5.87833504], [ -6.83994851]]) 
-        np.testing.assert_array_almost_equal(reg.u[0:5], u_5, 7)
-        self.assertAlmostEqual(reg.utu, 27028.127012241919, 7)
+        np.testing.assert_allclose(reg.u[0:5], u_5,RTOL)
+        np.testing.assert_allclose(reg.utu, 27028.127012241919,RTOL)
         varb = np.array([[ 0.41526237,  0.01879906, -0.01730372],
                          [ 0.01879906,  0.00362823, -0.00184604],
                          [-0.01730372, -0.00184604,  0.0011406 ]]) 
-        np.testing.assert_array_almost_equal(reg.varb, varb, 7)
+        np.testing.assert_allclose(reg.varb, varb,RTOL)
         vm = np.array([[ 229.05640809,   10.36945783,   -9.54463414],
                        [  10.36945783,    2.0013142 ,   -1.01826408],
                        [  -9.54463414,   -1.01826408,    0.62914915]]) 
-        np.testing.assert_array_almost_equal(reg.vm, vm, 7)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
         x_0 = np.array([  1.   ,  19.531])
-        np.testing.assert_array_almost_equal(reg.x[0], x_0, 7)
+        np.testing.assert_allclose(reg.x[0], x_0,RTOL)
         y_5 = np.array([[ 15.72598 ], [ 18.801754], [ 30.626781], [ 32.38776 ], [ 50.73151 ]]) 
-        np.testing.assert_array_almost_equal(reg.y[0:5], y_5, 7)
+        np.testing.assert_allclose(reg.y[0:5], y_5,RTOL)
         yend_5 = np.array([[ 80.467003], [ 44.567001], [ 26.35    ], [ 33.200001], [ 23.225   ]]) 
-        np.testing.assert_array_almost_equal(reg.yend[0:5], yend_5, 7)
+        np.testing.assert_allclose(reg.yend[0:5], yend_5,RTOL)
         z_0 = np.array([  1.      ,  19.531   ,  80.467003]) 
-        np.testing.assert_array_almost_equal(reg.z[0], z_0, 7)
+        np.testing.assert_allclose(reg.z[0], z_0,RTOL)
         zthhthi = np.array([[  1.00000000e+00,  -1.66533454e-16,   4.44089210e-16],
                             [  0.00000000e+00,   1.00000000e+00,   0.00000000e+00],
                             [  1.26978671e+01,   1.05598709e+00,   3.70212359e+00]]) 
+        #np.testing.assert_allclose(reg.zthhthi, zthhthi,RTOL)
         np.testing.assert_array_almost_equal(reg.zthhthi, zthhthi, 7)
-        self.assertAlmostEqual(reg.pr2, 0.27936137128173893, 7)
+        np.testing.assert_allclose(reg.pr2, 0.27936137128173893,RTOL)
         z_stat = np.array([[  5.84526447e+00,   5.05764078e-09],
                            [  3.67601567e-01,   7.13170346e-01],
                            [ -1.99468913e+00,   4.60767956e-02]])
-        np.testing.assert_array_almost_equal(reg.z_stat, z_stat, 7)
+        np.testing.assert_allclose(reg.z_stat, z_stat,RTOL)
         title = 'TWO STAGE LEAST SQUARES'
         self.assertEqual(reg.title, title)
         
     def test_n_k(self):
         reg = TSLS(self.y, self.X, self.yd, self.q, sig2n_k=True)
         betas = np.array([[ 88.46579584], [  0.5200379 ], [ -1.58216593]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         vm = np.array([[ 243.99486949,   11.04572682,  -10.16711028],
                        [  11.04572682,    2.13183469,   -1.08467261],
                        [ -10.16711028,   -1.08467261,    0.67018062]]) 
-        np.testing.assert_array_almost_equal(reg.vm, vm, 7)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
 
     def test_white(self):
         reg = TSLS(self.y, self.X, self.yd, self.q, robust='white')
         betas = np.array([[ 88.46579584], [  0.5200379 ], [ -1.58216593]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         vm = np.array([[ 208.27139316,   15.6687805 ,  -11.53686154],
                        [  15.6687805 ,    2.26882747,   -1.30312033],
                        [ -11.53686154,   -1.30312033,    0.81940656]]) 
-        np.testing.assert_array_almost_equal(reg.vm, vm, 7)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
         self.assertEqual(reg.robust, 'white')
 
     def test_hac(self):
         gwk = pysal.kernelW_from_shapefile(pysal.examples.get_path('columbus.shp'),k=5,function='triangular', fixed=False)
         reg = TSLS(self.y, self.X, self.yd, self.q, robust='hac', gwk=gwk)
         betas = np.array([[ 88.46579584], [  0.5200379 ], [ -1.58216593]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         vm = np.array([[ 225.0795089 ,   17.11660041,  -12.22448566],
                        [  17.67097154,    2.47483461,   -1.4183641 ],
                        [ -12.45093722,   -1.40495464,    0.8700441 ]]) 
-        np.testing.assert_array_almost_equal(reg.vm, vm, 7)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
         self.assertEqual(reg.robust, 'hac')
 
     def test_spatial(self):
         w = pysal.queen_from_shapefile(pysal.examples.get_path('columbus.shp'))
         reg = TSLS(self.y, self.X, self.yd, self.q, spat_diag=True, w=w)
         betas = np.array([[ 88.46579584], [  0.5200379 ], [ -1.58216593]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         vm = np.array([[ 229.05640809,   10.36945783,   -9.54463414],
                        [  10.36945783,    2.0013142 ,   -1.01826408],
                        [  -9.54463414,   -1.01826408,    0.62914915]]) 
-        np.testing.assert_array_almost_equal(reg.vm, vm, 7)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
         ak_test = np.array([ 1.16816972,  0.27977763])
-        np.testing.assert_array_almost_equal(reg.ak_test, ak_test, 7)
+        np.testing.assert_allclose(reg.ak_test, ak_test,RTOL)
 
     def test_names(self):
         w = pysal.queen_from_shapefile(pysal.examples.get_path('columbus.shp'))
@@ -234,11 +237,11 @@ class TestTSLS(unittest.TestCase):
                 name_x=name_x, name_y=name_y, name_q=name_q, name_w=name_w,
                 name_yend=name_yend, name_gwk=name_gwk, name_ds=name_ds)
         betas = np.array([[ 88.46579584], [  0.5200379 ], [ -1.58216593]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         vm = np.array([[ 225.0795089 ,   17.11660041,  -12.22448566],
                        [  17.67097154,    2.47483461,   -1.4183641 ],
                        [ -12.45093722,   -1.40495464,    0.8700441 ]])
-        np.testing.assert_array_almost_equal(reg.vm, vm, 7)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
         self.assertListEqual(reg.name_x, ['CONSTANT']+name_x)
         self.assertListEqual(reg.name_yend, name_yend)
         self.assertListEqual(reg.name_q, name_q)

--- a/pysal/spreg/tests/test_twosls_regimes.py
+++ b/pysal/spreg/tests/test_twosls_regimes.py
@@ -3,6 +3,7 @@ import numpy as np
 import pysal
 from pysal.spreg.twosls_regimes import TSLS_Regimes
 from pysal.spreg.twosls import TSLS
+from pysal.common import RTOL
 
 class TestTSLS(unittest.TestCase):
     def setUp(self):
@@ -24,9 +25,9 @@ class TestTSLS(unittest.TestCase):
     def test_basic(self):
         reg = TSLS_Regimes(self.y, self.x, self.yd, self.q, self.regimes, regime_err_sep=False)        
         betas = np.array([[ 80.23408166],[  5.48218125],[ 82.98396737],[  0.49775429],[ -3.72663211],[ -1.27451485]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         h_0 = np.array([[  0.   ,   0.   ,   1.   ,  19.531,   0.   ,   5.03 ]])
-        np.testing.assert_array_almost_equal(reg.h[0]*np.eye(6), h_0)
+        np.testing.assert_allclose(reg.h[0]*np.eye(6), h_0, RTOL)
         hth = np.array([[   25.        ,   416.378999  ,     0.        ,     0.        ,\
            76.03      ,     0.        ],\
        [  416.378999  ,  7831.05477839,     0.        ,     0.        ,\
@@ -39,7 +40,7 @@ class TestTSLS(unittest.TestCase):
           291.9749    ,     0.        ],\
        [    0.        ,     0.        ,    63.72      ,   827.47378   ,\
             0.        ,   206.6102    ]])
-        np.testing.assert_array_almost_equal(reg.hth, hth, 7)
+        np.testing.assert_allclose(reg.hth, hth,RTOL)
         hthi = np.array([[ 0.3507855 , -0.0175615 ,  0.        ,  0.        , -0.00601601,\
          0.        ],\
        [-0.0175615 ,  0.00194521, -0.        , -0.        , -0.00487844,\
@@ -52,10 +53,10 @@ class TestTSLS(unittest.TestCase):
          0.        ],\
        [ 0.        ,  0.        , -0.02789128, -0.00570605,  0.        ,\
          0.03629464]])
-        np.testing.assert_array_almost_equal(reg.hthi, hthi, 7)
-        self.assertEqual(reg.k, 6)
+        np.testing.assert_allclose(reg.hthi, hthi,RTOL)
+        self.assertEqual(reg.k,6)
         self.assertEqual(reg.kstar, 2)
-        self.assertAlmostEqual(reg.mean_y, 35.128823897959187, 7)
+        np.testing.assert_allclose(reg.mean_y, 35.128823897959187,RTOL)
         np.testing.assert_equal(reg.kf, 0)
         np.testing.assert_equal(reg.kr, 3)
         np.testing.assert_equal(reg.n, 49)
@@ -72,18 +73,18 @@ class TestTSLS(unittest.TestCase):
           1.01810757,   0.        ],\
        [  0.        ,   0.        ,  -5.42403871,  -0.6641704 ,\
           0.        ,   0.34027606]]) 
-        np.testing.assert_array_almost_equal(reg.pfora1a2, pfora1a2, 7)
+        np.testing.assert_allclose(reg.pfora1a2, pfora1a2,RTOL)
         predy_5 = np.array([[ -9.85078372],[ 36.75098196],[ 57.34266859],[ 42.89851907],[ 58.9840913 ]]) 
-        np.testing.assert_array_almost_equal(reg.predy[0:5], predy_5, 7)
+        np.testing.assert_allclose(reg.predy[0:5], predy_5,RTOL)
         q_5 = np.array([ 5.03,  4.27,  3.89,  3.7 ,  2.83])
         np.testing.assert_array_equal((reg.q[0:5].T*np.eye(5))[1,:], q_5)
-        self.assertAlmostEqual(reg.sig2n_k, 990.00750983736714, 7)
-        self.assertAlmostEqual(reg.sig2n, 868.78210046952631, 7)
-        self.assertAlmostEqual(reg.sig2, 990.00750983736714, 7)
-        self.assertAlmostEqual(reg.std_y, 16.732092091229699, 7)
+        np.testing.assert_allclose(reg.sig2n_k, 990.00750983736714,RTOL)
+        np.testing.assert_allclose(reg.sig2n, 868.78210046952631,RTOL)
+        np.testing.assert_allclose(reg.sig2, 990.00750983736714,RTOL)
+        np.testing.assert_allclose(reg.std_y, 16.732092091229699,RTOL)
         u_5 = np.array([[ 25.57676372],[-17.94922796],[-26.71588759],[-10.51075907],[ -8.2525813 ]]) 
-        np.testing.assert_array_almost_equal(reg.u[0:5], u_5, 7)
-        self.assertAlmostEqual(reg.utu, 42570.322923006788, 7)
+        np.testing.assert_allclose(reg.u[0:5], u_5,RTOL)
+        np.testing.assert_allclose(reg.utu, 42570.322923006788,RTOL)
         varb = np.array([[ 0.50015831,  0.07969376,  0.        ,  0.        , -0.04760541,\
          0.        ],\
        [ 0.07969376,  0.06523527,  0.        ,  0.        , -0.03105915,\
@@ -96,7 +97,7 @@ class TestTSLS(unittest.TestCase):
         -0.        ],\
        [-0.        , -0.        , -0.02117969, -0.00259344, -0.        ,\
          0.0013287 ]]) 
-        np.testing.assert_array_almost_equal(reg.varb, varb, 7)
+        np.testing.assert_allclose(reg.varb, varb,RTOL)
         vm = np.array([[ 495.16048523,   78.89742341,    0.        ,    0.        ,\
          -47.12971066,    0.        ],\
        [  78.89742341,   64.58341083,    0.        ,    0.        ,\
@@ -109,15 +110,15 @@ class TestTSLS(unittest.TestCase):
           14.89456384,    0.        ],\
        [   0.        ,    0.        ,  -20.96804956,   -2.56752553,\
            0.        ,    1.3154267 ]]) 
-        np.testing.assert_array_almost_equal(reg.vm, vm, 7)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
         x_0 = np.array([[  0.   ,   0.   ,   1.   ,  19.531]])
-        np.testing.assert_array_almost_equal(reg.x[0]*np.eye(4), x_0, 7)
+        np.testing.assert_allclose(reg.x[0]*np.eye(4), x_0,RTOL)
         y_5 = np.array([[ 15.72598 ], [ 18.801754], [ 30.626781], [ 32.38776 ], [ 50.73151 ]]) 
-        np.testing.assert_array_almost_equal(reg.y[0:5], y_5, 7)
+        np.testing.assert_allclose(reg.y[0:5], y_5,RTOL)
         yend_3 = np.array([[  0.      ,  80.467003],[  0.      ,  44.567001],[  0.      ,  26.35    ]]) 
-        np.testing.assert_array_almost_equal(reg.yend[0:3]*np.eye(2), yend_3, 7)
+        np.testing.assert_allclose(reg.yend[0:3]*np.eye(2), yend_3,RTOL)
         z_0 = np.array([[  0.      ,   0.      ,   1.      ,  19.531   ,   0.      , 80.467003]]) 
-        np.testing.assert_array_almost_equal(reg.z[0]*np.eye(6), z_0, 7)
+        np.testing.assert_allclose(reg.z[0]*np.eye(6), z_0,RTOL)
         zthhthi = np.array([[  1.00000000e+00,   0.00000000e+00,   0.00000000e+00,\
           0.00000000e+00,  -4.44089210e-16,   0.00000000e+00],\
        [ -1.24344979e-14,   1.00000000e+00,   0.00000000e+00,\
@@ -130,27 +131,28 @@ class TestTSLS(unittest.TestCase):
           0.00000000e+00,   1.38104644e+00,   0.00000000e+00],\
        [  0.00000000e+00,   0.00000000e+00,   1.19237474e+01,\
           1.13018165e+00,   0.00000000e+00,   5.22645427e+00]]) 
+        #np.testing.assert_allclose(reg.zthhthi, zthhthi, RTOL) #why does this fail??
         np.testing.assert_array_almost_equal(reg.zthhthi, zthhthi, 7)
-        self.assertAlmostEqual(reg.pr2, 0.17729324026706564, 7)
+        np.testing.assert_allclose(reg.pr2, 0.17729324026706564,RTOL)
         z_stat = np.array([[  3.60566933e+00,   3.11349387e-04],\
        [  6.82170447e-01,   4.95131179e-01],\
        [  3.06705211e+00,   2.16181168e-03],\
        [  1.81902371e-01,   8.55659343e-01],\
        [ -9.65611937e-01,   3.34238400e-01],\
        [ -1.11124949e+00,   2.66460976e-01]])
-        np.testing.assert_array_almost_equal(np.array(reg.z_stat), z_stat, 7)
+        np.testing.assert_allclose(np.array(reg.z_stat), z_stat,RTOL)
         chow_regi = np.array([[ 0.00616179,  0.93743265],
        [ 0.3447218 ,  0.55711631],
        [ 0.37093662,  0.54249417]])
-        np.testing.assert_array_almost_equal(reg.chow.regi, chow_regi, 7)
-        self.assertAlmostEqual(reg.chow.joint[0], 1.1353790779820598, 7)
+        np.testing.assert_allclose(reg.chow.regi, chow_regi,RTOL)
+        np.testing.assert_allclose(reg.chow.joint[0], 1.1353790779820598,RTOL)
         title = 'TWO STAGE LEAST SQUARES - REGIMES'
         self.assertEqual(reg.title, title)
         
     def test_n_k(self):
         reg = TSLS_Regimes(self.y, self.x, self.yd, self.q, self.regimes, sig2n_k=True, regime_err_sep=False)
         betas = np.array([[ 80.23408166],[  5.48218125],[ 82.98396737],[  0.49775429],[ -3.72663211],[ -1.27451485]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         vm = np.array([[ 495.16048523,   78.89742341,    0.        ,    0.        ,\
          -47.12971066,    0.        ],\
        [  78.89742341,   64.58341083,    0.        ,    0.        ,\
@@ -163,13 +165,13 @@ class TestTSLS(unittest.TestCase):
           14.89456384,    0.        ],\
        [   0.        ,    0.        ,  -20.96804956,   -2.56752553,\
            0.        ,    1.3154267 ]]) 
-        np.testing.assert_array_almost_equal(reg.vm, vm, 7)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
 
     def test_spatial(self):
         w = pysal.queen_from_shapefile(pysal.examples.get_path('columbus.shp'))
         reg = TSLS_Regimes(self.y, self.x, self.yd, self.q, self.regimes, spat_diag=True, w=w, regime_err_sep=False)
         betas = np.array([[ 80.23408166],[  5.48218125],[ 82.98396737],[  0.49775429],[ -3.72663211],[ -1.27451485]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         vm = np.array([[ 495.16048523,   78.89742341,    0.        ,    0.        ,\
          -47.12971066,    0.        ],\
        [  78.89742341,   64.58341083,    0.        ,    0.        ,\
@@ -182,9 +184,9 @@ class TestTSLS(unittest.TestCase):
           14.89456384,    0.        ],\
        [   0.        ,    0.        ,  -20.96804956,   -2.56752553,\
            0.        ,    1.3154267 ]]) 
-        np.testing.assert_array_almost_equal(reg.vm, vm, 7)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
         ak_test = np.array([ 0.69774552,  0.40354227])
-        np.testing.assert_array_almost_equal(reg.ak_test, ak_test, 7)   
+        np.testing.assert_allclose(reg.ak_test, ak_test,RTOL)   
 
     def test_names(self):
         w = pysal.queen_from_shapefile(pysal.examples.get_path('columbus.shp'))
@@ -202,7 +204,7 @@ class TestTSLS(unittest.TestCase):
                 name_x=name_x, name_y=name_y, name_q=name_q, name_w=name_w,
                 name_yend=name_yend, name_gwk=name_gwk, name_ds=name_ds)
         betas = np.array([[ 80.23408166],[  5.48218125],[ 82.98396737],[  0.49775429],[ -3.72663211],[ -1.27451485]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         vm = np.array([[ 522.75813101,  120.64940697,  -15.60303241,   -0.976389  ,\
          -67.15556574,    0.64553579],\
        [ 122.83491674,  122.62303068,   -5.52270916,    0.05023488,\
@@ -215,7 +217,7 @@ class TestTSLS(unittest.TestCase):
           27.68512974,   -0.08124602],\
        [  -0.08001296,    0.13575504,  -14.6998294 ,   -1.28225201,\
           -0.05193056,    0.79845124]])
-        np.testing.assert_array_almost_equal(reg.vm, vm, 7)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
         self.assertEqual(reg.name_x, ['0_CONSTANT', '0_inc', '1_CONSTANT', '1_inc'])
         self.assertEqual(reg.name_yend, ['0_hoval', '1_hoval'])
         self.assertEqual(reg.name_q, ['0_discbd', '1_discbd'])
@@ -239,9 +241,9 @@ class TestTSLS(unittest.TestCase):
         model1 = TSLS(y[0:(n/2)].reshape((n/2),1), x1[0:(n/2)], yend=x2[0:(n/2)], q=q[0:(n/2)], sig2n_k=False)
         model2 = TSLS(y[(n/2):n].reshape((n/2),1), x1[(n/2):n], yend=x2[(n/2):n], q=q[(n/2):n], sig2n_k=False)
         tbetas = np.vstack((model1.betas, model2.betas))
-        np.testing.assert_array_almost_equal(model.betas,tbetas)
+        np.testing.assert_allclose(model.betas,tbetas)
         vm = np.hstack((model1.vm.diagonal(),model2.vm.diagonal()))
-        np.testing.assert_array_almost_equal(model.vm.diagonal(), vm, 6)
+        np.testing.assert_allclose(model.vm.diagonal(), vm,RTOL)
         #Columbus:
         reg = TSLS_Regimes(self.y, self.x, regimes=self.regimes, yend=self.yd, q=self.q, regime_err_sep=False)
         tbetas = np.array([[ 80.23408166],
@@ -250,23 +252,23 @@ class TestTSLS(unittest.TestCase):
        [  0.49775429],
        [ -3.72663211],
        [ -1.27451485],])
-        np.testing.assert_array_almost_equal(tbetas, reg.betas)
+        np.testing.assert_allclose(tbetas, reg.betas,RTOL)
         vm = np.array([ 495.16048523,   78.89742341,    0.        ,    0.        ,
         -47.12971066,    0.        ])
-        np.testing.assert_array_almost_equal(reg.vm[0], vm, 6)
+        np.testing.assert_allclose(reg.vm[0], vm,RTOL)
         u_3 = np.array([[ 25.57676372],
        [-17.94922796],
        [-26.71588759]])
-        np.testing.assert_array_almost_equal(reg.u[0:3], u_3, 7)
+        np.testing.assert_allclose(reg.u[0:3], u_3,RTOL)
         predy_3 = np.array([[ -9.85078372],
        [ 36.75098196],
        [ 57.34266859]])
-        np.testing.assert_array_almost_equal(reg.predy[0:3], predy_3, 7)
+        np.testing.assert_allclose(reg.predy[0:3], predy_3,RTOL)
         chow_regi = np.array([[ 0.00616179,  0.93743265],
        [ 0.3447218 ,  0.55711631],
        [ 0.37093662,  0.54249417]])
-        np.testing.assert_array_almost_equal(reg.chow.regi, chow_regi, 7)
-        self.assertAlmostEqual(reg.chow.joint[0], 1.1353790779821029, 7)
+        np.testing.assert_allclose(reg.chow.regi, chow_regi,RTOL)
+        np.testing.assert_allclose(reg.chow.joint[0], 1.1353790779821029,RTOL)
 
 if __name__ == '__main__':
     start_suppress = np.get_printoptions()['suppress']

--- a/pysal/spreg/tests/test_twosls_sp.py
+++ b/pysal/spreg/tests/test_twosls_sp.py
@@ -3,6 +3,7 @@ import numpy as np
 import pysal
 import pysal.spreg.diagnostics as D
 from pysal.spreg.twosls_sp import BaseGM_Lag, GM_Lag
+from pysal.common import RTOL
 
 class TestBaseGMLag(unittest.TestCase):
     def setUp(self):
@@ -22,52 +23,52 @@ class TestBaseGMLag(unittest.TestCase):
         self.X = np.hstack((np.ones(self.y.shape),self.X))
         reg = BaseGM_Lag(self.y, self.X, yend=yd2, q=q2, w=self.w.sparse, w_lags=w_lags)
         betas = np.array([[  4.53017056e+01], [  6.20888617e-01], [ -4.80723451e-01], [  2.83622122e-02]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         h_0 = np.array([  1.        ,  19.531     ,  15.72598   ,  18.594     ,
                             24.7142675 ,  13.72216667,  27.82929567])
-        np.testing.assert_array_almost_equal(reg.h[0], h_0)
+        np.testing.assert_allclose(reg.h[0], h_0)
         hth = np.  array([   49.        ,   704.371999  ,  1721.312371  ,   724.7435916 ,
                              1707.35412945,   711.31248483,  1729.63201243])
-        np.testing.assert_array_almost_equal(reg.hth[0], hth, 7)
+        np.testing.assert_allclose(reg.hth[0], hth,RTOL)
         hthi = np.array([  7.33701328e+00,   2.27764882e-02,   2.18153588e-02,
                            -5.11035447e-02,   1.22515181e-03,  -2.38079378e-01,
                            -1.20149133e-01])
-        np.testing.assert_array_almost_equal(reg.hthi[0], hthi, 7)
+        np.testing.assert_allclose(reg.hthi[0], hthi,RTOL)
         self.assertEqual(reg.k, 4)
         self.assertEqual(reg.kstar, 1)
-        self.assertAlmostEqual(reg.mean_y, 38.436224469387746, 7)
+        np.testing.assert_allclose(reg.mean_y, 38.436224469387746,RTOL)
         self.assertEqual(reg.n, 49)
         pfora1a2 = np.array([ 80.5588479 ,  -1.06625281,  -0.61703759,  -1.10071931]) 
-        np.testing.assert_array_almost_equal(reg.pfora1a2[0], pfora1a2, 7)
+        np.testing.assert_allclose(reg.pfora1a2[0], pfora1a2,RTOL)
         predy_5 = np.array([[ 50.87411532],[ 50.76969931],[ 41.77223722],[ 33.44262382],[ 28.77418036]])
-        np.testing.assert_array_almost_equal(reg.predy[0:5], predy_5, 7)
+        np.testing.assert_allclose(reg.predy[0:5], predy_5,RTOL)
         q_5 = np.array([ 18.594     ,  24.7142675 ,  13.72216667,  27.82929567])
-        np.testing.assert_array_almost_equal(reg.q[0], q_5)
-        self.assertAlmostEqual(reg.sig2n_k, 234.54258763039289, 7)
-        self.assertAlmostEqual(reg.sig2n, 215.39625394627919, 7)
-        self.assertAlmostEqual(reg.sig2, 215.39625394627919, 7)
-        self.assertAlmostEqual(reg.std_y, 18.466069465206047, 7)
+        np.testing.assert_allclose(reg.q[0], q_5)
+        np.testing.assert_allclose(reg.sig2n_k, 234.54258763039289,RTOL)
+        np.testing.assert_allclose(reg.sig2n, 215.39625394627919,RTOL)
+        np.testing.assert_allclose(reg.sig2, 215.39625394627919,RTOL)
+        np.testing.assert_allclose(reg.std_y, 18.466069465206047,RTOL)
         u_5 = np.array( [[ 29.59288768], [ -6.20269831], [-15.42223722], [ -0.24262282], [ -5.54918036]])
-        np.testing.assert_array_almost_equal(reg.u[0:5], u_5, 7)
-        self.assertAlmostEqual(reg.utu, 10554.41644336768, 7)
+        np.testing.assert_allclose(reg.u[0:5], u_5,RTOL)
+        np.testing.assert_allclose(reg.utu, 10554.41644336768,RTOL)
         varb = np.array( [[  1.48966377e+00, -2.28698061e-02, -1.20217386e-02, -1.85763498e-02],
                           [ -2.28698061e-02,  1.27893998e-03,  2.74600023e-04, -1.33497705e-04],
                           [ -1.20217386e-02,  2.74600023e-04,  1.54257766e-04,  6.86851184e-05],
                           [ -1.85763498e-02, -1.33497705e-04,  6.86851184e-05,  4.67711582e-04]])
-        np.testing.assert_array_almost_equal(reg.varb, varb, 7)
+        np.testing.assert_allclose(reg.varb, varb,RTOL)
         vm = np.array([[  3.20867996e+02, -4.92607057e+00, -2.58943746e+00, -4.00127615e+00],
                        [ -4.92607057e+00,  2.75478880e-01,  5.91478163e-02, -2.87549056e-02],
                        [ -2.58943746e+00,  5.91478163e-02,  3.32265449e-02,  1.47945172e-02],
                        [ -4.00127615e+00, -2.87549056e-02,  1.47945172e-02,  1.00743323e-01]])
-        np.testing.assert_array_almost_equal(reg.vm, vm, 6)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
         x_0 = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.x[0], x_0, 7)
+        np.testing.assert_allclose(reg.x[0], x_0,RTOL)
         y_5 = np.array( [[ 80.467003], [ 44.567001], [ 26.35    ], [ 33.200001], [ 23.225   ]])
-        np.testing.assert_array_almost_equal(reg.y[0:5], y_5, 7)
+        np.testing.assert_allclose(reg.y[0:5], y_5,RTOL)
         yend_5 = np.array( [[ 35.4585005 ], [ 46.67233467], [ 45.36475125], [ 32.81675025], [ 30.81785714]])
-        np.testing.assert_array_almost_equal(reg.yend[0:5], yend_5, 7)
+        np.testing.assert_allclose(reg.yend[0:5], yend_5,RTOL)
         z_0 = np.array([  1.       ,  19.531    ,  15.72598  ,  35.4585005]) 
-        np.testing.assert_array_almost_equal(reg.z[0], z_0, 7)
+        np.testing.assert_allclose(reg.z[0], z_0,RTOL)
         zthhthi = np.array( [[  1.00000000e+00, -2.22044605e-16, -2.22044605e-16 , 2.22044605e-16,
                                 4.44089210e-16,  0.00000000e+00, -8.88178420e-16],
                              [  0.00000000e+00,  1.00000000e+00, -3.55271368e-15 , 3.55271368e-15,
@@ -76,6 +77,7 @@ class TestBaseGMLag(unittest.TestCase):
                                -2.84217094e-14,  5.68434189e-14,  5.68434189e-14],
                              [ -8.31133940e+00, -3.76104678e-01, -2.07028208e-01 , 1.32618931e+00,
                                -8.04284562e-01,  1.30527047e+00,  1.39136816e+00]])
+        # np.testing.assert_allclose(reg.zthhthi, zthhthi, RTOL) WHYYYY
         np.testing.assert_array_almost_equal(reg.zthhthi, zthhthi, 7)
 
     def test_init_white_(self):
@@ -88,10 +90,10 @@ class TestBaseGMLag(unittest.TestCase):
         self.X = np.hstack((np.ones(self.y.shape),self.X))
         base_gm_lag = BaseGM_Lag(self.y, self.X,  yend=yd2, q=q2, w=self.w.sparse, w_lags=w_lags, robust='white')
         tbetas = np.array([[  4.53017056e+01], [  6.20888617e-01], [ -4.80723451e-01], [  2.83622122e-02]])
-        np.testing.assert_array_almost_equal(base_gm_lag.betas, tbetas) 
+        np.testing.assert_allclose(base_gm_lag.betas, tbetas) 
         dbetas = D.se_betas(base_gm_lag)
         se_betas = np.array([ 20.47077481, 0.50613931, 0.20138425, 0.38028295 ])
-        np.testing.assert_array_almost_equal(dbetas, se_betas)
+        np.testing.assert_allclose(dbetas, se_betas)
 
     def test_init_hac_(self):
         w_lags = 2
@@ -104,10 +106,10 @@ class TestBaseGMLag(unittest.TestCase):
         gwk = pysal.kernelW_from_shapefile(pysal.examples.get_path('columbus.shp'),k=15,function='triangular', fixed=False)        
         base_gm_lag = BaseGM_Lag(self.y, self.X, yend=yd2, q=q2, w=self.w.sparse, w_lags=w_lags, robust='hac', gwk=gwk)
         tbetas = np.array([[  4.53017056e+01], [  6.20888617e-01], [ -4.80723451e-01], [  2.83622122e-02]])
-        np.testing.assert_array_almost_equal(base_gm_lag.betas, tbetas) 
+        np.testing.assert_allclose(base_gm_lag.betas, tbetas) 
         dbetas = D.se_betas(base_gm_lag)
         se_betas = np.array([ 19.08513569,   0.51769543,   0.18244862,   0.35460553])
-        np.testing.assert_array_almost_equal(dbetas, se_betas)
+        np.testing.assert_allclose(dbetas, se_betas)
 
     def test_init_discbd(self):
         w_lags = 2
@@ -121,10 +123,10 @@ class TestBaseGMLag(unittest.TestCase):
         self.X = np.hstack((np.ones(self.y.shape),self.X))
         reg = BaseGM_Lag(self.y, self.X, w=self.w.sparse, yend=yd2, q=q2, w_lags=w_lags)
         tbetas = np.array([[ 100.79359082], [  -0.50215501], [  -1.14881711], [  -0.38235022]])
-        np.testing.assert_array_almost_equal(tbetas, reg.betas)
+        np.testing.assert_allclose(tbetas, reg.betas)
         dbetas = D.se_betas(reg)
         se_betas = np.array([ 53.0829123 ,   1.02511494,   0.57589064,   0.59891744 ])
-        np.testing.assert_array_almost_equal(dbetas, se_betas)
+        np.testing.assert_allclose(dbetas, se_betas)
 
     def test_n_k(self):
         w_lags = 2
@@ -136,12 +138,12 @@ class TestBaseGMLag(unittest.TestCase):
         self.X = np.hstack((np.ones(self.y.shape),self.X))
         reg = BaseGM_Lag(self.y, self.X, yend=yd2, q=q2, w=self.w.sparse, w_lags=w_lags, sig2n_k=True)
         betas = np.  array([[  4.53017056e+01], [  6.20888617e-01], [ -4.80723451e-01], [  2.83622122e-02]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         vm = np.array( [[  3.49389596e+02, -5.36394351e+00, -2.81960968e+00, -4.35694515e+00],
                          [ -5.36394351e+00,  2.99965892e-01,  6.44054000e-02, -3.13108972e-02],
                          [ -2.81960968e+00,  6.44054000e-02,  3.61800155e-02,  1.61095854e-02],
                          [ -4.35694515e+00, -3.13108972e-02,  1.61095854e-02,  1.09698285e-01]])
-        np.testing.assert_array_almost_equal(reg.vm, vm, 7)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
 
     def test_lag_q(self):
         w_lags = 2
@@ -155,10 +157,10 @@ class TestBaseGMLag(unittest.TestCase):
         self.X = np.hstack((np.ones(self.y.shape),self.X))
         reg = BaseGM_Lag(self.y, self.X, w=self.w.sparse, yend=yd2, q=q2, w_lags=w_lags, lag_q=False)
         tbetas = np.array( [[ 108.83261383], [  -0.48041099], [  -1.18950006], [  -0.56140186]])
-        np.testing.assert_array_almost_equal(tbetas, reg.betas)
+        np.testing.assert_allclose(tbetas, reg.betas)
         dbetas = D.se_betas(reg)
         se_betas = np.array([ 58.33203837,   1.09100446,   0.62315167,   0.68088777])
-        np.testing.assert_array_almost_equal(dbetas, se_betas)
+        np.testing.assert_allclose(dbetas, se_betas)
 
 
 
@@ -177,59 +179,59 @@ class TestGMLag(unittest.TestCase):
         self.X = np.array(X).T
         reg = GM_Lag(self.y, self.X, w=self.w, w_lags=2)
         betas = np.array([[  4.53017056e+01], [  6.20888617e-01], [ -4.80723451e-01], [  2.83622122e-02]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         e_5 = np.array( [[ 29.28976367], [ -6.07439501], [-15.30080685], [ -0.41773375], [ -5.67197968]])
-        np.testing.assert_array_almost_equal(reg.e_pred[0:5], e_5, 7)
+        np.testing.assert_allclose(reg.e_pred[0:5], e_5,RTOL)
         h_0 = np.array([  1.        ,  19.531     ,  15.72598   ,  18.594     ,
                             24.7142675 ,  13.72216667,  27.82929567])
-        np.testing.assert_array_almost_equal(reg.h[0], h_0)
+        np.testing.assert_allclose(reg.h[0], h_0)
         hth = np.  array([   49.        ,   704.371999  ,  1721.312371  ,   724.7435916 ,
                              1707.35412945,   711.31248483,  1729.63201243])
-        np.testing.assert_array_almost_equal(reg.hth[0], hth, 7)
+        np.testing.assert_allclose(reg.hth[0], hth,RTOL)
         hthi = np.array([  7.33701328e+00,   2.27764882e-02,   2.18153588e-02,
                            -5.11035447e-02,   1.22515181e-03,  -2.38079378e-01,
                            -1.20149133e-01])
-        np.testing.assert_array_almost_equal(reg.hthi[0], hthi, 7)
+        np.testing.assert_allclose(reg.hthi[0], hthi,RTOL)
         self.assertEqual(reg.k, 4)
         self.assertEqual(reg.kstar, 1)
-        self.assertAlmostEqual(reg.mean_y, 38.436224469387746, 7)
+        np.testing.assert_allclose(reg.mean_y, 38.436224469387746,RTOL)
         self.assertEqual(reg.n, 49)
         pfora1a2 = np.array([ 80.5588479 ,  -1.06625281,  -0.61703759,  -1.10071931]) 
-        self.assertAlmostEqual(reg.pr2, 0.3551928222612527, 7)
-        self.assertAlmostEqual(reg.pr2_e, 0.34763857386174174, 7)
-        np.testing.assert_array_almost_equal(reg.pfora1a2[0], pfora1a2, 7)
+        np.testing.assert_allclose(reg.pr2, 0.3551928222612527,RTOL)
+        np.testing.assert_allclose(reg.pr2_e, 0.34763857386174174,RTOL)
+        np.testing.assert_allclose(reg.pfora1a2[0], pfora1a2,RTOL)
         predy_5 = np.array([[ 50.87411532],[ 50.76969931],[ 41.77223722],[ 33.44262382],[ 28.77418036]])
-        np.testing.assert_array_almost_equal(reg.predy[0:5], predy_5, 7)
+        np.testing.assert_allclose(reg.predy[0:5], predy_5,RTOL)
         predy_e_5 = np.array( [[ 51.17723933], [ 50.64139601], [ 41.65080685], [ 33.61773475], [ 28.89697968]])
-        np.testing.assert_array_almost_equal(reg.predy_e[0:5], predy_e_5, 7)
+        np.testing.assert_allclose(reg.predy_e[0:5], predy_e_5,RTOL)
         q_5 = np.array([ 18.594     ,  24.7142675 ,  13.72216667,  27.82929567])
-        np.testing.assert_array_almost_equal(reg.q[0], q_5)
+        np.testing.assert_allclose(reg.q[0], q_5)
         self.assertEqual(reg.robust, 'unadjusted')
-        self.assertAlmostEqual(reg.sig2n_k, 234.54258763039289, 7)
-        self.assertAlmostEqual(reg.sig2n, 215.39625394627919, 7)
-        self.assertAlmostEqual(reg.sig2, 215.39625394627919, 7)
-        self.assertAlmostEqual(reg.std_y, 18.466069465206047, 7)
+        np.testing.assert_allclose(reg.sig2n_k, 234.54258763039289,RTOL)
+        np.testing.assert_allclose(reg.sig2n, 215.39625394627919,RTOL)
+        np.testing.assert_allclose(reg.sig2, 215.39625394627919,RTOL)
+        np.testing.assert_allclose(reg.std_y, 18.466069465206047,RTOL)
         u_5 = np.array( [[ 29.59288768], [ -6.20269831], [-15.42223722], [ -0.24262282], [ -5.54918036]])
-        np.testing.assert_array_almost_equal(reg.u[0:5], u_5, 7)
-        self.assertAlmostEqual(reg.utu, 10554.41644336768, 7)
+        np.testing.assert_allclose(reg.u[0:5], u_5,RTOL)
+        np.testing.assert_allclose(reg.utu, 10554.41644336768,RTOL)
         varb = np.array( [[  1.48966377e+00, -2.28698061e-02, -1.20217386e-02, -1.85763498e-02],
                           [ -2.28698061e-02,  1.27893998e-03,  2.74600023e-04, -1.33497705e-04],
                           [ -1.20217386e-02,  2.74600023e-04,  1.54257766e-04,  6.86851184e-05],
                           [ -1.85763498e-02, -1.33497705e-04,  6.86851184e-05,  4.67711582e-04]])
-        np.testing.assert_array_almost_equal(reg.varb, varb, 7)
+        np.testing.assert_allclose(reg.varb, varb,RTOL)
         vm = np.array([[  3.20867996e+02, -4.92607057e+00, -2.58943746e+00, -4.00127615e+00],
                        [ -4.92607057e+00,  2.75478880e-01,  5.91478163e-02, -2.87549056e-02],
                        [ -2.58943746e+00,  5.91478163e-02,  3.32265449e-02,  1.47945172e-02],
                        [ -4.00127615e+00, -2.87549056e-02,  1.47945172e-02,  1.00743323e-01]])
-        np.testing.assert_array_almost_equal(reg.vm, vm, 6)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
         x_0 = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.x[0], x_0, 7)
+        np.testing.assert_allclose(reg.x[0], x_0,RTOL)
         y_5 = np.array( [[ 80.467003], [ 44.567001], [ 26.35    ], [ 33.200001], [ 23.225   ]])
-        np.testing.assert_array_almost_equal(reg.y[0:5], y_5, 7)
+        np.testing.assert_allclose(reg.y[0:5], y_5,RTOL)
         yend_5 = np.array( [[ 35.4585005 ], [ 46.67233467], [ 45.36475125], [ 32.81675025], [ 30.81785714]])
-        np.testing.assert_array_almost_equal(reg.yend[0:5], yend_5, 7)
+        np.testing.assert_allclose(reg.yend[0:5], yend_5,RTOL)
         z_0 = np.array([  1.       ,  19.531    ,  15.72598  ,  35.4585005]) 
-        np.testing.assert_array_almost_equal(reg.z[0], z_0, 7)
+        np.testing.assert_allclose(reg.z[0], z_0,RTOL)
         zthhthi = np.array( [[  1.00000000e+00, -2.22044605e-16, -2.22044605e-16 , 2.22044605e-16,
                                 4.44089210e-16,  0.00000000e+00, -8.88178420e-16],
                              [  0.00000000e+00,  1.00000000e+00, -3.55271368e-15 , 3.55271368e-15,
@@ -238,6 +240,7 @@ class TestGMLag(unittest.TestCase):
                                -2.84217094e-14,  5.68434189e-14,  5.68434189e-14],
                              [ -8.31133940e+00, -3.76104678e-01, -2.07028208e-01 , 1.32618931e+00,
                                -8.04284562e-01,  1.30527047e+00,  1.39136816e+00]])
+        # np.testing.assert_allclose(reg.zthhthi, zthhthi RTOL) #another issue with rtol
         np.testing.assert_array_almost_equal(reg.zthhthi, zthhthi, 7)
 
     def test_init_white_(self):
@@ -247,10 +250,10 @@ class TestGMLag(unittest.TestCase):
         self.X = np.array(X).T
         base_gm_lag = GM_Lag(self.y, self.X, w=self.w, w_lags=2, robust='white')
         tbetas = np.array([[  4.53017056e+01], [  6.20888617e-01], [ -4.80723451e-01], [  2.83622122e-02]])
-        np.testing.assert_array_almost_equal(base_gm_lag.betas, tbetas) 
+        np.testing.assert_allclose(base_gm_lag.betas, tbetas) 
         dbetas = D.se_betas(base_gm_lag)
         se_betas = np.array([ 20.47077481, 0.50613931, 0.20138425, 0.38028295 ])
-        np.testing.assert_array_almost_equal(dbetas, se_betas)
+        np.testing.assert_allclose(dbetas, se_betas)
 
     def test_init_hac_(self):
         X = []
@@ -260,10 +263,10 @@ class TestGMLag(unittest.TestCase):
         gwk = pysal.kernelW_from_shapefile(pysal.examples.get_path('columbus.shp'),k=15,function='triangular', fixed=False)        
         base_gm_lag = GM_Lag(self.y, self.X, w=self.w, w_lags=2, robust='hac', gwk=gwk)
         tbetas = np.array([[  4.53017056e+01], [  6.20888617e-01], [ -4.80723451e-01], [  2.83622122e-02]])
-        np.testing.assert_array_almost_equal(base_gm_lag.betas, tbetas) 
+        np.testing.assert_allclose(base_gm_lag.betas, tbetas) 
         dbetas = D.se_betas(base_gm_lag)
         se_betas = np.array([ 19.08513569,   0.51769543,   0.18244862,   0.35460553])
-        np.testing.assert_array_almost_equal(dbetas, se_betas)
+        np.testing.assert_allclose(dbetas, se_betas)
 
     def test_init_discbd(self):
         X = np.array(self.db.by_col("INC"))
@@ -274,10 +277,10 @@ class TestGMLag(unittest.TestCase):
         q = np.reshape(q, (49,1))
         reg = GM_Lag(self.y, X, w=self.w, yend=yd, q=q, w_lags=2)
         tbetas = np.array([[ 100.79359082], [  -0.50215501], [  -1.14881711], [  -0.38235022]])
-        np.testing.assert_array_almost_equal(tbetas, reg.betas)
+        np.testing.assert_allclose(tbetas, reg.betas)
         dbetas = D.se_betas(reg)
         se_betas = np.array([ 53.0829123 ,   1.02511494,   0.57589064,   0.59891744 ])
-        np.testing.assert_array_almost_equal(dbetas, se_betas)
+        np.testing.assert_allclose(dbetas, se_betas)
 
     def test_n_k(self):
         X = []
@@ -286,12 +289,12 @@ class TestGMLag(unittest.TestCase):
         self.X = np.array(X).T
         reg = GM_Lag(self.y, self.X, w=self.w, w_lags=2, sig2n_k=True)
         betas = np.  array([[  4.53017056e+01], [  6.20888617e-01], [ -4.80723451e-01], [  2.83622122e-02]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         vm = np.array( [[  3.49389596e+02, -5.36394351e+00, -2.81960968e+00, -4.35694515e+00],
                          [ -5.36394351e+00,  2.99965892e-01,  6.44054000e-02, -3.13108972e-02],
                          [ -2.81960968e+00,  6.44054000e-02,  3.61800155e-02,  1.61095854e-02],
                          [ -4.35694515e+00, -3.13108972e-02,  1.61095854e-02,  1.09698285e-01]])
-        np.testing.assert_array_almost_equal(reg.vm, vm, 7)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
 
     def test_lag_q(self):
         X = np.array(self.db.by_col("INC"))
@@ -302,10 +305,10 @@ class TestGMLag(unittest.TestCase):
         q = np.reshape(q, (49,1))
         reg = GM_Lag(self.y, X, w=self.w, yend=yd, q=q, w_lags=2, lag_q=False)
         tbetas = np.array( [[ 108.83261383], [  -0.48041099], [  -1.18950006], [  -0.56140186]])
-        np.testing.assert_array_almost_equal(tbetas, reg.betas)
+        np.testing.assert_allclose(tbetas, reg.betas)
         dbetas = D.se_betas(reg)
         se_betas = np.array([ 58.33203837,   1.09100446,   0.62315167,   0.68088777])
-        np.testing.assert_array_almost_equal(dbetas, se_betas)
+        np.testing.assert_allclose(dbetas, se_betas)
 
     def test_spatial(self):
         X = np.array(self.db.by_col("INC"))
@@ -317,14 +320,14 @@ class TestGMLag(unittest.TestCase):
         w = pysal.queen_from_shapefile(pysal.examples.get_path('columbus.shp'))
         reg = GM_Lag(self.y, X, yd, q, spat_diag=True, w=w)
         betas = np.array([[  5.46344924e+01], [  4.13301682e-01], [ -5.92637442e-01], [ -7.40490883e-03]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         vm = np.array( [[  4.45202654e+02, -1.50290275e+01, -6.36557072e+00, -5.71403440e-03],
                         [ -1.50290275e+01,  5.93124683e-01,  2.19169508e-01, -6.70675916e-03],
                         [ -6.36557072e+00,  2.19169508e-01,  1.06577542e-01, -2.96533875e-03],
                         [ -5.71403440e-03, -6.70675916e-03, -2.96533875e-03,  1.15655425e-03]]) 
-        np.testing.assert_array_almost_equal(reg.vm, vm, 6)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
         ak_test = np.array([ 2.52597326,  0.11198567])
-        np.testing.assert_array_almost_equal(reg.ak_test, ak_test, 7)
+        np.testing.assert_allclose(reg.ak_test, ak_test,RTOL)
 
     def test_names(self):
         X = np.array(self.db.by_col("INC"))
@@ -347,12 +350,12 @@ class TestGMLag(unittest.TestCase):
                 name_x=name_x, name_y=name_y, name_q=name_q, name_w=name_w,
                 name_yend=name_yend, name_gwk=name_gwk, name_ds=name_ds)
         betas = np.array([[  5.46344924e+01], [  4.13301682e-01], [ -5.92637442e-01], [ -7.40490883e-03]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         vm = np.array( [[  5.70817052e+02, -1.83655385e+01, -8.36602575e+00,  2.37538877e-02],
                         [ -1.85224661e+01,  6.53311383e-01,  2.84209566e-01, -6.47694160e-03],
                         [ -8.31105622e+00,  2.78772694e-01,  1.38144928e-01, -3.98175246e-03],
                         [  2.66662466e-02, -6.23783104e-03, -4.11092891e-03,  1.10936528e-03]]) 
-        np.testing.assert_array_almost_equal(reg.vm, vm, 6)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
         self.assertListEqual(reg.name_x, ['CONSTANT']+name_x)
         name_yend.append('W_crime')
         self.assertListEqual(reg.name_yend, name_yend)

--- a/pysal/spreg/tests/test_twosls_sp_regimes.py
+++ b/pysal/spreg/tests/test_twosls_sp_regimes.py
@@ -4,6 +4,7 @@ import pysal
 from pysal.spreg.twosls_sp_regimes import GM_Lag_Regimes
 from pysal.spreg import utils
 from pysal.spreg.twosls_sp import GM_Lag
+from pysal.common import RTOL
 
 class TestGMLag_Regimes(unittest.TestCase):
     def setUp(self):
@@ -29,87 +30,88 @@ class TestGMLag_Regimes(unittest.TestCase):
        [ -0.81498302],
        [ -0.28391409],
        [  0.4736163 ]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         e_5 = np.array([[ -1.47960519],
        [ -7.93748769],
        [ -5.88561835],
        [-13.37941105],
        [  5.2524303 ]])
-        np.testing.assert_array_almost_equal(reg.e_pred[0:5], e_5, 7)
+        np.testing.assert_allclose(reg.e_pred[0:5], e_5,RTOL)
         h_0 = np.array([[  0.       ,   0.       ,   0.       ,   1.       ,  19.531    ,
          80.467003 ,   0.       ,   0.       ,  18.594    ,  35.4585005]])
-        np.testing.assert_array_almost_equal(reg.h[0]*np.eye(10), h_0)
+        np.testing.assert_allclose(reg.h[0]*np.eye(10), h_0)
         self.assertEqual(reg.k, 7)
         self.assertEqual(reg.kstar, 1)
-        self.assertAlmostEqual(reg.mean_y, 35.128823897959187, 7)
+        np.testing.assert_allclose(reg.mean_y, 35.128823897959187,RTOL)
         self.assertEqual(reg.n, 49)
-        self.assertAlmostEqual(reg.pr2, 0.6572182131915739, 7)
-        self.assertAlmostEqual(reg.pr2_e, 0.5779687278635434, 7)
+        np.testing.assert_allclose(reg.pr2, 0.6572182131915739,RTOL)
+        np.testing.assert_allclose(reg.pr2_e, 0.5779687278635434,RTOL)
         pfora1a2 = np.array([ -2.15017629,  -0.30169328,  -0.07603704, -22.06541809,
          0.45738058,   0.02805828,   0.39073923]) 
-        np.testing.assert_array_almost_equal(reg.pfora1a2[0], pfora1a2, 7)
+        np.testing.assert_allclose(reg.pfora1a2[0], pfora1a2,RTOL)
         predy_5 = np.array([[ 13.93216104],
        [ 23.46424269],
        [ 34.43510955],
        [ 44.32473878],
        [ 44.39117516]])
-        np.testing.assert_array_almost_equal(reg.predy[0:5], predy_5, 7)
+        np.testing.assert_allclose(reg.predy[0:5], predy_5,RTOL)
         predy_e_5 = np.array([[ 17.20558519],
        [ 26.73924169],
        [ 36.51239935],
        [ 45.76717105],
        [ 45.4790797 ]])
-        np.testing.assert_array_almost_equal(reg.predy_e[0:5], predy_e_5, 7)
+        np.testing.assert_allclose(reg.predy_e[0:5], predy_e_5,RTOL)
         q_5 = np.array([[  0.       ,   0.       ,  18.594    ,  35.4585005]])
-        np.testing.assert_array_almost_equal(reg.q[0]*np.eye(4), q_5)
+        np.testing.assert_allclose(reg.q[0]*np.eye(4), q_5, RTOL)
         self.assertEqual(reg.robust, 'unadjusted')
-        self.assertAlmostEqual(reg.sig2n_k, 109.76462904625834, 7)
-        self.assertAlmostEqual(reg.sig2n, 94.08396775393571, 7)
-        self.assertAlmostEqual(reg.sig2, 109.76462904625834, 7)
-        self.assertAlmostEqual(reg.std_y, 16.732092091229699, 7)
+        np.testing.assert_allclose(reg.sig2n_k, 109.76462904625834,RTOL)
+        np.testing.assert_allclose(reg.sig2n, 94.08396775393571,RTOL)
+        np.testing.assert_allclose(reg.sig2, 109.76462904625834,RTOL)
+        np.testing.assert_allclose(reg.std_y, 16.732092091229699,RTOL)
         u_5 = np.array([[  1.79381896],
        [ -4.66248869],
        [ -3.80832855],
        [-11.93697878],
        [  6.34033484]])
-        np.testing.assert_array_almost_equal(reg.u[0:5], u_5, 7)
-        self.assertAlmostEqual(reg.utu, 4610.11441994285, 7)
+        np.testing.assert_allclose(reg.u[0:5], u_5,RTOL)
+        np.testing.assert_allclose(reg.utu, 4610.11441994285,RTOL)
         varb = np.array([  1.23841820e+00,  -3.65620114e-02,  -1.21919663e-03,
          1.00057547e+00,  -2.07403182e-02,  -1.27232693e-03,
         -1.77184084e-02])
-        np.testing.assert_array_almost_equal(reg.varb[0], varb, 7)
+        np.testing.assert_allclose(reg.varb[0], varb,RTOL)
         vm = np.array([  1.35934514e+02,  -4.01321561e+00,  -1.33824666e-01,
          1.09827796e+02,  -2.27655334e+00,  -1.39656494e-01,
         -1.94485452e+00])
-        np.testing.assert_array_almost_equal(reg.vm[0], vm, 6)
+        np.testing.assert_allclose(reg.vm[0], vm,RTOL)
         x_0 = np.array([[  0.      ,   0.      ,   0.      ,   1.      ,  19.531   ,
          80.467003]])
-        np.testing.assert_array_almost_equal(reg.x[0]*np.eye(6), x_0, 7)
+        np.testing.assert_allclose(reg.x[0]*np.eye(6), x_0,RTOL)
         y_5 = np.array([[ 15.72598 ],
        [ 18.801754],
        [ 30.626781],
        [ 32.38776 ],
        [ 50.73151 ]])
-        np.testing.assert_array_almost_equal(reg.y[0:5], y_5, 7)
+        np.testing.assert_allclose(reg.y[0:5], y_5,RTOL)
         yend_5 = np.array([[ 24.7142675 ],
        [ 26.24684033],
        [ 29.411751  ],
        [ 34.64647575],
        [ 40.4653275 ]])
-        np.testing.assert_array_almost_equal(reg.yend[0:5]*np.array([[1]]), yend_5, 7)
+        np.testing.assert_allclose(reg.yend[0:5]*np.array([[1]]), yend_5,RTOL)
         z_0 = np.array([[  0.       ,   0.       ,   0.       ,   1.       ,  19.531    ,
          80.467003 ,  24.7142675]]) 
-        np.testing.assert_array_almost_equal(reg.z[0]*np.eye(7), z_0, 7)
+        np.testing.assert_allclose(reg.z[0]*np.eye(7), z_0,RTOL)
         zthhthi = np.array([  1.00000000e+00,  -2.35922393e-16,   5.55111512e-17,
          0.00000000e+00,   0.00000000e+00,   0.00000000e+00,
         -4.44089210e-16,   2.22044605e-16,   0.00000000e+00,
          0.00000000e+00])
-        np.testing.assert_array_almost_equal(reg.zthhthi[0], zthhthi, 7)
+        # np.testing.assert_allclose(reg.zthhthi[0], zthhthi, RTOL)
+        np.testing.assert_array_almost_equal(reg.zthhthi[0], zthhthi)
         chow_regi = np.array([[ 0.19692667,  0.65721307],
        [ 0.5666492 ,  0.45159351],
        [ 0.45282066,  0.5009985 ]])
-        np.testing.assert_array_almost_equal(reg.chow.regi, chow_regi, 7)
-        self.assertAlmostEqual(reg.chow.joint[0], 0.82409867601863462, 7)
+        np.testing.assert_allclose(reg.chow.regi, chow_regi,RTOL)
+        np.testing.assert_allclose(reg.chow.joint[0], 0.82409867601863462,RTOL)
     
     def test_init_discbd(self):
         #Matches SpaceStat.
@@ -127,31 +129,31 @@ class TestGMLag_Regimes(unittest.TestCase):
        [ -0.68305796],
        [ -0.37106077],
        [  0.55809516]])
-        np.testing.assert_array_almost_equal(tbetas, reg.betas)
+        np.testing.assert_allclose(tbetas, reg.betas,RTOL)
         vm = np.array([ 270.62979422,    3.62539081,  327.89638627,    6.24949355,
          -5.25333106,   -6.01743515,   -4.19290074])
-        np.testing.assert_array_almost_equal(reg.vm[0], vm, 6)
+        np.testing.assert_allclose(reg.vm[0], vm,RTOL)
         e_3 = np.array([[-0.33142796],
        [-9.51719607],
        [-7.86272153]])
-        np.testing.assert_array_almost_equal(reg.e_pred[0:3], e_3, 7)
+        np.testing.assert_allclose(reg.e_pred[0:3], e_3,RTOL)
         u_3 = np.array([[ 4.51839601],
        [-5.67363147],
        [-5.1927562 ]])
-        np.testing.assert_array_almost_equal(reg.u[0:3], u_3, 7)
+        np.testing.assert_allclose(reg.u[0:3], u_3,RTOL)
         predy_3 = np.array([[ 11.20758399],
        [ 24.47538547],
        [ 35.8195372 ]])
-        np.testing.assert_array_almost_equal(reg.predy[0:3], predy_3, 7)
+        np.testing.assert_allclose(reg.predy[0:3], predy_3,RTOL)
         predy_e_3 = np.array([[ 16.05740796],
        [ 28.31895007],
        [ 38.48950253]])
-        np.testing.assert_array_almost_equal(reg.predy_e[0:3], predy_e_3, 7)
+        np.testing.assert_allclose(reg.predy_e[0:3], predy_e_3,RTOL)
         chow_regi = np.array([[ 0.13130991,  0.71707772],
        [ 0.04740966,  0.82763357],
        [ 0.15474413,  0.6940423 ]])
-        np.testing.assert_array_almost_equal(reg.chow.regi, chow_regi, 7)
-        self.assertAlmostEqual(reg.chow.joint[0], 0.31248100032096549, 7)
+        np.testing.assert_allclose(reg.chow.regi, chow_regi,RTOL)
+        np.testing.assert_allclose(reg.chow.joint[0], 0.31248100032096549,RTOL)
     
     def test_lag_q(self):
         X = np.array(self.db.by_col("INC"))
@@ -168,15 +170,15 @@ class TestGMLag_Regimes(unittest.TestCase):
        [ -0.28494432],
        [ -0.2294271 ],
        [  0.62996544]])
-        np.testing.assert_array_almost_equal(tbetas, reg.betas)
+        np.testing.assert_allclose(tbetas, reg.betas,RTOL)
         vm = np.array([ 128.25714554,   -0.38975354,   95.7271044 ,   -1.8429218 ,
          -1.75331978,   -0.18240338,   -1.67767464])
-        np.testing.assert_array_almost_equal(reg.vm[0], vm, 6)
+        np.testing.assert_allclose(reg.vm[0], vm,RTOL)
         chow_regi = np.array([[ 0.43494049,  0.50957463],
        [ 0.02089281,  0.88507135],
        [ 0.01180501,  0.91347943]])
-        np.testing.assert_array_almost_equal(reg.chow.regi, chow_regi, 7)
-        self.assertAlmostEqual(reg.chow.joint[0], 0.54288190938307757, 7)
+        np.testing.assert_allclose(reg.chow.regi, chow_regi,RTOL)
+        np.testing.assert_allclose(reg.chow.joint[0], 0.54288190938307757,RTOL)
     
     def test_all_regi(self):
         X = np.array(self.db.by_col("INC"))
@@ -188,31 +190,31 @@ class TestGMLag_Regimes(unittest.TestCase):
         reg = GM_Lag_Regimes(self.y, X, self.regimes, yend=yd, q=q, w=self.w, regime_lag_sep=False, regime_err_sep=True) 
         tbetas = np.array([[ 37.87698329,  -0.89426982,  31.4714777 ,  -0.71640525,
          -0.28494432,  -0.2294271 ,   0.62996544]])
-        np.testing.assert_array_almost_equal(tbetas, reg.betas.T)
+        np.testing.assert_allclose(tbetas, reg.betas.T,RTOL)
         vm = np.array([ 70.38291551,  -0.64868787,  49.25453215,  -0.62851534,
         -0.75413453,  -0.12674433,  -0.97179236])
-        np.testing.assert_array_almost_equal(reg.vm[0], vm, 6)
+        np.testing.assert_allclose(reg.vm[0], vm,RTOL)
         e_3 = np.array([[-2.66997799],
        [-7.69786264],
        [-4.39412782]])
-        np.testing.assert_array_almost_equal(reg.e_pred[0:3], e_3, 7)
+        np.testing.assert_allclose(reg.e_pred[0:3], e_3,RTOL)
         u_3 = np.array([[ 1.13879007],
        [-3.76873198],
        [-1.89671717]])
-        np.testing.assert_array_almost_equal(reg.u[0:3], u_3, 7)
+        np.testing.assert_allclose(reg.u[0:3], u_3,RTOL)
         predy_3 = np.array([[ 14.58718993],
        [ 22.57048598],
        [ 32.52349817]])
-        np.testing.assert_array_almost_equal(reg.predy[0:3], predy_3, 7)
+        np.testing.assert_allclose(reg.predy[0:3], predy_3,RTOL)
         predy_e_3 = np.array([[ 18.39595799],
        [ 26.49961664],
        [ 35.02090882]])
-        np.testing.assert_array_almost_equal(reg.predy_e[0:3], predy_e_3, 7)
+        np.testing.assert_allclose(reg.predy_e[0:3], predy_e_3,RTOL)
         chow_regi = np.array([[ 0.60091096,  0.43823066],
        [ 0.03006744,  0.8623373 ],
        [ 0.01943727,  0.88912016]])
-        np.testing.assert_array_almost_equal(reg.chow.regi, chow_regi, 7)
-        self.assertAlmostEqual(reg.chow.joint[0], 0.88634854058300516, 7)
+        np.testing.assert_allclose(reg.chow.regi, chow_regi,RTOL)
+        np.testing.assert_allclose(reg.chow.joint[0], 0.88634854058300516,RTOL)
     
     def test_all_regi_sig2(self):
         #Artficial:
@@ -232,9 +234,9 @@ class TestGMLag_Regimes(unittest.TestCase):
         model1 = GM_Lag(y[0:(n/2)].reshape((n/2),1), x1[0:(n/2)], yend=x2[0:(n/2)], q=q[0:(n/2)], w=w1)
         model2 = GM_Lag(y[(n/2):n].reshape((n/2),1), x1[(n/2):n], yend=x2[(n/2):n], q=q[(n/2):n], w=w1)
         tbetas = np.vstack((model1.betas, model2.betas))
-        np.testing.assert_array_almost_equal(model.betas,tbetas)
+        np.testing.assert_allclose(model.betas,tbetas)
         vm = np.hstack((model1.vm.diagonal(),model2.vm.diagonal()))
-        np.testing.assert_array_almost_equal(model.vm.diagonal(), vm, 6)
+        np.testing.assert_allclose(model.vm.diagonal(), vm,RTOL)
         #Columbus:
         X = np.array(self.db.by_col("INC"))
         X = np.reshape(X, (49,1))
@@ -251,32 +253,32 @@ class TestGMLag_Regimes(unittest.TestCase):
        [ -0.12304063],
        [ -0.46840307],
        [  0.67108156]])
-        np.testing.assert_array_almost_equal(tbetas, reg.betas)
+        np.testing.assert_allclose(tbetas, reg.betas)
         vm = np.array([ 200.92894859,    4.56244927,   -4.85603079,   -2.9755413 ,
           0.        ,    0.        ,    0.        ,    0.        ])
-        np.testing.assert_array_almost_equal(reg.vm[0], vm, 6)
+        np.testing.assert_allclose(reg.vm[0], vm,RTOL)
         e_3 = np.array([[ -1.32209547],
        [-13.15611199],
        [-11.62357696]])
-        np.testing.assert_array_almost_equal(reg.e_pred[0:3], e_3, 7)
+        np.testing.assert_allclose(reg.e_pred[0:3], e_3,RTOL)
         u_3 = np.array([[ 6.99250069],
        [-7.5665856 ],
        [-7.04753328]])
-        np.testing.assert_array_almost_equal(reg.u[0:3], u_3, 7)
+        np.testing.assert_allclose(reg.u[0:3], u_3,RTOL)
         predy_3 = np.array([[  8.73347931],
        [ 26.3683396 ],
        [ 37.67431428]])
-        np.testing.assert_array_almost_equal(reg.predy[0:3], predy_3, 7)
+        np.testing.assert_allclose(reg.predy[0:3], predy_3,RTOL)
         predy_e_3 = np.array([[ 17.04807547],
        [ 31.95786599],
        [ 42.25035796]])
-        np.testing.assert_array_almost_equal(reg.predy_e[0:3], predy_e_3, 7)
+        np.testing.assert_allclose(reg.predy_e[0:3], predy_e_3,RTOL)
         chow_regi = np.array([[  1.51825373e-01,   6.96797034e-01],
        [  3.20105698e-04,   9.85725412e-01],
        [  8.58836996e-02,   7.69476896e-01],
        [  1.01357290e-01,   7.50206873e-01]])
-        np.testing.assert_array_almost_equal(reg.chow.regi, chow_regi, 7)
-        self.assertAlmostEqual(reg.chow.joint[0], 0.38417230022512161, 7)
+        np.testing.assert_allclose(reg.chow.regi, chow_regi,RTOL)
+        np.testing.assert_allclose(reg.chow.joint[0], 0.38417230022512161,RTOL)
 
     def test_fixed_const(self):
         X = np.array(self.db.by_col("INC"))
@@ -292,30 +294,30 @@ class TestGMLag_Regimes(unittest.TestCase):
        [ -0.45793559],
        [ -0.24216904],
        [  0.62500602]])
-        np.testing.assert_array_almost_equal(tbetas, reg.betas)
+        np.testing.assert_allclose(tbetas, reg.betas,RTOL)
         vm = np.array([ 1.4183697 , -0.05975784, -0.27161863, -0.62517245,  0.02266177,
         0.00312976])
-        np.testing.assert_array_almost_equal(reg.vm[0], vm, 6)
+        np.testing.assert_allclose(reg.vm[0], vm,RTOL)
         e_3 = np.array([[ 0.17317815],
        [-5.53766328],
        [-3.82889307]])
-        np.testing.assert_array_almost_equal(reg.e_pred[0:3], e_3, 7)
+        np.testing.assert_allclose(reg.e_pred[0:3], e_3,RTOL)
         u_3 = np.array([[ 3.10025518],
        [-1.83150689],
        [-1.49598494]])
-        np.testing.assert_array_almost_equal(reg.u[0:3], u_3, 7)
+        np.testing.assert_allclose(reg.u[0:3], u_3,RTOL)
         predy_3 = np.array([[ 12.62572482],
        [ 20.63326089],
        [ 32.12276594]])
-        np.testing.assert_array_almost_equal(reg.predy[0:3], predy_3, 7)
+        np.testing.assert_allclose(reg.predy[0:3], predy_3,RTOL)
         predy_e_3 = np.array([[ 15.55280185],
        [ 24.33941728],
        [ 34.45567407]])
-        np.testing.assert_array_almost_equal(reg.predy_e[0:3], predy_e_3, 7)
+        np.testing.assert_allclose(reg.predy_e[0:3], predy_e_3,RTOL)
         chow_regi = np.array([[  1.85767047e-01,   6.66463269e-01],
        [  1.19445012e+01,   5.48089036e-04]])
-        np.testing.assert_array_almost_equal(reg.chow.regi, chow_regi, 7)
-        self.assertAlmostEqual(reg.chow.joint[0], 12.017256217621382, 7)
+        np.testing.assert_allclose(reg.chow.regi, chow_regi,RTOL)
+        np.testing.assert_allclose(reg.chow.joint[0], 12.017256217621382,RTOL)
 
     def test_names(self):
         y_var = 'CRIME'
@@ -334,15 +336,15 @@ class TestGMLag_Regimes(unittest.TestCase):
        [ -0.28494432],
        [ -0.2294271 ],
        [  0.62996544]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         vm = np.array([ 109.93469618,   -0.33407447,   82.05180377,   -1.57964725,
          -1.50284553,   -0.15634575,   -1.43800683])
-        np.testing.assert_array_almost_equal(reg.vm[0], vm, 6)
+        np.testing.assert_allclose(reg.vm[0], vm,RTOL)
         chow_regi = np.array([[ 0.50743058,  0.47625326],
        [ 0.02437494,  0.87593468],
        [ 0.01377251,  0.9065777 ]])
-        np.testing.assert_array_almost_equal(reg.chow.regi, chow_regi, 7)
-        self.assertAlmostEqual(reg.chow.joint[0], 0.63336222761359162, 7)
+        np.testing.assert_allclose(reg.chow.regi, chow_regi,RTOL)
+        np.testing.assert_allclose(reg.chow.joint[0], 0.63336222761359162,RTOL)
         self.assertListEqual(reg.name_x, ['0_CONSTANT', '0_INC', '1_CONSTANT', '1_INC'])
         self.assertListEqual(reg.name_yend, ['0_HOVAL', '1_HOVAL', '_Global_W_CRIME'])
         self.assertListEqual(reg.name_q, ['0_DISCBD', '0_W_INC', '0_W_DISCBD', '1_DISCBD', '1_W_INC', '1_W_DISCBD'])

--- a/pysal/spreg/tests/test_twosls_sp_sparse.py
+++ b/pysal/spreg/tests/test_twosls_sp_sparse.py
@@ -1,10 +1,10 @@
 import unittest
 import numpy as np
 import pysal
-from pysal.spreg.twosls_sp import BaseGM_Lag, GM_Lag
 import pysal.spreg.diagnostics as D
 from scipy import sparse as SP
-
+from pysal.spreg.twosls_sp import BaseGM_Lag, GM_Lag
+from pysal.common import RTOL
 
 class TestBaseGMLag(unittest.TestCase):
     def setUp(self):
@@ -24,52 +24,52 @@ class TestBaseGMLag(unittest.TestCase):
         self.X = SP.csr_matrix(self.X)
         reg = BaseGM_Lag(self.y, self.X, yend=yd2, q=q2, w=self.w, w_lags=2)
         betas = np.array([[  4.53017056e+01], [  6.20888617e-01], [ -4.80723451e-01], [  2.83622122e-02]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         h_0 = np.array([  1.        ,  19.531     ,  15.72598   ,  18.594     ,
                             24.7142675 ,  13.72216667,  27.82929567])
-        np.testing.assert_array_almost_equal(reg.h.toarray()[0], h_0)
+        np.testing.assert_allclose(reg.h.toarray()[0], h_0)
         hth = np.array([   49.        ,   704.371999  ,  1721.312371  ,   724.7435916 ,
                              1707.35412945,   711.31248483,  1729.63201243])
-        np.testing.assert_array_almost_equal(reg.hth[0], hth, 7)
+        np.testing.assert_allclose(reg.hth[0], hth,RTOL)
         hthi = np.array([  7.33701328e+00,   2.27764882e-02,   2.18153588e-02,
                            -5.11035447e-02,   1.22515181e-03,  -2.38079378e-01,
                            -1.20149133e-01])
-        np.testing.assert_array_almost_equal(reg.hthi[0], hthi, 7)
+        np.testing.assert_allclose(reg.hthi[0], hthi,RTOL)
         self.assertEqual(reg.k, 4)
         self.assertEqual(reg.kstar, 1)
-        self.assertAlmostEqual(reg.mean_y, 38.436224469387746, 7)
+        np.testing.assert_allclose(reg.mean_y, 38.436224469387746,RTOL)
         self.assertEqual(reg.n, 49)
         pfora1a2 = np.array([ 80.5588479 ,  -1.06625281,  -0.61703759,  -1.10071931]) 
-        np.testing.assert_array_almost_equal(reg.pfora1a2[0], pfora1a2, 7)
+        np.testing.assert_allclose(reg.pfora1a2[0], pfora1a2,RTOL)
         predy_5 = np.array([[ 50.87411532],[ 50.76969931],[ 41.77223722],[ 33.44262382],[ 28.77418036]])
-        np.testing.assert_array_almost_equal(reg.predy[0:5], predy_5, 7)
+        np.testing.assert_allclose(reg.predy[0:5], predy_5,RTOL)
         q_5 = np.array([ 18.594     ,  24.7142675 ,  13.72216667,  27.82929567])
-        np.testing.assert_array_almost_equal(reg.q[0], q_5)
-        self.assertAlmostEqual(reg.sig2n_k, 234.54258763039289, 7)
-        self.assertAlmostEqual(reg.sig2n, 215.39625394627919, 7)
-        self.assertAlmostEqual(reg.sig2, 215.39625394627919, 7)
-        self.assertAlmostEqual(reg.std_y, 18.466069465206047, 7)
+        np.testing.assert_allclose(reg.q[0], q_5)
+        np.testing.assert_allclose(reg.sig2n_k, 234.54258763039289,RTOL)
+        np.testing.assert_allclose(reg.sig2n, 215.39625394627919,RTOL)
+        np.testing.assert_allclose(reg.sig2, 215.39625394627919,RTOL)
+        np.testing.assert_allclose(reg.std_y, 18.466069465206047,RTOL)
         u_5 = np.array( [[ 29.59288768], [ -6.20269831], [-15.42223722], [ -0.24262282], [ -5.54918036]])
-        np.testing.assert_array_almost_equal(reg.u[0:5], u_5, 7)
-        self.assertAlmostEqual(reg.utu, 10554.41644336768, 7)
+        np.testing.assert_allclose(reg.u[0:5], u_5,RTOL)
+        np.testing.assert_allclose(reg.utu, 10554.41644336768,RTOL)
         varb = np.array( [[  1.48966377e+00, -2.28698061e-02, -1.20217386e-02, -1.85763498e-02],
                           [ -2.28698061e-02,  1.27893998e-03,  2.74600023e-04, -1.33497705e-04],
                           [ -1.20217386e-02,  2.74600023e-04,  1.54257766e-04,  6.86851184e-05],
                           [ -1.85763498e-02, -1.33497705e-04,  6.86851184e-05,  4.67711582e-04]])
-        np.testing.assert_array_almost_equal(reg.varb, varb, 7)
+        np.testing.assert_allclose(reg.varb, varb,RTOL)
         vm = np.array([[  3.20867996e+02, -4.92607057e+00, -2.58943746e+00, -4.00127615e+00],
                        [ -4.92607057e+00,  2.75478880e-01,  5.91478163e-02, -2.87549056e-02],
                        [ -2.58943746e+00,  5.91478163e-02,  3.32265449e-02,  1.47945172e-02],
                        [ -4.00127615e+00, -2.87549056e-02,  1.47945172e-02,  1.00743323e-01]])
-        np.testing.assert_array_almost_equal(reg.vm, vm, 6)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
         x_0 = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.x.toarray()[0], x_0, 7)
+        np.testing.assert_allclose(reg.x.toarray()[0], x_0,RTOL)
         y_5 = np.array( [[ 80.467003], [ 44.567001], [ 26.35    ], [ 33.200001], [ 23.225   ]])
-        np.testing.assert_array_almost_equal(reg.y[0:5], y_5, 7)
+        np.testing.assert_allclose(reg.y[0:5], y_5,RTOL)
         yend_5 = np.array( [[ 35.4585005 ], [ 46.67233467], [ 45.36475125], [ 32.81675025], [ 30.81785714]])
-        np.testing.assert_array_almost_equal(reg.yend[0:5], yend_5, 7)
+        np.testing.assert_allclose(reg.yend[0:5], yend_5,RTOL)
         z_0 = np.array([  1.       ,  19.531    ,  15.72598  ,  35.4585005]) 
-        np.testing.assert_array_almost_equal(reg.z.toarray()[0], z_0, 7)
+        np.testing.assert_allclose(reg.z.toarray()[0], z_0,RTOL)
         zthhthi = np.array( [[  1.00000000e+00, -2.22044605e-16, -2.22044605e-16 , 2.22044605e-16,
                                 4.44089210e-16,  0.00000000e+00, -8.88178420e-16],
                              [  0.00000000e+00,  1.00000000e+00, -3.55271368e-15 , 3.55271368e-15,
@@ -78,6 +78,7 @@ class TestBaseGMLag(unittest.TestCase):
                                -2.84217094e-14,  5.68434189e-14,  5.68434189e-14],
                              [ -8.31133940e+00, -3.76104678e-01, -2.07028208e-01 , 1.32618931e+00,
                                -8.04284562e-01,  1.30527047e+00,  1.39136816e+00]])
+        #np.testing.assert_allclose(reg.zthhthi, zthhthi,RTOL)
         np.testing.assert_array_almost_equal(reg.zthhthi, zthhthi, 7)
 
     def test_init_white_(self):
@@ -90,10 +91,10 @@ class TestBaseGMLag(unittest.TestCase):
         self.X = SP.csr_matrix(self.X)
         base_gm_lag = BaseGM_Lag(self.y, self.X, yend=yd2, q=q2, w=self.w, w_lags=2, robust='white')
         tbetas = np.array([[  4.53017056e+01], [  6.20888617e-01], [ -4.80723451e-01], [  2.83622122e-02]])
-        np.testing.assert_array_almost_equal(base_gm_lag.betas, tbetas) 
+        np.testing.assert_allclose(base_gm_lag.betas, tbetas) 
         dbetas = D.se_betas(base_gm_lag)
         se_betas = np.array([ 20.47077481, 0.50613931, 0.20138425, 0.38028295 ])
-        np.testing.assert_array_almost_equal(dbetas, se_betas)
+        np.testing.assert_allclose(dbetas, se_betas)
 
     def test_init_hac_(self):
         X = []
@@ -106,10 +107,10 @@ class TestBaseGMLag(unittest.TestCase):
         gwk = pysal.kernelW_from_shapefile(pysal.examples.get_path('columbus.shp'),k=15,function='triangular', fixed=False)        
         base_gm_lag = BaseGM_Lag(self.y, self.X, yend=yd2, q=q2, w=self.w, w_lags=2, robust='hac', gwk=gwk)
         tbetas = np.array([[  4.53017056e+01], [  6.20888617e-01], [ -4.80723451e-01], [  2.83622122e-02]])
-        np.testing.assert_array_almost_equal(base_gm_lag.betas, tbetas) 
+        np.testing.assert_allclose(base_gm_lag.betas, tbetas) 
         dbetas = D.se_betas(base_gm_lag)
         se_betas = np.array([ 19.08513569,   0.51769543,   0.18244862,   0.35460553])
-        np.testing.assert_array_almost_equal(dbetas, se_betas)
+        np.testing.assert_allclose(dbetas, se_betas)
 
     def test_init_discbd(self):
         X = np.array(self.db.by_col("INC"))
@@ -123,10 +124,10 @@ class TestBaseGMLag(unittest.TestCase):
         self.X = SP.csr_matrix(self.X)
         reg = BaseGM_Lag(self.y, self.X, yend=yd2, q=q2, w=self.w, w_lags=2)
         tbetas = np.array([[ 100.79359082], [  -0.50215501], [  -1.14881711], [  -0.38235022]])
-        np.testing.assert_array_almost_equal(tbetas, reg.betas)
+        np.testing.assert_allclose(tbetas, reg.betas)
         dbetas = D.se_betas(reg)
         se_betas = np.array([ 53.0829123 ,   1.02511494,   0.57589064,   0.59891744 ])
-        np.testing.assert_array_almost_equal(dbetas, se_betas)
+        np.testing.assert_allclose(dbetas, se_betas)
 
     def test_n_k(self):
         X = []
@@ -138,12 +139,12 @@ class TestBaseGMLag(unittest.TestCase):
         self.X = SP.csr_matrix(self.X)
         reg = BaseGM_Lag(self.y, self.X, yend=yd2, q=q2, w=self.w, w_lags=2, sig2n_k=True)
         betas = np.  array([[  4.53017056e+01], [  6.20888617e-01], [ -4.80723451e-01], [  2.83622122e-02]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         vm = np.array( [[  3.49389596e+02, -5.36394351e+00, -2.81960968e+00, -4.35694515e+00],
                          [ -5.36394351e+00,  2.99965892e-01,  6.44054000e-02, -3.13108972e-02],
                          [ -2.81960968e+00,  6.44054000e-02,  3.61800155e-02,  1.61095854e-02],
                          [ -4.35694515e+00, -3.13108972e-02,  1.61095854e-02,  1.09698285e-01]])
-        np.testing.assert_array_almost_equal(reg.vm, vm, 7)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
 
     def test_lag_q(self):
         X = np.array(self.db.by_col("INC"))
@@ -157,10 +158,10 @@ class TestBaseGMLag(unittest.TestCase):
         self.X = SP.csr_matrix(self.X)
         reg = BaseGM_Lag(self.y, self.X, yend=yd2, q=q2, w=self.w, w_lags=2, lag_q=False)
         tbetas = np.array( [[ 108.83261383], [  -0.48041099], [  -1.18950006], [  -0.56140186]])
-        np.testing.assert_array_almost_equal(tbetas, reg.betas)
+        np.testing.assert_allclose(tbetas, reg.betas)
         dbetas = D.se_betas(reg)
         se_betas = np.array([ 58.33203837,   1.09100446,   0.62315167,   0.68088777])
-        np.testing.assert_array_almost_equal(dbetas, se_betas)
+        np.testing.assert_allclose(dbetas, se_betas)
 
 
 
@@ -180,59 +181,59 @@ class TestGMLag(unittest.TestCase):
         self.X = SP.csr_matrix(self.X)
         reg = GM_Lag(self.y, self.X, w=self.w, w_lags=2)
         betas = np.array([[  4.53017056e+01], [  6.20888617e-01], [ -4.80723451e-01], [  2.83622122e-02]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         e_5 = np.array( [[ 29.28976367], [ -6.07439501], [-15.30080685], [ -0.41773375], [ -5.67197968]])
-        np.testing.assert_array_almost_equal(reg.e_pred[0:5], e_5, 7)
+        np.testing.assert_allclose(reg.e_pred[0:5], e_5,RTOL)
         h_0 = np.array([  1.        ,  19.531     ,  15.72598   ,  18.594     ,
                             24.7142675 ,  13.72216667,  27.82929567])
-        np.testing.assert_array_almost_equal(reg.h.toarray()[0], h_0)
+        np.testing.assert_allclose(reg.h.toarray()[0], h_0)
         hth = np.  array([   49.        ,   704.371999  ,  1721.312371  ,   724.7435916 ,
                              1707.35412945,   711.31248483,  1729.63201243])
-        np.testing.assert_array_almost_equal(reg.hth[0], hth, 7)
+        np.testing.assert_allclose(reg.hth[0], hth,RTOL)
         hthi = np.array([  7.33701328e+00,   2.27764882e-02,   2.18153588e-02,
                            -5.11035447e-02,   1.22515181e-03,  -2.38079378e-01,
                            -1.20149133e-01])
-        np.testing.assert_array_almost_equal(reg.hthi[0], hthi, 7)
+        np.testing.assert_allclose(reg.hthi[0], hthi,RTOL)
         self.assertEqual(reg.k, 4)
         self.assertEqual(reg.kstar, 1)
-        self.assertAlmostEqual(reg.mean_y, 38.436224469387746, 7)
+        np.testing.assert_allclose(reg.mean_y, 38.436224469387746,RTOL)
         self.assertEqual(reg.n, 49)
         pfora1a2 = np.array([ 80.5588479 ,  -1.06625281,  -0.61703759,  -1.10071931]) 
-        self.assertAlmostEqual(reg.pr2, 0.3551928222612527, 7)
-        self.assertAlmostEqual(reg.pr2_e, 0.34763857386174174, 7)
-        np.testing.assert_array_almost_equal(reg.pfora1a2[0], pfora1a2, 7)
+        np.testing.assert_allclose(reg.pr2, 0.3551928222612527,RTOL)
+        np.testing.assert_allclose(reg.pr2_e, 0.34763857386174174,RTOL)
+        np.testing.assert_allclose(reg.pfora1a2[0], pfora1a2,RTOL)
         predy_5 = np.array([[ 50.87411532],[ 50.76969931],[ 41.77223722],[ 33.44262382],[ 28.77418036]])
-        np.testing.assert_array_almost_equal(reg.predy[0:5], predy_5, 7)
+        np.testing.assert_allclose(reg.predy[0:5], predy_5,RTOL)
         predy_e_5 = np.array( [[ 51.17723933], [ 50.64139601], [ 41.65080685], [ 33.61773475], [ 28.89697968]])
-        np.testing.assert_array_almost_equal(reg.predy_e[0:5], predy_e_5, 7)
+        np.testing.assert_allclose(reg.predy_e[0:5], predy_e_5,RTOL)
         q_5 = np.array([ 18.594     ,  24.7142675 ,  13.72216667,  27.82929567])
-        np.testing.assert_array_almost_equal(reg.q.toarray()[0], q_5)
+        np.testing.assert_allclose(reg.q.toarray()[0], q_5)
         self.assertEqual(reg.robust, 'unadjusted')
-        self.assertAlmostEqual(reg.sig2n_k, 234.54258763039289, 7)
-        self.assertAlmostEqual(reg.sig2n, 215.39625394627919, 7)
-        self.assertAlmostEqual(reg.sig2, 215.39625394627919, 7)
-        self.assertAlmostEqual(reg.std_y, 18.466069465206047, 7)
+        np.testing.assert_allclose(reg.sig2n_k, 234.54258763039289,RTOL)
+        np.testing.assert_allclose(reg.sig2n, 215.39625394627919,RTOL)
+        np.testing.assert_allclose(reg.sig2, 215.39625394627919,RTOL)
+        np.testing.assert_allclose(reg.std_y, 18.466069465206047,RTOL)
         u_5 = np.array( [[ 29.59288768], [ -6.20269831], [-15.42223722], [ -0.24262282], [ -5.54918036]])
-        np.testing.assert_array_almost_equal(reg.u[0:5], u_5, 7)
-        self.assertAlmostEqual(reg.utu, 10554.41644336768, 7)
+        np.testing.assert_allclose(reg.u[0:5], u_5,RTOL)
+        np.testing.assert_allclose(reg.utu, 10554.41644336768,RTOL)
         varb = np.array( [[  1.48966377e+00, -2.28698061e-02, -1.20217386e-02, -1.85763498e-02],
                           [ -2.28698061e-02,  1.27893998e-03,  2.74600023e-04, -1.33497705e-04],
                           [ -1.20217386e-02,  2.74600023e-04,  1.54257766e-04,  6.86851184e-05],
                           [ -1.85763498e-02, -1.33497705e-04,  6.86851184e-05,  4.67711582e-04]])
-        np.testing.assert_array_almost_equal(reg.varb, varb, 7)
+        np.testing.assert_allclose(reg.varb, varb,RTOL)
         vm = np.array([[  3.20867996e+02, -4.92607057e+00, -2.58943746e+00, -4.00127615e+00],
                        [ -4.92607057e+00,  2.75478880e-01,  5.91478163e-02, -2.87549056e-02],
                        [ -2.58943746e+00,  5.91478163e-02,  3.32265449e-02,  1.47945172e-02],
                        [ -4.00127615e+00, -2.87549056e-02,  1.47945172e-02,  1.00743323e-01]])
-        np.testing.assert_array_almost_equal(reg.vm, vm, 6)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
         x_0 = np.array([  1.     ,  19.531  ,  15.72598])
-        np.testing.assert_array_almost_equal(reg.x.toarray()[0], x_0, 7)
+        np.testing.assert_allclose(reg.x.toarray()[0], x_0,RTOL)
         y_5 = np.array( [[ 80.467003], [ 44.567001], [ 26.35    ], [ 33.200001], [ 23.225   ]])
-        np.testing.assert_array_almost_equal(reg.y[0:5], y_5, 7)
+        np.testing.assert_allclose(reg.y[0:5], y_5,RTOL)
         yend_5 = np.array( [[ 35.4585005 ], [ 46.67233467], [ 45.36475125], [ 32.81675025], [ 30.81785714]])
-        np.testing.assert_array_almost_equal(reg.yend[0:5], yend_5, 7)
+        np.testing.assert_allclose(reg.yend[0:5], yend_5,RTOL)
         z_0 = np.array([  1.       ,  19.531    ,  15.72598  ,  35.4585005]) 
-        np.testing.assert_array_almost_equal(reg.z.toarray()[0], z_0, 7)
+        np.testing.assert_allclose(reg.z.toarray()[0], z_0,RTOL)
         zthhthi = np.array( [[  1.00000000e+00, -2.22044605e-16, -2.22044605e-16 , 2.22044605e-16,
                                 4.44089210e-16,  0.00000000e+00, -8.88178420e-16],
                              [  0.00000000e+00,  1.00000000e+00, -3.55271368e-15 , 3.55271368e-15,
@@ -241,6 +242,7 @@ class TestGMLag(unittest.TestCase):
                                -2.84217094e-14,  5.68434189e-14,  5.68434189e-14],
                              [ -8.31133940e+00, -3.76104678e-01, -2.07028208e-01 , 1.32618931e+00,
                                -8.04284562e-01,  1.30527047e+00,  1.39136816e+00]])
+        #np.testing.assert_allclose(reg.zthhthi, zthhthi,RTOL)
         np.testing.assert_array_almost_equal(reg.zthhthi, zthhthi, 7)
 
     def test_init_white_(self):
@@ -251,10 +253,10 @@ class TestGMLag(unittest.TestCase):
         self.X = SP.csr_matrix(self.X)
         base_gm_lag = GM_Lag(self.y, self.X, w=self.w, w_lags=2, robust='white')
         tbetas = np.array([[  4.53017056e+01], [  6.20888617e-01], [ -4.80723451e-01], [  2.83622122e-02]])
-        np.testing.assert_array_almost_equal(base_gm_lag.betas, tbetas) 
+        np.testing.assert_allclose(base_gm_lag.betas, tbetas) 
         dbetas = D.se_betas(base_gm_lag)
         se_betas = np.array([ 20.47077481, 0.50613931, 0.20138425, 0.38028295 ])
-        np.testing.assert_array_almost_equal(dbetas, se_betas)
+        np.testing.assert_allclose(dbetas, se_betas)
 
     def test_init_hac_(self):
         X = []
@@ -265,10 +267,10 @@ class TestGMLag(unittest.TestCase):
         gwk = pysal.kernelW_from_shapefile(pysal.examples.get_path('columbus.shp'),k=15,function='triangular', fixed=False)        
         base_gm_lag = GM_Lag(self.y, self.X, w=self.w, w_lags=2, robust='hac', gwk=gwk)
         tbetas = np.array([[  4.53017056e+01], [  6.20888617e-01], [ -4.80723451e-01], [  2.83622122e-02]])
-        np.testing.assert_array_almost_equal(base_gm_lag.betas, tbetas) 
+        np.testing.assert_allclose(base_gm_lag.betas, tbetas) 
         dbetas = D.se_betas(base_gm_lag)
         se_betas = np.array([ 19.08513569,   0.51769543,   0.18244862,   0.35460553])
-        np.testing.assert_array_almost_equal(dbetas, se_betas)
+        np.testing.assert_allclose(dbetas, se_betas)
 
     def test_init_discbd(self):
         X = np.array(self.db.by_col("INC"))
@@ -280,10 +282,10 @@ class TestGMLag(unittest.TestCase):
         q = np.reshape(q, (49,1))
         reg = GM_Lag(self.y, X, w=self.w, yend=yd, q=q, w_lags=2)
         tbetas = np.array([[ 100.79359082], [  -0.50215501], [  -1.14881711], [  -0.38235022]])
-        np.testing.assert_array_almost_equal(tbetas, reg.betas)
+        np.testing.assert_allclose(tbetas, reg.betas)
         dbetas = D.se_betas(reg)
         se_betas = np.array([ 53.0829123 ,   1.02511494,   0.57589064,   0.59891744 ])
-        np.testing.assert_array_almost_equal(dbetas, se_betas)
+        np.testing.assert_allclose(dbetas, se_betas)
 
     def test_n_k(self):
         X = []
@@ -293,12 +295,12 @@ class TestGMLag(unittest.TestCase):
         self.X = SP.csr_matrix(self.X)
         reg = GM_Lag(self.y, self.X, w=self.w, w_lags=2, sig2n_k=True)
         betas = np.  array([[  4.53017056e+01], [  6.20888617e-01], [ -4.80723451e-01], [  2.83622122e-02]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         vm = np.array( [[  3.49389596e+02, -5.36394351e+00, -2.81960968e+00, -4.35694515e+00],
                          [ -5.36394351e+00,  2.99965892e-01,  6.44054000e-02, -3.13108972e-02],
                          [ -2.81960968e+00,  6.44054000e-02,  3.61800155e-02,  1.61095854e-02],
                          [ -4.35694515e+00, -3.13108972e-02,  1.61095854e-02,  1.09698285e-01]])
-        np.testing.assert_array_almost_equal(reg.vm, vm, 7)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
 
     def test_lag_q(self):
         X = np.array(self.db.by_col("INC"))
@@ -310,10 +312,10 @@ class TestGMLag(unittest.TestCase):
         q = np.reshape(q, (49,1))
         reg = GM_Lag(self.y, X, w=self.w, yend=yd, q=q, w_lags=2, lag_q=False)
         tbetas = np.array( [[ 108.83261383], [  -0.48041099], [  -1.18950006], [  -0.56140186]])
-        np.testing.assert_array_almost_equal(tbetas, reg.betas)
+        np.testing.assert_allclose(tbetas, reg.betas)
         dbetas = D.se_betas(reg)
         se_betas = np.array([ 58.33203837,   1.09100446,   0.62315167,   0.68088777])
-        np.testing.assert_array_almost_equal(dbetas, se_betas)
+        np.testing.assert_allclose(dbetas, se_betas)
 
     def test_spatial(self):
         X = np.array(self.db.by_col("INC"))
@@ -326,14 +328,14 @@ class TestGMLag(unittest.TestCase):
         w = pysal.queen_from_shapefile(pysal.examples.get_path('columbus.shp'))
         reg = GM_Lag(self.y, X, yd, q, spat_diag=True, w=w)
         betas = np.array([[  5.46344924e+01], [  4.13301682e-01], [ -5.92637442e-01], [ -7.40490883e-03]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         vm = np.array( [[  4.45202654e+02, -1.50290275e+01, -6.36557072e+00, -5.71403440e-03],
                         [ -1.50290275e+01,  5.93124683e-01,  2.19169508e-01, -6.70675916e-03],
                         [ -6.36557072e+00,  2.19169508e-01,  1.06577542e-01, -2.96533875e-03],
                         [ -5.71403440e-03, -6.70675916e-03, -2.96533875e-03,  1.15655425e-03]]) 
-        np.testing.assert_array_almost_equal(reg.vm, vm, 6)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
         ak_test = np.array([ 2.52597326,  0.11198567])
-        np.testing.assert_array_almost_equal(reg.ak_test, ak_test, 7)
+        np.testing.assert_allclose(reg.ak_test, ak_test,RTOL)
 
     def test_names(self):
         X = np.array(self.db.by_col("INC"))
@@ -357,12 +359,12 @@ class TestGMLag(unittest.TestCase):
                 name_x=name_x, name_y=name_y, name_q=name_q, name_w=name_w,
                 name_yend=name_yend, name_gwk=name_gwk, name_ds=name_ds)
         betas = np.array([[  5.46344924e+01], [  4.13301682e-01], [ -5.92637442e-01], [ -7.40490883e-03]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         vm = np.array( [[  5.70817052e+02, -1.83655385e+01, -8.36602575e+00,  2.37538877e-02],
                         [ -1.85224661e+01,  6.53311383e-01,  2.84209566e-01, -6.47694160e-03],
                         [ -8.31105622e+00,  2.78772694e-01,  1.38144928e-01, -3.98175246e-03],
                         [  2.66662466e-02, -6.23783104e-03, -4.11092891e-03,  1.10936528e-03]]) 
-        np.testing.assert_array_almost_equal(reg.vm, vm, 6)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
         self.assertListEqual(reg.name_x, ['CONSTANT']+name_x)
         name_yend.append('W_crime')
         self.assertListEqual(reg.name_yend, name_yend)

--- a/pysal/spreg/tests/test_twosls_sparse.py
+++ b/pysal/spreg/tests/test_twosls_sparse.py
@@ -3,7 +3,7 @@ import numpy as np
 import pysal
 from pysal.spreg.twosls import TSLS, BaseTSLS
 from scipy import sparse as SP
-
+from pysal.common import RTOL
 
 class TestBaseTSLS(unittest.TestCase):
     def setUp(self):
@@ -25,84 +25,84 @@ class TestBaseTSLS(unittest.TestCase):
     def test_basic(self):
         reg = BaseTSLS(self.y, self.X, self.yd, self.q)
         betas = np.array([[ 88.46579584], [  0.5200379 ], [ -1.58216593]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         h_0 = np.array([  1.   ,  19.531,   5.03 ])
-        np.testing.assert_array_almost_equal(reg.h.toarray()[0], h_0)
+        np.testing.assert_allclose(reg.h.toarray()[0], h_0)
         hth = np.array([[    49.        ,    704.371999  ,    139.75      ],
                         [   704.371999  ,  11686.67338121,   2246.12800625],
                         [   139.75      ,   2246.12800625,    498.5851    ]])
-        np.testing.assert_array_almost_equal(reg.hth, hth, 7)
+        np.testing.assert_allclose(reg.hth, hth,RTOL)
         hthi = np.array([[ 0.1597275 , -0.00762011, -0.01044191],
                         [-0.00762011,  0.00100135, -0.0023752 ],
                         [-0.01044191, -0.0023752 ,  0.01563276]]) 
-        np.testing.assert_array_almost_equal(reg.hthi, hthi, 7)
+        np.testing.assert_allclose(reg.hthi, hthi,RTOL)
         self.assertEqual(reg.k, 3)
         self.assertEqual(reg.kstar, 1)
-        self.assertAlmostEqual(reg.mean_y, 35.128823897959187, 7)
+        np.testing.assert_allclose(reg.mean_y, 35.128823897959187,RTOL)
         self.assertEqual(reg.n, 49)
         pfora1a2 = np.array([[ 9.58156106, -0.22744226, -0.13820537],
                              [ 0.02580142,  0.08226331, -0.03143731],
                              [-3.13896453, -0.33487872,  0.20690965]]) 
-        np.testing.assert_array_almost_equal(reg.pfora1a2, pfora1a2, 7)
+        np.testing.assert_allclose(reg.pfora1a2, pfora1a2,RTOL)
         predy_5 = np.array([[-28.68949467], [ 28.99484984], [ 55.07344824], [ 38.26609504], [ 57.57145851]]) 
-        np.testing.assert_array_almost_equal(reg.predy[0:5], predy_5, 7)
+        np.testing.assert_allclose(reg.predy[0:5], predy_5,RTOL)
         q_5 = np.array([[ 5.03], [ 4.27], [ 3.89], [ 3.7 ], [ 2.83]])
         np.testing.assert_array_equal(reg.q[0:5], q_5)
-        self.assertAlmostEqual(reg.sig2n_k, 587.56797852699822, 7)
-        self.assertAlmostEqual(reg.sig2n, 551.5944288212637, 7)
-        self.assertAlmostEqual(reg.sig2, 551.5944288212637, 7)
-        self.assertAlmostEqual(reg.std_y, 16.732092091229699, 7)
+        np.testing.assert_allclose(reg.sig2n_k, 587.56797852699822,RTOL)
+        np.testing.assert_allclose(reg.sig2n, 551.5944288212637,RTOL)
+        np.testing.assert_allclose(reg.sig2, 551.5944288212637,RTOL)
+        np.testing.assert_allclose(reg.std_y, 16.732092091229699,RTOL)
         u_5 = np.array([[ 44.41547467], [-10.19309584], [-24.44666724], [ -5.87833504], [ -6.83994851]]) 
-        np.testing.assert_array_almost_equal(reg.u[0:5], u_5, 7)
-        self.assertAlmostEqual(reg.utu, 27028.127012241919, 7)
+        np.testing.assert_allclose(reg.u[0:5], u_5,RTOL)
+        np.testing.assert_allclose(reg.utu, 27028.127012241919,RTOL)
         varb = np.array([[ 0.41526237,  0.01879906, -0.01730372],
                          [ 0.01879906,  0.00362823, -0.00184604],
                          [-0.01730372, -0.00184604,  0.0011406 ]]) 
-        np.testing.assert_array_almost_equal(reg.varb, varb, 7)
+        np.testing.assert_allclose(reg.varb, varb,RTOL)
         vm = np.array([[ 229.05640809,   10.36945783,   -9.54463414],
                        [  10.36945783,    2.0013142 ,   -1.01826408],
                        [  -9.54463414,   -1.01826408,    0.62914915]]) 
-        np.testing.assert_array_almost_equal(reg.vm, vm, 7)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
         x_0 = np.array([  1.   ,  19.531])
-        np.testing.assert_array_almost_equal(reg.x.toarray()[0], x_0, 7)
+        np.testing.assert_allclose(reg.x.toarray()[0], x_0,RTOL)
         y_5 = np.array([[ 15.72598 ], [ 18.801754], [ 30.626781], [ 32.38776 ], [ 50.73151 ]]) 
-        np.testing.assert_array_almost_equal(reg.y[0:5], y_5, 7)
+        np.testing.assert_allclose(reg.y[0:5], y_5,RTOL)
         yend_5 = np.array([[ 80.467003], [ 44.567001], [ 26.35    ], [ 33.200001], [ 23.225   ]]) 
-        np.testing.assert_array_almost_equal(reg.yend[0:5], yend_5, 7)
+        np.testing.assert_allclose(reg.yend[0:5], yend_5,RTOL)
         z_0 = np.array([  1.      ,  19.531   ,  80.467003]) 
-        np.testing.assert_array_almost_equal(reg.z.toarray()[0], z_0, 7)
+        np.testing.assert_allclose(reg.z.toarray()[0], z_0,RTOL)
         zthhthi = np.array([[  1.00000000e+00,  -1.66533454e-16,   4.44089210e-16],
                             [  0.00000000e+00,   1.00000000e+00,   0.00000000e+00],
                             [  1.26978671e+01,   1.05598709e+00,   3.70212359e+00]]) 
+        # np.testing.assert_allclose(reg.zthhthi, zthhthi,RTOL)
         np.testing.assert_array_almost_equal(reg.zthhthi, zthhthi, 7)
-        
     def test_n_k(self):
         reg = BaseTSLS(self.y, self.X, self.yd, self.q, sig2n_k=True)
         betas = np.array([[ 88.46579584], [  0.5200379 ], [ -1.58216593]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         vm = np.array([[ 243.99486949,   11.04572682,  -10.16711028],
                        [  11.04572682,    2.13183469,   -1.08467261],
                        [ -10.16711028,   -1.08467261,    0.67018062]]) 
-        np.testing.assert_array_almost_equal(reg.vm, vm, 7)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
 
     def test_white(self):
         reg = BaseTSLS(self.y, self.X, self.yd, self.q, robust='white')
         betas = np.array([[ 88.46579584], [  0.5200379 ], [ -1.58216593]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         vm = np.array([[ 208.27139316,   15.6687805 ,  -11.53686154],
                        [  15.6687805 ,    2.26882747,   -1.30312033],
                        [ -11.53686154,   -1.30312033,    0.81940656]]) 
-        np.testing.assert_array_almost_equal(reg.vm, vm, 7)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
 
     def test_hac(self):
         gwk = pysal.kernelW_from_shapefile(pysal.examples.get_path('columbus.shp'),k=15,function='triangular', fixed=False)
         reg = BaseTSLS(self.y, self.X, self.yd, self.q, robust='hac', gwk=gwk)
         betas = np.array([[ 88.46579584], [  0.5200379 ], [ -1.58216593]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         vm = np.array([[ 231.07254978,   15.42050291,  -11.3941033 ],
                        [  15.01376346,    1.92422887,   -1.11865505],
                        [ -11.34381641,   -1.1279227 ,    0.72053806]]) 
-        np.testing.assert_array_almost_equal(reg.vm, vm, 7)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
 
 class TestTSLS(unittest.TestCase):
     def setUp(self):
@@ -123,105 +123,106 @@ class TestTSLS(unittest.TestCase):
     def test_basic(self):
         reg = TSLS(self.y, self.X, self.yd, self.q)
         betas = np.array([[ 88.46579584], [  0.5200379 ], [ -1.58216593]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         h_0 = np.array([  1.   ,  19.531,   5.03 ])
-        np.testing.assert_array_almost_equal(reg.h.toarray()[0], h_0)
+        np.testing.assert_allclose(reg.h.toarray()[0], h_0)
         hth = np.array([[    49.        ,    704.371999  ,    139.75      ],
                         [   704.371999  ,  11686.67338121,   2246.12800625],
                         [   139.75      ,   2246.12800625,    498.5851    ]])
-        np.testing.assert_array_almost_equal(reg.hth, hth, 7)
+        np.testing.assert_allclose(reg.hth, hth,RTOL)
         hthi = np.array([[ 0.1597275 , -0.00762011, -0.01044191],
                         [-0.00762011,  0.00100135, -0.0023752 ],
                         [-0.01044191, -0.0023752 ,  0.01563276]]) 
-        np.testing.assert_array_almost_equal(reg.hthi, hthi, 7)
+        np.testing.assert_allclose(reg.hthi, hthi,RTOL)
         self.assertEqual(reg.k, 3)
         self.assertEqual(reg.kstar, 1)
-        self.assertAlmostEqual(reg.mean_y, 35.128823897959187, 7)
+        np.testing.assert_allclose(reg.mean_y, 35.128823897959187,RTOL)
         self.assertEqual(reg.n, 49)
         pfora1a2 = np.array([[ 9.58156106, -0.22744226, -0.13820537],
                              [ 0.02580142,  0.08226331, -0.03143731],
                              [-3.13896453, -0.33487872,  0.20690965]]) 
-        np.testing.assert_array_almost_equal(reg.pfora1a2, pfora1a2, 7)
+        np.testing.assert_allclose(reg.pfora1a2, pfora1a2,RTOL)
         predy_5 = np.array([[-28.68949467], [ 28.99484984], [ 55.07344824], [ 38.26609504], [ 57.57145851]]) 
-        np.testing.assert_array_almost_equal(reg.predy[0:5], predy_5, 7)
+        np.testing.assert_allclose(reg.predy[0:5], predy_5,RTOL)
         q_5 = np.array([[ 5.03], [ 4.27], [ 3.89], [ 3.7 ], [ 2.83]])
         np.testing.assert_array_equal(reg.q[0:5], q_5)
-        self.assertAlmostEqual(reg.sig2n_k, 587.56797852699822, 7)
-        self.assertAlmostEqual(reg.sig2n, 551.5944288212637, 7)
-        self.assertAlmostEqual(reg.sig2, 551.5944288212637, 7)
-        self.assertAlmostEqual(reg.std_y, 16.732092091229699, 7)
+        np.testing.assert_allclose(reg.sig2n_k, 587.56797852699822,RTOL)
+        np.testing.assert_allclose(reg.sig2n, 551.5944288212637,RTOL)
+        np.testing.assert_allclose(reg.sig2, 551.5944288212637,RTOL)
+        np.testing.assert_allclose(reg.std_y, 16.732092091229699,RTOL)
         u_5 = np.array([[ 44.41547467], [-10.19309584], [-24.44666724], [ -5.87833504], [ -6.83994851]]) 
-        np.testing.assert_array_almost_equal(reg.u[0:5], u_5, 7)
-        self.assertAlmostEqual(reg.utu, 27028.127012241919, 7)
+        np.testing.assert_allclose(reg.u[0:5], u_5,RTOL)
+        np.testing.assert_allclose(reg.utu, 27028.127012241919,RTOL)
         varb = np.array([[ 0.41526237,  0.01879906, -0.01730372],
                          [ 0.01879906,  0.00362823, -0.00184604],
                          [-0.01730372, -0.00184604,  0.0011406 ]]) 
-        np.testing.assert_array_almost_equal(reg.varb, varb, 7)
+        np.testing.assert_allclose(reg.varb, varb,RTOL)
         vm = np.array([[ 229.05640809,   10.36945783,   -9.54463414],
                        [  10.36945783,    2.0013142 ,   -1.01826408],
                        [  -9.54463414,   -1.01826408,    0.62914915]]) 
-        np.testing.assert_array_almost_equal(reg.vm, vm, 7)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
         x_0 = np.array([  1.   ,  19.531])
-        np.testing.assert_array_almost_equal(reg.x.toarray()[0], x_0, 7)
+        np.testing.assert_allclose(reg.x.toarray()[0], x_0,RTOL)
         y_5 = np.array([[ 15.72598 ], [ 18.801754], [ 30.626781], [ 32.38776 ], [ 50.73151 ]]) 
-        np.testing.assert_array_almost_equal(reg.y[0:5], y_5, 7)
+        np.testing.assert_allclose(reg.y[0:5], y_5,RTOL)
         yend_5 = np.array([[ 80.467003], [ 44.567001], [ 26.35    ], [ 33.200001], [ 23.225   ]]) 
-        np.testing.assert_array_almost_equal(reg.yend[0:5], yend_5, 7)
+        np.testing.assert_allclose(reg.yend[0:5], yend_5,RTOL)
         z_0 = np.array([  1.      ,  19.531   ,  80.467003]) 
-        np.testing.assert_array_almost_equal(reg.z.toarray()[0], z_0, 7)
+        np.testing.assert_allclose(reg.z.toarray()[0], z_0,RTOL)
         zthhthi = np.array([[  1.00000000e+00,  -1.66533454e-16,   4.44089210e-16],
                             [  0.00000000e+00,   1.00000000e+00,   0.00000000e+00],
                             [  1.26978671e+01,   1.05598709e+00,   3.70212359e+00]]) 
-        np.testing.assert_array_almost_equal(reg.zthhthi, zthhthi, 7)
-        self.assertAlmostEqual(reg.pr2, 0.27936137128173893, 7)
+        # np.testing.assert_allclose(reg.zthhthi, zthhthi,RTOL)
+        np.testing.assert_array_almost_equal(reg.zthhthi, zthhthi,7)
+        np.testing.assert_allclose(reg.pr2, 0.27936137128173893,RTOL)
         z_stat = np.array([[  5.84526447e+00,   5.05764078e-09],
                            [  3.67601567e-01,   7.13170346e-01],
                            [ -1.99468913e+00,   4.60767956e-02]])
-        np.testing.assert_array_almost_equal(reg.z_stat, z_stat, 7)
+        np.testing.assert_allclose(reg.z_stat, z_stat,RTOL)
         title = 'TWO STAGE LEAST SQUARES'
         self.assertEqual(reg.title, title)
         
     def test_n_k(self):
         reg = TSLS(self.y, self.X, self.yd, self.q, sig2n_k=True)
         betas = np.array([[ 88.46579584], [  0.5200379 ], [ -1.58216593]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         vm = np.array([[ 243.99486949,   11.04572682,  -10.16711028],
                        [  11.04572682,    2.13183469,   -1.08467261],
                        [ -10.16711028,   -1.08467261,    0.67018062]]) 
-        np.testing.assert_array_almost_equal(reg.vm, vm, 7)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
 
     def test_white(self):
         reg = TSLS(self.y, self.X, self.yd, self.q, robust='white')
         betas = np.array([[ 88.46579584], [  0.5200379 ], [ -1.58216593]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         vm = np.array([[ 208.27139316,   15.6687805 ,  -11.53686154],
                        [  15.6687805 ,    2.26882747,   -1.30312033],
                        [ -11.53686154,   -1.30312033,    0.81940656]]) 
-        np.testing.assert_array_almost_equal(reg.vm, vm, 7)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
         self.assertEqual(reg.robust, 'white')
 
     def test_hac(self):
         gwk = pysal.kernelW_from_shapefile(pysal.examples.get_path('columbus.shp'),k=5,function='triangular', fixed=False)
         reg = TSLS(self.y, self.X, self.yd, self.q, robust='hac', gwk=gwk)
         betas = np.array([[ 88.46579584], [  0.5200379 ], [ -1.58216593]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         vm = np.array([[ 225.0795089 ,   17.11660041,  -12.22448566],
                        [  17.67097154,    2.47483461,   -1.4183641 ],
                        [ -12.45093722,   -1.40495464,    0.8700441 ]]) 
-        np.testing.assert_array_almost_equal(reg.vm, vm, 7)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
         self.assertEqual(reg.robust, 'hac')
 
     def test_spatial(self):
         w = pysal.queen_from_shapefile(pysal.examples.get_path('columbus.shp'))
         reg = TSLS(self.y, self.X, self.yd, self.q, spat_diag=True, w=w)
         betas = np.array([[ 88.46579584], [  0.5200379 ], [ -1.58216593]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         vm = np.array([[ 229.05640809,   10.36945783,   -9.54463414],
                        [  10.36945783,    2.0013142 ,   -1.01826408],
                        [  -9.54463414,   -1.01826408,    0.62914915]]) 
-        np.testing.assert_array_almost_equal(reg.vm, vm, 7)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
         ak_test = np.array([ 1.16816972,  0.27977763])
-        np.testing.assert_array_almost_equal(reg.ak_test, ak_test, 7)
+        np.testing.assert_allclose(reg.ak_test, ak_test,RTOL)
 
     def test_names(self):
         w = pysal.queen_from_shapefile(pysal.examples.get_path('columbus.shp'))
@@ -238,11 +239,11 @@ class TestTSLS(unittest.TestCase):
                 name_x=name_x, name_y=name_y, name_q=name_q, name_w=name_w,
                 name_yend=name_yend, name_gwk=name_gwk, name_ds=name_ds)
         betas = np.array([[ 88.46579584], [  0.5200379 ], [ -1.58216593]])
-        np.testing.assert_array_almost_equal(reg.betas, betas, 7)
+        np.testing.assert_allclose(reg.betas, betas,RTOL)
         vm = np.array([[ 225.0795089 ,   17.11660041,  -12.22448566],
                        [  17.67097154,    2.47483461,   -1.4183641 ],
                        [ -12.45093722,   -1.40495464,    0.8700441 ]])
-        np.testing.assert_array_almost_equal(reg.vm, vm, 7)
+        np.testing.assert_allclose(reg.vm, vm,RTOL)
         self.assertListEqual(reg.name_x, ['CONSTANT']+name_x)
         self.assertListEqual(reg.name_yend, name_yend)
         self.assertListEqual(reg.name_q, name_q)


### PR DESCRIPTION
For anyone interested, this is what it looks like if we swap 

`assert_array_almost_equal` and `assertAlmostEqual` to using `numpy.testing.assert_allclose`, with a relative tolerance variable stored in `pysal.common`. 

This pull addresses #491 and #687 

Nearly all tests pass at a relative tolerance of 1e-5. The few that do not require use of 1e-4. So, that's a precision of +/-1 every 10k. 

Some issues in tsls remain unresolved, and are likely to not be resolvable using relative tolerance alone, since the values being compared are O(1e-16), and we're comparing them to zero. 