### PR TITLE
fixing KDTree/cKDTree changes to API & adding ckdtree to Arc_KDTree

### DIFF
--- a/pysal/weights/Distance.py
+++ b/pysal/weights/Distance.py
@@ -11,11 +11,11 @@ from pysal.common import KDTree
 from pysal.weights import W
 import scipy.stats
 import numpy as np
+from util import isKDTree
 
 __all__ = ["knnW", "Kernel", "DistanceBand"]
 
-
-def knnW(kdtree, k=2, p=2, ids=None):
+def knnW(data, k=2, p=2, ids=None):
     """
     Creates nearest neighbor weights matrix based on k nearest
     neighbors.
@@ -82,8 +82,12 @@ def knnW(kdtree, k=2, p=2, ids=None):
     pysal.weights.W
 
     """
-    data = kdtree.data
-    nnq = kdtree.query(data, k=k+1, p=p)
+    if isKDTree(data):
+        kdt = data
+        data = kdt.data
+    else:
+        kdt = KDTree(data)
+    nnq = kdt.query(data, k=k+1, p=p)
     info = nnq[1]
 
     neighbors = {}
@@ -264,7 +268,7 @@ class Kernel(W):
     def __init__(self, data, bandwidth=None, fixed=True, k=2,
                  function='triangular', eps=1.0000001, ids=None,
                  diagonal=False):
-        if issubclass(type(data), scipy.spatial.KDTree):
+        if isKDTree(data):
             self.kdt = data
             self.data = self.kdt.data
             data = self.data
@@ -357,7 +361,7 @@ class Kernel(W):
             c = c ** (-0.5)
             self.kernel = [c * np.exp(-(zi ** 2) / 2.) for zi in zs]
         else:
-            print 'Unsupported kernel function', self.function
+            print('Unsupported kernel function', self.function)
 
 
 class DistanceBand(W):
@@ -452,7 +456,7 @@ class DistanceBand(W):
         See detail in pysal issue #126.
 
         """
-        if issubclass(type(data), scipy.spatial.KDTree):
+        if isKDTree(data):
             self.kd = data
             self.data = self.kd.data
         else:

--- a/pysal/weights/util.py
+++ b/pysal/weights/util.py
@@ -15,6 +15,8 @@ __all__ = ['lat2W', 'block_weights', 'comb', 'order', 'higher_order',
            'higher_order_sp', 'hexLat2W', 'regime_weights']
 
 
+KDTREE_TYPES = [scipy.spatial.KDTree, scipy.spatial.cKDTree]
+
 def hexLat2W(nrows=5, ncols=5):
     """
     Create a W object for a hexagonal lattice.
@@ -1255,6 +1257,13 @@ def neighbor_equality(w1, w2):
         if set(w1.neighbors[i]) != set(w2.neighbors[i]):
             return False
     return True
+
+def isKDTree(obj):
+    """
+    This is a utility function to determine whether or not an object is a
+    KDTree, since KDTree and cKDTree have no common parent type
+    """
+    return any([issubclass(type(obj), KDTYPE) for KDTYPE in KDTREE_TYPES])
 
 if __name__ == "__main__":
     from pysal import lat2W


### PR DESCRIPTION
This incorporates @dfolch and @ljwolf's changes (in #773 & #659). 

First, we raise warnings when a user is passing arrays rather than kdtrees. This is to avoid breaking current doctests & notebooks, but still provide warnings to get users to do the correct thing when needed. This is a selection from #773 

Second, the changes to `Arc_KDTree` takee advantage potential speedups in `ckdtree` if it's available. But, since `cKDTree` and `KDTree` have no common supertype aside from `object`, we need to have more robust testing in `weights` to pick the correct function. This is a selection from #659 