### PR TITLE
Enh712

### DIFF
--- a/pysal/weights/tests/test_util.py
+++ b/pysal/weights/tests/test_util.py
@@ -55,6 +55,13 @@ class Testutil(unittest.TestCase):
         wn = {0: [1], 1: [0], 2: [3], 3: [2], 4: [5, 8], 5: [4, 8],
               6: [7], 7: [6], 8: [4, 5]}
         self.assertEquals(w.neighbors, wn)
+        ids = ['id-%i'%i for i in range(len(regimes))]
+        w = pysal.block_weights(regimes, ids=np.array(ids))
+        w0 = {'id-1': 1.0}
+        self.assertEquals(w['id-0'], w0)
+        w = pysal.block_weights(regimes, ids=ids)
+        w0 = {'id-1': 1.0}
+        self.assertEquals(w['id-0'], w0)
 
     def test_comb(self):
         x = range(4)

--- a/pysal/weights/util.py
+++ b/pysal/weights/util.py
@@ -251,7 +251,7 @@ def regime_weights(regimes):
 
 
 
-def block_weights(regimes):
+def block_weights(regimes, ids=None, sparse=False):
     """
     Construct spatial weights for regime neighbors.
 
@@ -262,8 +262,13 @@ def block_weights(regimes):
 
     Parameters
     ----------
-    regimes : list, array
-           ids of which regime an observation belongs to
+    regimes     : list, array
+                  ids of which regime an observation belongs to
+    ids         : list, array
+                  Ordered sequence of IDs for the observations
+    sparse      : boolean
+                  If True return WSP instance
+                  If False return W instance
 
     Returns
     -------
@@ -300,7 +305,12 @@ def block_weights(regimes):
         members = NPNZ(regimes == rid)[0]
         for member in members:
             neighbors[member] = members[NPNZ(members != member)[0]].tolist()
-    return pysal.weights.W(neighbors)
+    w = pysal.weights.W(neighbors)
+    if ids is not None:
+        w.remap_ids(ids)
+    if sparse:
+        w = pysal.weights.WSP(w.sparse, id_order=ids)
+    return w
 
 
 def comb(items, n=None):


### PR DESCRIPTION
This PR implements the enhancement specified in #712. Instead of `idVariable`, it is called `ids` because it isn't exactly the same argument: `idVariable` in the rest of the code base is the column name in the DBF, while here you need to pass the actual sequence of ids, hence the name `ids`. Other than that, it behaves in the same say.

There is also the optional argument `sparse`, which works as in `XXX_from_shapefile` by giving the user the option to obtain a `WSP` object instead.

The PR includes a unit test to make sure passing the ids as either a list or an array works as expected.