### PR TITLE
[REBASED] PySAL+ optional testing matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install:
   - ./miniconda.sh -b -p ./miniconda
   - export PATH=`pwd`/miniconda/bin:$PATH
   - conda update --yes conda
+  - conda config --add channels conda-forge
   - conda create -y -q -n test-env python=$TRAVIS_PYTHON_VERSION
   - source activate test-env
   - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then 2to3 -nw pysal/ > /dev/null; fi
@@ -25,19 +26,13 @@ before_install:
 install:
   - conda install --yes numpy scipy nose pip
   - if [ "$PYSAL_PLUS" == true ]; then
-        echo 'plus testing'; conda install --yes pandas numexpr numba patsy shapely; fi;
+        echo 'plus testing'; conda install --file requirements_plus.txt;
+        else conda install --file requirements.txt; 
+    fi;
   - pip install -r travis.txt
 
 script: 
-  - python -c 'import numpy; print(numpy.__version__)'
-  - python -c 'import scipy; print(scipy.__version__)'
-  - python setup.py install  >/dev/null
-  - python -c 'import pysal'
-  #- python -c 'import multiprocessing as mp; print mp.cpu_count()'
-  #- pychecker --limit 1000 pysal
   - python setup.py sdist >/dev/null
-  #- nosetests --processes=-1 --process-timeout=60 --verbosity=1 --ignore-files=collection --exclude-dir=pysal/contrib
-  #- nosetests
   - echo "check_stable=False" >pysal/config.py
   - nosetests --with-coverage --cover-package=pysal; 
   #- cd doc; make pickle; make doctest

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,13 @@ branches:
 only:
   - master
 python:
-  - 2.7
-  #- "2.6"
-  - 3.4
-  - 3.5
+  - "2.7"
+  - "3.4"
+  - "3.5"
+
+env:
+  - PYSAL_PLUS=false
+  - PYSAL_PLUS=true
 
 before_install:
   - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
@@ -17,11 +20,12 @@ before_install:
   - conda update --yes conda
   - conda create -y -q -n test-env python=$TRAVIS_PYTHON_VERSION
   - source activate test-env
-  - chmod +x ./.travis_testing.sh
-  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then rm -rf pysal/contrib; 2to3 -nw pysal/ > /dev/null; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then 2to3 -nw pysal/ > /dev/null; fi
 
 install:
   - conda install --yes numpy scipy nose pip
+  - if [ "$PYSAL_PLUS" == true ]; then
+        echo 'plus testing'; conda install --yes pandas numexpr numba patsy shapely; fi;
   - pip install -r travis.txt
 
 script: 
@@ -35,7 +39,7 @@ script:
   #- nosetests --processes=-1 --process-timeout=60 --verbosity=1 --ignore-files=collection --exclude-dir=pysal/contrib
   #- nosetests
   - echo "check_stable=False" >pysal/config.py
-  - ./.travis_testing.sh
+  - nosetests --with-coverage --cover-package=pysal; 
   #- cd doc; make pickle; make doctest
 notifications:
     email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ before_install:
 install:
   - conda install --yes numpy scipy nose pip
   - if [ "$PYSAL_PLUS" == true ]; then
-        echo 'plus testing'; conda install --file requirements_plus.txt;
-        else conda install --file requirements.txt; 
+        echo 'plus testing'; conda install --yes --file requirements_plus.txt;
+        else conda install --yes --file requirements.txt; 
     fi;
   - pip install -r travis.txt
 

--- a/.travis_testing.sh
+++ b/.travis_testing.sh
@@ -1,5 +1,0 @@
-if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then
-    cd pysal; python -m 'nose';
-else
-    nosetests --with-coverage --cover-package=pysal; 
-fi

--- a/pysal/common.py
+++ b/pysal/common.py
@@ -122,8 +122,8 @@ def requires(*args, **kwargs):
             def passer(*args,**kwargs):
                 if v:
                     missing = [arg for i, arg in enumerate(wanted) if not available[i]]
-                    print('missing dependencies: {d}'.format(d=missing))
-                    print('not running {}'.format(function.__name__))
+                    Warn('missing dependencies: {d}'.format(d=missing))
+                    Warn('not running {}'.format(function.__name__))
                 else:
                     pass
             return passer 

--- a/pysal/spreg/tests/test_ml_error.py
+++ b/pysal/spreg/tests/test_ml_error.py
@@ -4,7 +4,7 @@ import scipy
 import numpy as np
 from pysal.spreg.ml_error import ML_Error
 from pysal.spreg import utils
-from pysal.common import RTOL
+from pysal.common import RTOL, ATOL
 from warnings import warn as Warn
 
 @unittest.skipIf(int(scipy.__version__.split(".")[1]) < 11,
@@ -29,46 +29,46 @@ class TestMLError(unittest.TestCase):
         Warn('Running higher-tolerance tests in test_ml_error.py')
         np.testing.assert_allclose(reg.betas,betas,RTOL + .0001)
         u = np.array([-5.97649777])
-        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        np.testing.assert_allclose(reg.u[0],u,RTOL, ATOL)
         predy = np.array([ 6.92258051])
-        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL, ATOL)
         n = 1412
