### PR TITLE
DistanceBand speed ups

### DIFF
--- a/pysal/weights/Distance.py
+++ b/pysal/weights/Distance.py
@@ -488,12 +488,12 @@ class DistanceBand(W):
         if self.build_sp:    
             self.dmat = self.kd.sparse_distance_matrix(
                     self.kd, max_distance=self.threshold)
-    def _band(self):
-        """Find all pairs within threshold.
-
-        """
-        self.dmat = self.kd.sparse_distance_matrix(
-                self.kd, max_distance=self.threshold)
+        else:
+            if str(self.kd).split('.')[-1][0:10] == 'Arc_KDTree':
+            	raise TypeError('Unable to calculate dense arc distance matrix;'
+            	        ' parameter "build_sp" must be set to True for arc'
+            	        ' distance type weight')
+            self.dmat = self._spdistance_matrix(self.data, self.data, self.threshold)
 
     def _distance_to_W(self, ids=None):
         if ids:

--- a/pysal/weights/Distance.py
+++ b/pysal/weights/Distance.py
@@ -10,6 +10,8 @@ import scipy.spatial
 from pysal.common import KDTree
 from pysal.weights import W
 import scipy.stats
+from scipy.spatial import distance_matrix
+import scipy.sparse as sp
 import numpy as np
 from util import isKDTree
 

--- a/pysal/weights/Distance.py
+++ b/pysal/weights/Distance.py
@@ -392,6 +392,12 @@ class DistanceBand(W):
 
     ids         : list
                   values to use for keys of the neighbors and weights dicts
+    
+    build_sp    : boolean
+                  True to build sparse distance matrix and false to build dense
+                  distance matrix; significant speed gains may be obtained
+                  dending on the sparsity of the of distance_matrix and
+                  threshold that is applied
 
     Attributes
     ----------

--- a/pysal/weights/Distance.py
+++ b/pysal/weights/Distance.py
@@ -485,7 +485,6 @@ class DistanceBand(W):
             else:
                 self.data = data
                 self.kd = None       
-        print self.kd       
         self._band()
         neighbors, weights = self._distance_to_W(ids)
         W.__init__(self, neighbors, weights, ids)

--- a/pysal/weights/Distance.py
+++ b/pysal/weights/Distance.py
@@ -526,6 +526,12 @@ class DistanceBand(W):
 
         return neighbors, weights
 
+    def _spdistance_matrix(self, x,y, threshold=None):
+        dist = distance_matrix(x,y)
+        if threshold is not None:
+            zeros = dist > threshold
+            dist[zeros] = 0
+        return sp.csr_matrix(dist)
 
 def _test():
     import doctest

--- a/pysal/weights/Distance.py
+++ b/pysal/weights/Distance.py
@@ -448,32 +448,46 @@ class DistanceBand(W):
 
     """
 
-    def __init__(self, data, threshold, p=2, alpha=-1.0, binary=True, ids=None):
+    def __init__(self, data, threshold, p=2, alpha=-1.0, binary=True, ids=None,
+            build_sp=True):
         """Casting to floats is a work around for a bug in scipy.spatial.
         See detail in pysal issue #126.
 
         """
-        if isKDTree(data):
-            self.kd = data
-            self.data = self.kd.data
-        else:
-            try:
-                data = np.asarray(data)
-                if data.dtype.kind != 'f':
-                    data = data.astype(float)
-                self.data = data
-                self.kd = KDTree(self.data)
-            except:
-                raise ValueError("Could not make array from data")
-
         self.p = p
         self.threshold = threshold
         self.binary = binary
         self.alpha = alpha
+        self.build_sp = build_sp
+        
+        if isKDTree(data):
+            self.kd = data
+            self.data = self.kd.data
+        else:
+            if self.build_sp:
+                try:
+                    data = np.asarray(data)
+                    if data.dtype.kind != 'f':
+                        data = data.astype(float)
+                    self.data = data
+                    self.kd = KDTree(self.data)
+                except:
+                    raise ValueError("Could not make array from data")        
+            else:
+                self.data = data
+                self.kd = None       
+        print self.kd       
         self._band()
         neighbors, weights = self._distance_to_W(ids)
         W.__init__(self, neighbors, weights, ids)
 
+    def _band(self):
+        """Find all pairs within threshold.
+
+        """
+        if self.build_sp:    
+            self.dmat = self.kd.sparse_distance_matrix(
+                    self.kd, max_distance=self.threshold)
     def _band(self):
         """Find all pairs within threshold.
 

