### PR TITLE
handle verication context for githubstats

### DIFF
--- a/tools/github_stats.py
+++ b/tools/github_stats.py
@@ -14,6 +14,9 @@ import sys
 from datetime import datetime, timedelta
 from subprocess import check_output
 from urllib2 import urlopen
+import ssl
+
+context = ssl._create_unverified_context()
 
 #-----------------------------------------------------------------------------
 # Globals
@@ -43,7 +46,7 @@ def get_paged_request(url):
     results = []
     while url:
         print("fetching %s" % url, file=sys.stderr)
-        f = urlopen(url)
+        f = urlopen(url, context=context)
         results.extend(json.load(f))
         links = parse_link_header(f.headers)
         url = links.get('next')

--- a/tools/github_stats.py
+++ b/tools/github_stats.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 """Simple tools to query github.com and gather stats about issues.
+
+Adapted from: https://github.com/ipython/ipython/blob/master/tools/github_stats.py
 """
 #-----------------------------------------------------------------------------
 # Imports


### PR DESCRIPTION
Something must have changed regarding verification at github since our last release so our script would error out with:

```
 File "/home/serge/anaconda3/envs/pysal2/lib/python2.7/urllib2.py", line 1198, in do_open
    raise URLError(err)
urllib2.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590)>
```

This is a workaround for that error.