-        np.testing.assert_allclose(reg.n,n,RTOL)
+        np.testing.assert_allclose(reg.n,n,RTOL, ATOL)
         k = 5
-        np.testing.assert_allclose(reg.k,k,RTOL)
+        np.testing.assert_allclose(reg.k,k,RTOL, ATOL)
         y = np.array([ 0.94608274])
-        np.testing.assert_allclose(reg.y[0],y,RTOL)
+        np.testing.assert_allclose(reg.y[0],y,RTOL, ATOL)
         x = np.array([ 1.        , -0.39902838,  0.89645344,  6.85780705,  7.2636377 ])
-        np.testing.assert_allclose(reg.x[0],x,RTOL)
+        np.testing.assert_allclose(reg.x[0],x,RTOL, ATOL)
         e = np.array([-4.92843327])
-        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL, ATOL)
         my = 9.5492931620846928
         np.testing.assert_allclose(reg.mean_y,my)
         sy = 7.0388508798387219
         np.testing.assert_allclose(reg.std_y,sy)
         vm = np.array([ 1.06476526,  0.05548248,  0.04544514,  0.00614425,  0.01481356,
         0.00143001])
-        np.testing.assert_allclose(reg.vm.diagonal(),vm,RTOL)
+        np.testing.assert_allclose(reg.vm.diagonal(),vm,RTOL, ATOL)
         sig2 = np.array([[ 32.40685441]])
-        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL, ATOL)
         pr2 = 0.3057664820364818
         np.testing.assert_allclose(reg.pr2,pr2)
         std_err = np.array([ 1.03187463,  0.23554719,  0.21317867,  0.07838525,  0.12171098,
         0.03781546])
-        np.testing.assert_allclose(reg.std_err,std_err,RTOL)
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL, ATOL)
         z_stat = [(5.9592751097983534, 2.5335926307459251e-09),
  (18.690182928021841, 5.9508619446611137e-78),
  (8.3421632936950338, 7.2943630281051907e-17),
  (-4.8232686291115678, 1.4122456582517099e-06),
  (3.9913060809142995, 6.5710406838016854e-05),
  (7.9088780724028922, 2.5971882547279339e-15)]
-        np.testing.assert_allclose(reg.z_stat,z_stat,RTOL)
+        np.testing.assert_allclose(reg.z_stat,z_stat,RTOL, ATOL)
         logll = -4471.407066887894
-        np.testing.assert_allclose(reg.logll,logll,RTOL)
+        np.testing.assert_allclose(reg.logll,logll,RTOL, ATOL)
         aic = 8952.8141337757879
-        np.testing.assert_allclose(reg.aic,aic,RTOL)
+        np.testing.assert_allclose(reg.aic,aic,RTOL, ATOL)
         schwarz = 8979.0779458660545
-        np.testing.assert_allclose(reg.schwarz,schwarz,RTOL)
+        np.testing.assert_allclose(reg.schwarz,schwarz,RTOL, ATOL)
     
 
     def test_dense(self):
@@ -83,48 +83,48 @@ class TestMLError(unittest.TestCase):
                      name_w='south_q.gal',  method='ORD')
         betas = np.array([[ 6.1492], [ 4.4024], [ 1.7784], [-0.3781], [ 0.4858], [ 0.2991]])
         Warn('Running higher-tolerance tests in test_ml_error.py')
-        np.testing.assert_allclose(reg.betas,betas,RTOL + .0001)
+        np.testing.assert_allclose(reg.betas,betas,RTOL + .0001, ATOL)
         u = np.array([-5.97649777])
-        np.testing.assert_allclose(reg.u[0],u,RTOL)
+        np.testing.assert_allclose(reg.u[0],u,RTOL, ATOL)
         predy = np.array([ 6.92258051])
-        np.testing.assert_allclose(reg.predy[0],predy,RTOL)
+        np.testing.assert_allclose(reg.predy[0],predy,RTOL, ATOL)
         n = 1412
-        np.testing.assert_allclose(reg.n,n,RTOL)
+        np.testing.assert_allclose(reg.n,n,RTOL, ATOL)
         k = 5
-        np.testing.assert_allclose(reg.k,k,RTOL)
+        np.testing.assert_allclose(reg.k,k,RTOL, ATOL)
         y = np.array([ 0.94608274])
-        np.testing.assert_allclose(reg.y[0],y,RTOL)
+        np.testing.assert_allclose(reg.y[0],y,RTOL, ATOL)
         x = np.array([ 1.        , -0.39902838,  0.89645344,  6.85780705,  7.2636377 ])
-        np.testing.assert_allclose(reg.x[0],x,RTOL)
+        np.testing.assert_allclose(reg.x[0],x,RTOL, ATOL)
         e = np.array([-4.92843327])
-        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL)
+        np.testing.assert_allclose(reg.e_filtered[0],e,RTOL, ATOL)
         my = 9.5492931620846928
