### PR TITLE
Travis fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ virtualenv:
 before_install:
   - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
-  - ./miniconda.sh -b -p ./mc
-  - export PATH=`pwd`/mc/bin:$PATH
+  - ./miniconda.sh -b -p ./miniconda
+  - export PATH=`pwd`/miniconda/bin:$PATH
   - conda update --yes conda
   - conda create -y -q -n test-env python=$TRAVIS_PYTHON_VERSION
   - source activate test-env

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ python:
   - 2.7
   #- "2.6"
   # - 3.4
-env:
-  - SCIPY_VERSION="deb http://us.archive.ubuntu.com/ubuntu/ precise main universe"
-  - SCIPY_VERSION="deb http://us.archive.ubuntu.com/ubuntu/ trusty main universe"
 
 virtualenv:
   system_site_packages: true
@@ -17,8 +14,8 @@ virtualenv:
 before_install:
   - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
-  - ./miniconda.sh -b
-  - export PATH=/home/travis/miniconda/bin:$PATH
+  - ./miniconda.sh -b -p ./mc
+  - export PATH=`pwd`/mc/bin:$PATH
   - conda update --yes conda
   - conda create -y -q -n test-env python=$TRAVIS_PYTHON_VERSION
   - source activate test-env


### PR DESCRIPTION
This cleans up two things in our testing. 

1. We're using `conda` for scipy, not `apt`,  so setting the Ubuntu scipy repository via a `virtualenv` option is not changing the scipy we install. Here's a recent merge. The scipy used in both testing runs is `0.16.0`, since it's grabbed by anaconda: 
    - [scipy for `trusty`](https://travis-ci.org/pysal/pysal/jobs/84195219#L300)
    - [scpiy for `precise`](https://travis-ci.org/pysal/pysal/jobs/84195214#L300)
2. Travis [recommends not using](http://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables) the location of `/home/travis` as known. So, we can get around this by installing anaconda to a known prefix, `./miniconda`, and then using `pwd` to extend our path.