### PR TITLE
Modified the way area of a ring is calculated to allow for more precision

### DIFF
--- a/pysal/cg/shapes.py
+++ b/pysal/cg/shapes.py
@@ -1280,7 +1280,7 @@ class Ring(object):
                 A += (x[i] + x[i + 1]) * \
                     (y[i] - y[i + 1])
             A = A * 0.5
-            self._area = A
+            self._area = -A
         return self._area
 
     @property
@@ -1306,11 +1306,16 @@ class Ring(object):
             vertices = self.vertices
             x = [v[0] for v in vertices]
             y = [v[1] for v in vertices]
-            N = len(self) - 1
-            
-            cx = sum(x[:-1]) * 1.0 / N
-            cy = sum(y[:-1]) * 1.0 / N
-            
+            A = self.signed_area
+            N = len(self)
+            cx = 0
+            cy = 0
+            for i in xrange(N - 1):
+                f = (x[i] * y[i + 1] - x[i + 1] * y[i])
+                cx += (x[i] + x[i + 1]) * f
+                cy += (y[i] + y[i + 1]) * f
+            cx = 1.0 / (6 * A) * cx
+            cy = 1.0 / (6 * A) * cy
             self._centroid = Point((cx, cy))
         return self._centroid
 

--- a/pysal/cg/shapes.py
+++ b/pysal/cg/shapes.py
@@ -1277,8 +1277,9 @@ class Ring(object):
 
             A = 0.0
             for i in xrange(N - 1):
-                A += (x[i] * y[i + 1] - x[i + 1] * y[i])
-            A = A / 2.0
+                A += (x[i] + x[i + 1]) * \
+                    (y[i] - y[i + 1])
+            A = A * 0.5
             self._area = A
         return self._area
 

--- a/pysal/cg/shapes.py
+++ b/pysal/cg/shapes.py
@@ -1198,7 +1198,7 @@ class Ring(object):
     """
     def __init__(self, vertices):
         if vertices[0] != vertices[-1]:
-            vertices = vertices[:] + vertices[0:1]
+            vertices = vertices[:] + vertices[0]
             #raise ValueError, "Supplied vertices do not form a closed ring, the first and last vertices are not the same"
         self.vertices = tuple(vertices)
         self._perimeter = None
@@ -1306,16 +1306,11 @@ class Ring(object):
             vertices = self.vertices
             x = [v[0] for v in vertices]
             y = [v[1] for v in vertices]
-            A = self.signed_area
-            N = len(self)
-            cx = 0
-            cy = 0
-            for i in xrange(N - 1):
-                f = (x[i] * y[i + 1] - x[i + 1] * y[i])
-                cx += (x[i] + x[i + 1]) * f
-                cy += (y[i] + y[i + 1]) * f
-            cx = 1.0 / (6 * A) * cx
-            cy = 1.0 / (6 * A) * cy
+            N = len(self) - 1
+            
+            cx = sum(x[:-1]) * 1.0 / N
+            cy = sum(y[:-1]) * 1.0 / N
+            
             self._centroid = Point((cx, cy))
         return self._centroid
 

--- a/pysal/cg/shapes.py
+++ b/pysal/cg/shapes.py
@@ -1198,7 +1198,7 @@ class Ring(object):
     """
     def __init__(self, vertices):
         if vertices[0] != vertices[-1]:
-            vertices = vertices[:] + vertices[0]
+            vertices = vertices[:] + vertices[0:1]
             #raise ValueError, "Supplied vertices do not form a closed ring, the first and last vertices are not the same"
         self.vertices = tuple(vertices)
         self._perimeter = None


### PR DESCRIPTION
#767 : The problem is when the area of a ring is calculated: Precision is lost somehow and area becomes 0 for very small rings. This problem does not occur when the area of a Polygon is calculated which contains this single ring (the method used is different and retains precision). Hence the same method can be used to calculate the area of a ring.