-        np.testing.assert_allclose(reg.mean_y,my)
+        np.testing.assert_allclose(reg.mean_y,my, RTOL, ATOL)
         sy = 7.0388508798387219
-        np.testing.assert_allclose(reg.std_y,sy)
+        np.testing.assert_allclose(reg.std_y,sy, RTOL, ATOL)
         vm = np.array([ 1.06476526,  0.05548248,  0.04544514,  0.00614425,  0.01481356,
         0.001501])
-        np.testing.assert_allclose(reg.vm.diagonal(),vm,RTOL * 10)
+        np.testing.assert_allclose(reg.vm.diagonal(),vm,RTOL * 10, ATOL)
         sig2 = np.array([[ 32.40685441]])
-        np.testing.assert_allclose(reg.sig2,sig2,RTOL)
+        np.testing.assert_allclose(reg.sig2,sig2,RTOL, ATOL)
         pr2 = 0.3057664820364818
         np.testing.assert_allclose(reg.pr2,pr2)
         std_err = np.array([ 1.03187463,  0.23554719,  0.21317867,  0.07838525,  0.12171098,
         0.038744])
-        np.testing.assert_allclose(reg.std_err,std_err,RTOL*10)
+        np.testing.assert_allclose(reg.std_err,std_err,RTOL*10, ATOL)
         z_stat = [(5.95927510, 2.5335927e-09),
                   (18.6901829, 5.9508630e-78),
                   (8.34216329, 7.2943634e-17),
                   (-4.8232686, 1.4122457e-06),
                   (3.99130608, 6.5710407e-05),
                   (7.71923784, 1.1702739e-14)]
-        np.testing.assert_allclose(reg.z_stat,z_stat,rtol=RTOL)
+        np.testing.assert_allclose(reg.z_stat,z_stat,rtol=RTOL,atol=ATOL)
         logll = -4471.407066887894
-        np.testing.assert_allclose(reg.logll,logll,RTOL)
+        np.testing.assert_allclose(reg.logll,logll,RTOL, ATOL)
         aic = 8952.8141337757879
-        np.testing.assert_allclose(reg.aic,aic,RTOL)
+        np.testing.assert_allclose(reg.aic,aic,RTOL, ATOL)
         schwarz = 8979.0779458660545
-        np.testing.assert_allclose(reg.schwarz,schwarz,RTOL)
+        np.testing.assert_allclose(reg.schwarz,schwarz,RTOL, ATOL)
         
 if __name__ == '__main__':
     unittest.main()

--- a/requirements_plus.txt
+++ b/requirements_plus.txt
@@ -1,0 +1,11 @@
+scipy>=0.11
+matplotlib>=1.5.1
+seaborn>=0.7.0
+geopandas>=0.2
+scikit-learn>=0.17.1
+bokeh>=0.11.1
+datashader>=0.2.0
+geojson>=1.3.2
+folium>=0.2.1
+mplleaflet>=0.0.5
+statsmodels>=0.6.1

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ def setup_package():
                                         "meta"]),
         package_data={'pysal': list(example_data_files)},
         install_requires=['scipy'],
-        extra_requires={'plus':psplus},
+        extras_require={'plus':psplus},
         cmdclass= {'build_py': build_py}
     )
 

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,9 @@ ISRELEASED = False
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 
+psplus = open('./requirements_plus.txt')
+psplus = psplus.readlines()
+
 # BEFORE importing distutils, remove MANIFEST. distutils doesn't properly
 # update it when the contents of directories change.
 if os.path.exists('MANIFEST'):
@@ -74,7 +77,8 @@ def setup_package():
         packages=find_packages(exclude=[".meta", "*.meta.*", "meta.*",
                                         "meta"]),
         package_data={'pysal': list(example_data_files)},
-        requires=['scipy'],
+        install_requires=['scipy'],
+        extra_requires={'plus':psplus},
         cmdclass= {'build_py': build_py}
     )
 

--- a/travis.txt
+++ b/travis.txt
@@ -2,5 +2,3 @@ nose-exclude
 nose-progressive
 sphinx
 sphinxcontrib-napoleon
-networkx
-Shapely

--- a/travis.txt
+++ b/travis.txt
@@ -1,4 +1,5 @@
 nose-exclude
 nose-progressive
+coverage
 sphinx
 sphinxcontrib-napoleon


### PR DESCRIPTION
This sets up a multi-environment test matrix for PySAL using an environment variable, `PYSAL_PLUS` & is the remaining blocker for #829 

If `PYSAL_PLUS`, we include pandas, numba, numexpr, shapely, and patsy in the testing environment. This way, if we have numba versions of computational functions, tabular methods, etc, these get tested. 

In theory, these should also be added to the `setup.py` `extras_require` flag, if we want to appropriately incorporate this metadata by module. 

It makes sense to make the `PYSAL_PLUS` environment as open as possible, as long as things were correctly wrapped in try/except or `common.requires`. <s> I will write that up in a wiki page, too. </s> I've written [this notebook](http://nbviewer.jupyter.org/gist/ljwolf/b9817ce4590994f20a77f783a9bff3f4) documenting things I've seen & tried. 