### PR TITLE
fix space/tab inconsistency

### DIFF
--- a/pysal/contrib/glm/iwls.py
+++ b/pysal/contrib/glm/iwls.py
@@ -55,7 +55,7 @@ def iwls(y, x, family, offset, y_fix,
     mu = family.starting_mu(y)
     v = family.predict(mu)
     while diff > tol and n_iter < max_iter:
-    	n_iter += 1
+        n_iter += 1
         w = family.weights(mu)
         z = v + (family.link.deriv(mu)*(y-mu))
         w = np.sqrt(w)


### PR DESCRIPTION
 The justification for this PR is is to fix a space/tab inconsistency in iwls.py of the glm module used for the spint module. It was causing an error when using python3 but not python2. After testing on my machine it seems to be working with both python2 and python3 now. There are no substantial code changes just a change of white space for one line of code. 

