### PR TITLE
precommit hook

### DIFF
--- a/pysal/contrib/githooks/pre-commit
+++ b/pysal/contrib/githooks/pre-commit
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+NOCHANGE='^pysal/spreg'
+git diff --cached --name-only | grep -E $NOCHANGE && \
+    echo "COMMIT REJECTED: Contains changes to pysal/spreg." && exit 1
+exit 0


### PR DESCRIPTION
This is one potential way to address #705 in a pre-commit hook. 

With this added to `.git/hooks`, any commit that touches `spreg` is caught and rejected, unless the hooks are explicitly skipped with `git commit --no-verify`. 

In addition, we can run something like this in travis to echo in the log when offending changes occurs. 
If we just want to reject these kinds of commits out of hand, something very much like this hook could get run in `.travis.yml`. 

I don't think travis supports very rich notifications in Github, so I don't know if there's another state besides "error" or "fail" that we could use to flag an offending commit.