### PR TITLE
fixed typo in test_network.py

### DIFF
--- a/pysal/network/tests/test_network.py
+++ b/pysal/network/tests/test_network.py
@@ -136,5 +136,5 @@ class TestNetworkUtils(unittest.TestCase):
         self.assertAlmostEqual(self.distance[196], 5505.668247, places=4)
         self.assertEqual(self.pred[196], 133)
 
-if __name__ == 'main':
+if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This pull request corrects a typo on line 139 of `pysal/network/tests/test_network.py`.
@sjsrey 