### PR TITLE
force counts to be same length as bins

### DIFF
--- a/pysal/esda/mapclassify.py
+++ b/pysal/esda/mapclassify.py
@@ -247,7 +247,7 @@ def bin1d(x, bins):
         k -= 1
         l, r = cuts.pop(-1)
         binIds += (x > l) * (x <= r) * k
-    counts = np.bincount(binIds)
+    counts = np.bincount(binIds, minlength=len(bins))
     return (binIds, counts)
 
 


### PR DESCRIPTION
This forces `User_Defined` to provide bin counts for all bins, and not omit zero-count bins at the tail of the distribution. 