### PR TITLE
Incoprate updates to db driver and unittests

### DIFF
--- a/pysal/__init__.py
+++ b/pysal/__init__.py
@@ -45,7 +45,6 @@ try:
     from pysal.contrib import pdio
     pysal.common.pandas = pandas
 except ImportError:
-    print('Pandas adapters not loaded')
     pysal.common.pandas = None
     
 # Load the IOHandlers

--- a/pysal/core/IOHandlers/tests/test_db.py
+++ b/pysal/core/IOHandlers/tests/test_db.py
@@ -1,0 +1,55 @@
+import os
+import pysal as ps
+import unittest as ut
+
+try:
+    import sqlalchemy
+    missing_sql = False
+except ImportError:
+    missing_sql = True
+
+try:
+    import geomet
+    missing_geomet = False
+except ImportError:
+    missing_geomet = True
+
+
+def to_wkb_point(c):
+    """
+    Super quick hack that does not actually belong in here
+    """
+    point = {'type': 'Point', 'coordinates':[c[0], c[1]]}
+    return geomet.wkb.dumps(point)
+
+
+@ut.skipIf(missing_sql or missing_geomet,
+           'missing dependencies: Geomet ({}) & SQLAlchemy ({})'.format(missing_geomet, missing_sql))
+class Test_sqlite_reader(ut.TestCase):
+
+    def setUp(self):
+        df = ps.pdio.read_files(ps.examples.get_path('new_haven_merged.dbf'))
+        df['GEOMETRY'] = df['geometry'].apply(to_wkb_point)
+        del df['geometry'] # This is a hack to not have to worry about a custom point type in the DB
+        engine = sqlalchemy.create_engine('sqlite:///test.db')
+        conn = engine.connect()
+        df.to_sql('newhaven', conn, index=True,
+                  dtype={'date': sqlalchemy.types.UnicodeText,  # Should convert the df date into a true date object, just a hack again
+                      'dataset': sqlalchemy.types.UnicodeText,
+                      'street': sqlalchemy.types.UnicodeText,
+                      'intersection': sqlalchemy.types.UnicodeText,
+                      'time': sqlalchemy.types.UnicodeText,  # As above re: date
+                      'GEOMETRY': sqlalchemy.types.BLOB})  # This is converted to TEXT as lowest type common sqlite
+
+    def test_deserialize(self):
+        db = ps.open('sqlite:///test.db')
+        self.assertEqual(db.tables, [u'newhaven'])
+
+        gj = db._get_gjson('newhaven')
+        self.assertFalse(True)
+
+    def tearDown(self):
+        os.remove('test.db')
+
+if __name__ == '__main__':
+    ut.main()


### PR DESCRIPTION
I believe this is the code that disables the warnings in the database driver. 
As I'm closing up the GSOC loose ends, I wanted to make sure this was filed somewhere. 

I believe it's complete:
- When you don't have pandas, no print statement is made on import. 
- When you try to read a file that is registered with the database driver and are missing geomet/shapely/sqlalchemy, an `ImportError` is raised telling you which packages are missing. When a WKB reader is missing:
```
No WKB parser found. Please install one of the following packages to enable this functionality: [geomet, shapely]
```
and when there's no sqlalchemy:
```
No module named sqlalchemy. Please install sqlalchemy to enable this functionality.
```

I've tested it in a clean conda env, with only numpy and scipy. 
