### PR TITLE
Make the output and build reproducible

### DIFF
--- a/pysal/core/IOHandlers/pyDbfIO.py
+++ b/pysal/core/IOHandlers/pyDbfIO.py
@@ -4,6 +4,8 @@ import struct
 import itertools
 from warnings import warn
 import pysal
+import os
+import time
 
 __author__ = "Charles R Schmidt <schmidtc@gmail.com>"
 __all__ = ['DBF']
@@ -272,7 +274,9 @@ class DBF(pysal.core.Tables.DataTable):
         POS = self.f.tell()
         self.f.seek(0)
         ver = 3
-        now = datetime.datetime.now()
+        now = datetime.datetime.utcfromtimestamp(
+            int(os.environ.get('SOURCE_DATE_EPOCH', time.time())),
+        )
         yr, mon, day = now.year - 1900, now.month, now.day
         numrec = self.numrec
         numfields = len(self.header)


### PR DESCRIPTION
As part of the effort to support [Reproducible Builds](https://reproducible-builds.org/) Chris Lamb submitted a patch in [Debian Bug #832997](https://bugs.debian.org/832997) to implement the [`SOURCE_DATE_EPOCH` specification](https://reproducible-builds.org/specs/source-date-epoch/).