### PR TITLE
Local Moran was using the incorrect moments in z_sim and p_z_sim

### DIFF
--- a/pysal/esda/moran.py
+++ b/pysal/esda/moran.py
@@ -309,7 +309,7 @@ class Moran_BV:
         self.zx = zx
         self.zy = zy
         n = x.shape[0]
-        self.den =  n - 1.  # zx'zx = zy'zy = n-1
+        self.den = n - 1.  # zx'zx = zy'zy = n-1
         w.transform = transformation
         self.w = w
         self.I = self.__calc(zy)
@@ -568,21 +568,21 @@ class Moran_Local:
                    alternative: the observed Ii is further away or extreme
                    from the median of simulated values. It is either extremelyi
                    high or extremely low in the distribution of simulated Is.
-    EI_sim       : float
+    EI_sim       : array
                    (if permutations>0)
-                   average value of I from permutations
-    VI_sim       : float
+                   average values of local Is from permutations
+    VI_sim       : array
                    (if permutations>0)
-                   variance of I from permutations
-    seI_sim      : float
+                   variance of Is from permutations
+    seI_sim      : array
                    (if permutations>0)
-                   standard deviation of I under permutations.
-    z_sim        : float
+                   standard deviations of Is under permutations.
+    z_sim        : arrray
                    (if permutations>0)
-                   standardized I based on permutations
-    p_z_sim      : float
+                   standardized Is based on permutations
+    p_z_sim      : array
                    (if permutations>0)
-                   p-value based on standard normal approximation from
+                   p-values based on standard normal approximation from
                    permutations (one-sided)
                    for two-sided tests, these values should be multiplied by 2
 
@@ -598,7 +598,7 @@ class Moran_Local:
     >>> lm.q
     array([4, 4, 4, 2, 3, 3, 1, 4, 3, 3])
     >>> lm.p_z_sim[0]
-    0.46756830387716064
+    0.24669152541631179
     >>> lm = ps.Moran_Local(y, w, transformation = "r", permutations = 99, \
                             geoda_quads=True)
     >>> lm.q
@@ -642,8 +642,8 @@ class Moran_Local:
             larger[low_extreme] = self.permutations - larger[low_extreme]
             self.p_sim = (larger + 1.0) / (permutations + 1.0)
             self.sim = sim
-            self.EI_sim = sim.mean()
-            self.seI_sim = sim.std()
+            self.EI_sim = sim.mean(axis=0)
+            self.seI_sim = sim.std(axis=0)
             self.VI_sim = self.seI_sim * self.seI_sim
             self.z_sim = (self.Is - self.EI_sim) / self.seI_sim
             self.p_z_sim = 1 - stats.norm.cdf(np.abs(self.z_sim))
@@ -750,23 +750,24 @@ class Moran_Local_BV:
                    alternative: the observed Ii is further away or extreme
                    from the median of simulated values. It is either extremelyi
                    high or extremely low in the distribution of simulated Is.
-    EI_sim       : float
+    EI_sim       : array
                    (if permutations>0)
-                   average value of I from permutations
-    VI_sim       : float
+                   average values of local Is from permutations
+    VI_sim       : array
                    (if permutations>0)
-                   variance of I from permutations
-    seI_sim      : float
+                   variance of Is from permutations
+    seI_sim      : array
                    (if permutations>0)
-                   standard deviation of I under permutations.
-    z_sim        : float
+                   standard deviations of Is under permutations.
+    z_sim        : arrray
                    (if permutations>0)
-                   standardized I based on permutations
-    p_z_sim      : float
+                   standardized Is based on permutations
+    p_z_sim      : array
                    (if permutations>0)
-                   p-value based on standard normal approximation from
+                   p-values based on standard normal approximation from
                    permutations (one-sided)
                    for two-sided tests, these values should be multiplied by 2
+
 
     Examples
     --------
@@ -830,8 +831,8 @@ class Moran_Local_BV:
             larger[low_extreme] = self.permutations - larger[low_extreme]
             self.p_sim = (larger + 1.0) / (permutations + 1.0)
             self.sim = sim
-            self.EI_sim = sim.mean()
-            self.seI_sim = sim.std()
+            self.EI_sim = sim.mean(axis=0)
+            self.seI_sim = sim.std(axis=0)
             self.VI_sim = self.seI_sim * self.seI_sim
             self.z_sim = (self.Is - self.EI_sim) / self.seI_sim
             self.p_z_sim = 1 - stats.norm.cdf(np.abs(self.z_sim))

--- a/pysal/esda/tests/test_moran.py
+++ b/pysal/esda/tests/test_moran.py
@@ -62,9 +62,8 @@ class Moran_Local_Tester(unittest.TestCase):
     def test_Moran_Local(self):
         lm = moran.Moran_Local(
             self.y, self.w, transformation="r", permutations=99)
-        self.assertAlmostEquals(lm.z_sim[0], -0.081383956359666748)
-        self.assertAlmostEquals(lm.p_z_sim[0], 0.46756830387716064)
-        self.assertAlmostEquals(lm.VI_sim, 0.2067126047680822)
+        self.assertAlmostEquals(lm.z_sim[0], -0.68493799168603808)
+        self.assertAlmostEquals(lm.p_z_sim[0],  0.24669152541631179)
 
 
 class Moran_Local_BV_Tester(unittest.TestCase):
@@ -79,9 +78,8 @@ class Moran_Local_BV_Tester(unittest.TestCase):
         lm = moran.Moran_Local_BV(self.x, self.y, self.w,
                                   transformation="r", permutations=99)
         self.assertAlmostEquals(lm.Is[0], 1.4649221250620736)
-        self.assertAlmostEquals(lm.z_sim[0], 2.9246889997781773)
-        self.assertAlmostEquals(lm.p_z_sim[0], 0.0017240031348827456)
-        self.assertAlmostEquals(lm.VI_sim, 0.24983591065175745)
+        self.assertAlmostEquals(lm.z_sim[0],  1.5816540860500772)
+        self.assertAlmostEquals(lm.p_z_sim[0], 0.056864279811026153)
 
 
 class Moran_Local_Rate_Tester(unittest.TestCase):
@@ -95,13 +93,12 @@ class Moran_Local_Rate_Tester(unittest.TestCase):
     def test_moran_rate(self):
         lm = moran.Moran_Local_Rate(self.e, self.b, self.w,
                                     transformation="r", permutations=99)
-        self.assertAlmostEquals(lm.z_sim[0], -0.27099998923550017)
-        self.assertAlmostEquals(lm.p_z_sim[0], 0.39319552026912641)
-        self.assertAlmostEquals(lm.VI_sim, 0.21879403675396222)
+        self.assertAlmostEquals(lm.z_sim[0], -0.13699844503985936)
+        self.assertAlmostEquals(lm.p_z_sim[0], 0.44551601210081715)
 
 
 suite = unittest.TestSuite()
-test_classes = [Moran_Tester, Moran_Rate_Tester, 
+test_classes = [Moran_Tester, Moran_Rate_Tester,
                 Moran_BV_matrix_Tester, Moran_Local_Tester,
                 Moran_Local_BV_Tester, Moran_Local_Rate_Tester]
 for i in test_classes:


### PR DESCRIPTION
Means and standard errors were taken over all local permutations rather than over the permutations specific to each local value. 