### PR TITLE
adding github chrome to make project contributions easier to handle

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,2 @@
+Thank you for your interest in contributing! We work primarily on Github. Please
+review the [contributing procedures](https://github.com/pysal/pysal/wiki/GitHub-Standard-Operating-Procedures) so that we can accept your contributions! Alternatively, contact someone in the [development chat channel](https://gitter.im/pysal.pysal).

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,30 @@
+Thank you for filing this issue! To help troubleshoot this issue, please follow
+the following directions to the best of your ability before submitting an issue.
+Feel free to delete this text once you've filled out the relevant requests. 
+
+Please include the output of the following in your issue submission. If you don't know how to provide the information, commands to get the relevant information from the Python interpreter will follow each bullet point.
+
+Feel free to delete the commands after you've filled out each bullet. 
+
+- Platform information:
+```python
+>>> import os; print(os.name, os.sys.platform);print(os.uname())
+```
+- Python version: 
+```python
+>>> import sys; print(sys.version)
+```
+- SciPy version:
+```python
+>>> import scpiy; print(scipy.__version__)
+```
+- NumPy version:
+```python
+>>> import numpy; print(numpy.__version__)
+```
+
+Also, please upload any relevant data as [a file
+attachment](https://help.github.com/articles/file-attachments-on-issues-and-pull-requests/). Please **do not** upload pickled objects, since it's nearly impossible to troubleshoot them without replicating your exact namespace. Instead, provide the minimal subset of the data required to replicate the problem. If it makes you more comfortable submitting the issue, feel free to:
+
+1. remove personally identifying information from data or code
+2. provide only the required subset of the full data or code 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+Hello! Please make sure to check all these boxes before submitting a Pull Request
+(PR). Once you have checked the boxes, feel free to remove all text except the
+justification in point 5. 
+
+1. [ ] You have run tests on this submission, either by using [Travis Continuous Integration testing](https://github.com/pysal/pysal/wiki/GitHub-Standard-Operating-Procedures#automated-testing-w-travis-ci) testing or running `nosetests` on your changes?
+2. [ ] This pull request is directed to the `pysal/dev` branch.
+3. [ ] This pull introduces new functionality covered by
+   [docstrings](https://en.wikipedia.org/wiki/Docstring#Python) and
+   [unittests](https://docs.python.org/2/library/unittest.html)? 
+4. [ ] You have [assigned a
+   reviewer](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) and added relevant [labels](https://help.github.com/articles/applying-labels-to-issues-and-pull-requests/)
+5. [ ] The justification for this PR is: 


### PR DESCRIPTION
This is a stab at exploiting the [new tools](https://github.com/blog/2111-issue-and-pull-request-templates) provided by github to make contributing to projects easier. 

I've included an Issue template, a PR template, and a CONTRIBUTING.md that links to our Github Standard Operating Procedures page. 

We can turn this off if it's too cumbersome, or edit it down if it's too wordy. 

For the issue template, I took the directions from the pysal readthedocs page on submitting an issue. 

For the PR template, I just provided common questions on PRs. 