### PR TITLE
try pinning scipy,numpy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - source activate test-env
 
 install:
-  - conda install --yes numpy scipy nose pip
+  - conda install --yes numpy=1.10.2 scipy=0.16.0 nose pip
   - pip install -r travis.txt
 
 script: 


### PR DESCRIPTION
Pinning to scipy `0.16.0` and numpy `1.10.2`, even though floating numpy will likely not change things. 
 Will file an issue to maintain/assess `scipy` going forward