### PR TITLE
[REBASED]: Update moran.py with much faster iterations

### DIFF
--- a/pysal/esda/moran.py
+++ b/pysal/esda/moran.py
@@ -671,15 +671,17 @@ class Moran_Local:
         prange = range(self.permutations)
         k = self.w.max_neighbors + 1
         nn = self.n - 1
-        rids = np.array([np.random.permutation(nn)[0:k] for i in prange])
+        rids = np.random.randint(0, np.minimum(nn, self.permutations), (np.minimum(nn, self.permutations), k))
         ids = np.arange(self.w.n)
         ido = self.w.id_order
         w = [self.w.weights[ido[i]] for i in ids]
         wc = [self.w.cardinalities[ido[i]] for i in ids]
 
         for i in xrange(self.w.n):
-            idsi = ids[ids != i]
-            np.random.shuffle(idsi)
+            idsi = np.random.choice(
+                ids[ids != i], 
+                np.minimum(nn, self.permutations)
+               )
             tmp = z[idsi[rids[:, 0:wc[i]]]]
             lisas[i] = z[i] * (w[i] * tmp).sum(1)
         self.rlisas = (n_1 / self.den) * lisas


### PR DESCRIPTION
From @andrewxhill, rebasing #732 onto PySAL 1.11. 

The rebase still appears to be failing/erroring out on some [moran-related tests](https://travis-ci.org/ljwolf/pysal/jobs/109445428), but those could just be plumbing issues. 

> Here is an interesting optimization that @ohasselblad and I have been toying with. Basically, it takes into effect that fact that you are shuffling (at times very large) arrays for every iteration of the loop. When in reality, you should be limiting your necessary shuffle to only the number of permutations or the length of the array, whichever is less.
> 
> since it uses the magic of index pointers in numpy, the choice sample will still act across the entire population, while the rids points to that new subsample instead.