### PR TITLE
DistanceBand should correctly handle named weights

### DIFF
--- a/pysal/weights/Distance.py
+++ b/pysal/weights/Distance.py
@@ -489,8 +489,9 @@ class DistanceBand(W):
         neighbors = dict([(i,[]) for i in ids])
         weights = dict([(i,[]) for i in ids])
         if self.binary:
-            for key,weight in self.dmat.items():
-                i,j = key
+            for idxs,weight in self.dmat.items():
+                idx,jdx = idxs
+                i, j = ids[idx], ids[jdx]
                 if i != j:
                     if j not in neighbors[i]:
                         weights[i].append(1)
@@ -498,10 +499,10 @@ class DistanceBand(W):
                     if i not in neighbors[j]:
                         weights[j].append(1)
                         neighbors[j].append(i)
-
         else:
-            for key,weight in self.dmat.items():
-                i,j = key
+            for idxs,weight in self.dmat.items():
+                idx, jdx = idxs
+                i, j = ids[idx], ids[jdx]
                 if i != j:
                     if j not in neighbors[i]:
                         weights[i].append(weight**self.alpha)
@@ -509,7 +510,6 @@ class DistanceBand(W):
                     if i not in neighbors[j]:
                         weights[j].append(weight**self.alpha)
                         neighbors[j].append(i)
-
         return neighbors, weights
 
 

--- a/pysal/weights/tests/test_Distance.py
+++ b/pysal/weights/tests/test_Distance.py
@@ -2,6 +2,7 @@ import os
 import unittest
 import pysal
 import numpy as np
+from itertools import product
 
 
 class TestDistanceWeights(unittest.TestCase):
@@ -113,6 +114,22 @@ class TestDistanceWeights(unittest.TestCase):
         w1 = pysal.DistanceBand(points1, 1)
         for k in range(w.n):
             self.assertEqual(w[k], w1[k])
+
+    def test_DistanceBand_named(self):
+        w = pysal.rook_from_shapefile(
+                pysal.examples.get_path('lattice10x10.shp'))
+        polygons = pysal.open(
+                pysal.examples.get_path('lattice10x10.shp'),'r').read()
+        points1 = [poly.centroid for poly in polygons]
+        # two-letter names: 'AA', 'AB', .. 'JJ'
+        names = [''.join((chr(65+i), chr(65+j))) for i,j in product(range(10), range(10))]
+        w1 = pysal.DistanceBand(points1, 1, ids=names)
+        for k in range(w.n):
+            #need heaver comparison because looking between named & unnamed
+            name = names[k]
+            self.assertEqual(set(w.weights[k]), set(w1.weights[name]))
+            idxs_as_names = [names[i] for i in w.neighbors[k]]
+            self.assertEqual(set(idxs_as_names), set(w1.neighbors[name]))
 
     def test_DistanceBand_ints(self):
         """ see issue #126 """


### PR DESCRIPTION
1. [X] You have run tests on this submission: [here](https://travis-ci.org/ljwolf/pysal/builds/132917118)
2. [X] This pull request is directed to the `pysal/dev` branch.
3. [X] This pull introduces new functionality covered by
   [docstrings](https://en.wikipedia.org/wiki/Docstring#Python) and
   [unittests](https://docs.python.org/2/library/unittest.html)? 
4. [X] You have [assigned a
   reviewer](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) and added relevant [labels](https://help.github.com/articles/applying-labels-to-issues-and-pull-requests/)
5. [X] The justification for this PR is: 

#810 demonstrates that `DistanceBand` weights construction fails when `ids` is provided. This is done when a user wants to use an external list of ids to build `DistanceBand` weights. 

This fixes #810 by using names instead of indexes for the outputted weights & neighbors dictionaries. This appears to be the original intent of the code, but what is an index is called a `key` by the code. 

