### PR TITLE
fix minor issues with using stdlib warnings in mapclassify.py

### DIFF
--- a/pysal/esda/mapclassify.py
+++ b/pysal/esda/mapclassify.py
@@ -135,12 +135,12 @@ def binC(y, bins):
     for i, bin in enumerate(bins):
         b[np.nonzero(y == bin)] = i
 
-    # check for non-binned items and print a warning if needed
+    # check for non-binned items and warn if needed
     vals = set(y.flatten())
     for val in vals:
         if val not in bins:
-            print('warning: value not in bin: '.format(val))
-            print('bins: {}'.format(bins))
+            Warn('value not in bin: {}'.format(val), UserWarning)
+            Warn('bins: {}'.format(bins), UserWarning)
 
     return b
 


### PR DESCRIPTION
I guess some stuff got left off of #776. This is noncritical, but should be merged eventually. 