### PR TITLE
Geodf io

### DIFF
--- a/pysal/__init__.py
+++ b/pysal/__init__.py
@@ -84,6 +84,11 @@ import pysal.spreg
 import pysal.examples
 from pysal.network.network import Network, NetworkG, NetworkK, NetworkF
 
+try:
+    import pandas
+    from pysal.contrib import pdutilities as pdio
+except ImportError:
+    print('Pandas adapters not loaded')
 
 # Load the IOHandlers
 from pysal.core import IOHandlers

--- a/pysal/contrib/pdutilities/__init__.py
+++ b/pysal/contrib/pdutilities/__init__.py
@@ -1,0 +1,4 @@
+import dbf_utilities as dbio
+import shp_utilities as shio
+import file_utilities as fio
+from file_utilities import read_files, write_files

--- a/pysal/contrib/pdutilities/dbf_utilities.py
+++ b/pysal/contrib/pdutilities/dbf_utilities.py
@@ -106,9 +106,6 @@ def df2dbf(df, dbf_path, my_specs=None):
     db.close()
     return dbf_path
 
-
-
-    
 def dbf2df(dbf_path, index=None, cols=False, incl_index=False):
     '''
     Read a dbf file as a pandas.DataFrame, optionally selecting the index
@@ -218,4 +215,3 @@ def dta2dbf(dta_path,dbf_path):
     db = pd.read_stata(dta_path)
     dp = df2dbf(db,dbf_path)
     return dp    
-    

--- a/pysal/contrib/pdutilities/file_utilities.py
+++ b/pysal/contrib/pdutilities/file_utilities.py
@@ -49,10 +49,10 @@ def write_files(df, filepath, **kwargs):
         dbf_out = df2dbf(df[not_geom], dbf_path, **kwargs)
         if hasattr(df, 'W'):
             W_path = os.path.splitext(filepath)[0] + '.' + weights
-            ps.open(W_path).write(df.W)
+            ps.open(W_path, 'w').write(df.W)
         else:
             W_path = 'no weights written'
-        return outshp, outdbf, W_path
+        return dbf_out, shp_out, W_path
             
 
 

--- a/pysal/contrib/pdutilities/file_utilities.py
+++ b/pysal/contrib/pdutilities/file_utilities.py
@@ -1,0 +1,65 @@
+import pysal as ps
+import os
+from shp_utilities import shp2series, series2shp
+from dbf_utilities import dbf2df, df2dbf
+
+
+def read_files(filepath, **kwargs):
+    """
+    Reads a dbf/shapefile pair, squashing geometries into a "geometry" column.
+    """
+    #keyword arguments wrapper will strip all around dbf2df's required arguments
+    geomcol = kwargs.pop('geomcol', 'geometry')
+    weights = kwargs.pop('weights', '')
+    
+    dbf_path, shp_path = _pairpath(filepath)
+
+    df = dbf2df(dbf_path, **kwargs)
+    df[geomcol] = shp2series(shp_path)
+
+    if weights != '' and isinstance(weights, str):
+        if weights.lower() in ['rook', 'queen']:
+            if weights.lower() == 'rook':
+                df.W = ps.rook_from_shapefile(shp_path)
+            else:
+                df.W = ps.queen_from_shapefile(shp_path)
+        else:
+            try:
+                W_path = os.path.splitext(dbf_path)[0] + '.' + weights
+                df.W = ps.open(W_path).read()
+            except IOError:
+                print('Weights construction failed! Passing on weights')
+    
+    return df
+   
+def write_files(df, filepath, **kwargs):
+    """
+    writes dataframes with potential geometric components out to files. 
+    """
+    geomcol = kwargs.pop('geomcol', 'geometry')
+    weights = kwargs.pop('weights', 'gal')
+    
+    dbf_path, shp_path = _pairpath(filepath)
+
+    if geomcol not in df.columns:
+        return df2dbf(df, dbf_path, **kwargs)
+    else:
+        shp_out = series2shp(df[geomcol], shp_path)
+        not_geom = [x for x in df.columns if x != geomcol]
+        dbf_out = df2dbf(df[not_geom], dbf_path, **kwargs)
+        if hasattr(df, 'W'):
+            W_path = os.path.splitext(filepath)[0] + '.' + weights
+            ps.open(W_path).write(df.W)
+        else:
+            W_path = 'no weights written'
+        return outshp, outdbf, W_path
+            
+
+
+def _pairpath(filepath):
+    """
+    return dbf/shp paths for any shp, dbf, or basepath passed to function. 
+    """
+    base = os.path.splitext(filepath)[0]
+    return base + '.dbf', base + '.shp'
+    

--- a/pysal/contrib/pdutilities/shp_utilities.py
+++ b/pysal/contrib/pdutilities/shp_utilities.py
@@ -1,0 +1,16 @@
+import pandas as pd
+import pysal as ps
+
+def shp2series(filepath):
+    """
+    reads a shapefile, stuffing each shape into an element of a Pandas Series
+    """
+    return pd.Series(poly for poly in ps.open(filepath))
+
+def series2shp(series, filepath):
+    """
+    writes a series of pysal polygons to a file
+    """
+    f = ps.open(filepath, 'w')
+    for poly in series:
+        f.write(poly)

--- a/pysal/contrib/pdutilities/shp_utilities.py
+++ b/pysal/contrib/pdutilities/shp_utilities.py
@@ -5,7 +5,10 @@ def shp2series(filepath):
     """
     reads a shapefile, stuffing each shape into an element of a Pandas Series
     """
-    return pd.Series(poly for poly in ps.open(filepath))
+    f = ps.open(filepath)
+    s = pd.Series(poly for poly in f)
+    f.close()
+    return s
 
 def series2shp(series, filepath):
     """
@@ -14,3 +17,5 @@ def series2shp(series, filepath):
     f = ps.open(filepath, 'w')
     for poly in series:
         f.write(poly)
+    f.close()
+    return filepath


### PR DESCRIPTION
This includes a number of new pandas tools for shapefile IO. They're loaded in `pysal.contrib.pdio`.

Since these are explicitly paired to our shapefile readers, they only go shapfile-to-dataframe and dataframe-to-shapefile using our IO. I've also got IO-swapped geopandas sitting [here](https://github.com/ljwolf/pysal/tree/geodf/pysal/contrib/geodf), but this (I think) gets us closest to what we want in the smallest amount of code, a raw pandas dataframe, filled with properties & pysal shapes. 

