### PR TITLE
minor bugfix to #816

### DIFF
--- a/pysal/core/IOHandlers/geoda_txt.py
+++ b/pysal/core/IOHandlers/geoda_txt.py
@@ -60,7 +60,7 @@ class GeoDaTxtReader(Tables.DataTable):
             self.pos += 1
             return row
         else:
-            raise None
+            return None
 
     def close(self):
         self.fileObj.close()


### PR DESCRIPTION
Instead of raising none (or even raising at all), we need to `return None` in order to `raise StopIteration`  at the correct time. 

This addresses #816 