--- a/pysal/weights/tests/test_Distance.py
+++ b/pysal/weights/tests/test_Distance.py
@@ -134,7 +134,7 @@ class TestDistanceWeights(unittest.TestCase):
         kd = pysal.cg.kdtree.KDTree(pts, distance_metric='Arc',
                                     radius=pysal.cg.sphere.RADIUS_EARTH_KM)
         w = pysal.DistanceBand(kd, full.max(), binary=False, alpha=1.0)
-        np.testing.assert_allclose(w.sparse.todense(), full)
+        self.assertTrue((w.sparse.todense() == full).all())
 
     def test_DistanceBand_dense(self):
         """ see issue #126 """

--- a/pysal/weights/tests/test_Distance.py
+++ b/pysal/weights/tests/test_Distance.py
@@ -2,6 +2,7 @@ import os
 import unittest
 import pysal
 import numpy as np
+import sys
 
 
 class TestDistanceWeights(unittest.TestCase):

--- a/pysal/weights/tests/test_Distance.py
+++ b/pysal/weights/tests/test_Distance.py
@@ -137,6 +137,16 @@ class TestDistanceWeights(unittest.TestCase):
         w = pysal.DistanceBand(kd, full.max(), binary=False, alpha=1.0)
         np.testing.assert_allclose(w.sparse.todense(), full)
 
+    def test_DistanceBand_dense(self):
+        """ see issue #126 """
+        w = pysal.rook_from_shapefile(
+            pysal.examples.get_path("lattice10x10.shp"))
+        polygons = pysal.open(
+            pysal.examples.get_path("lattice10x10.shp"), "r").read()
+        points1 = [poly.centroid for poly in polygons]
+        w1 = pysal.DistanceBand(points1, 1, build_sp=False)
+        for k in range(w.n):
+            self.assertEqual(w[k], w1[k])
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestDistanceWeights)
 

--- a/pysal/weights/tests/test_Distance.py
+++ b/pysal/weights/tests/test_Distance.py
@@ -134,7 +134,7 @@ class TestDistanceWeights(unittest.TestCase):
         kd = pysal.cg.kdtree.KDTree(pts, distance_metric='Arc',
                                     radius=pysal.cg.sphere.RADIUS_EARTH_KM)
         w = pysal.DistanceBand(kd, full.max(), binary=False, alpha=1.0)
-        self.assertTrue((w.sparse.todense() == full).all())
+        np.testing.assert_allclose(w.sparse.todense(), full)
 
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestDistanceWeights)

--- a/pysal/weights/tests/test_Distance.py
+++ b/pysal/weights/tests/test_Distance.py
@@ -4,7 +4,6 @@ import pysal
 import numpy as np
 import sys
 
-
 class TestDistanceWeights(unittest.TestCase):
     def setUp(self):
         np.random.seed(1234)


### PR DESCRIPTION
This PR introduces two changes to the DistanceBand class in the weights module. The first change is to the way the neighbors and weights dictionaries are created when constructing the the DistanceBand W object. Instead of using a loop, a pairwise distance matrix is used to create a sparse matrix using ``WSP()`` and then converted to a regular W using ``WSP2W()``. Finally, the neighbor and weight dictionaries from this regular W can be used to instantiate a DistanceBand class W. This provides a speed-up, especially as the number of spatial units increases. 

The second significant change is the addition of an option to build the DistanceBand weight using a dense distance matrix function rather than solely the option to use the sparse distance matrix method from the kdtree. If the user is has a relatively high threshold set, the W will not be that sparse, so using dense operators will result in significant speed-ups. This option can be enabled by changing a new Boolean parameter ``build_sp`` to ``False``. The default is set to ``True`` which maintains the behavior of the DistanceBand class as it was previously. 

Tagging @sjsrey , @carsonfarmer , and @darribas  as this is somewhat related to GSOC goals and tagging @dfolch who was helping with this at Scipy. Also tagging @ljwolf because there may be merge conflicts previously merged PR's from his GSOC work.
