### PR TITLE
docs fix: incorrect array dimensions listed for spatial interaction SpaceTimeEvents

### DIFF
--- a/pysal/spatial_dynamics/interaction.py
+++ b/pysal/spatial_dynamics/interaction.py
@@ -47,10 +47,10 @@ class SpaceTimeEvents:
     t               : array
                       (n, 1), array of the temporal coordinates for the events.
     space           : array
-                      (n, 1), array of the spatial coordinates (x,y) for the
+                      (n, 2), array of the spatial coordinates (x,y) for the
                       events.
     time            : array
-                      (n, 1), array of the temporal coordinates (t,1) for the
+                      (n, 2), array of the temporal coordinates (t,1) for the
                       events, the second column is a vector of ones.
 
     Examples


### PR DESCRIPTION
Doing this
```python
>>> import pysal as ps
>>> import pysal.spatial_dynamics.interaction as interaction
>>> path = ps.examples.get_path('burkitt.shp')
>>> events = interaction.SpaceTimeEvents(path, 'T')
>>> print (events.space).shape
(188, 2)
>>> print (events.time).shape
(188, 2)
```

Gives array dimensions of `(n, 2)` instead of `(n, 1)` as [listed in the docs](https://github.com/pysal/pysal/blob/dev/pysal/spatial_dynamics/interaction.py#L49-L54).