### PR TITLE
Use standard python facilites for warning

### DIFF
--- a/pysal/weights/weights.py
+++ b/pysal/weights/weights.py
@@ -4,6 +4,7 @@ Weights.
 __author__ = "Sergio J. Rey <srey@asu.edu> "
 
 import math
+import warnings
 import numpy as np
 import scipy.sparse
 from os.path import basename as BASENAME
@@ -182,11 +183,11 @@ class W(object):
         if self.islands and not self.silent_island_warning:
             ni = len(self.islands)
             if ni == 1:
-                print("WARNING: there is one disconnected observation (no neighbors)")
-                print("Island id: ", self.islands)
+                warnings.warn("There is one disconnected observation (no neighbors)")
+                warnings.warn("Island id: ", self.islands)
             else:
-                print("WARNING: there are %d disconnected observations" % ni)
-                print("Island ids: ", self.islands)
+                warnings.warn("There are %d disconnected observations" % ni)
+                warnings.warn("Island ids: ", self.islands)
 
     def _reset(self):
         """Reset properties.

--- a/pysal/weights/weights.py
+++ b/pysal/weights/weights.py
@@ -184,10 +184,10 @@ class W(object):
             ni = len(self.islands)
             if ni == 1:
                 warnings.warn("There is one disconnected observation (no neighbors)")
-                warnings.warn("Island id: ", self.islands)
+                warnings.warn("Island id: %s" % str(self.islands[0]))
             else:
                 warnings.warn("There are %d disconnected observations" % ni)
-                warnings.warn("Island ids: ", self.islands)
+                warnings.warn("Island ids: %s" % ', '.join(str(island) for island in self.islands))
 
     def _reset(self):
         """Reset properties.


### PR DESCRIPTION
Hello! Please make sure to check all these boxes before submitting a Pull Request
(PR). Once you have checked the boxes, feel free to remove all text except the
justification in point 5. 

1. [ ] You have run tests on this submission, either by using [Travis Continuous Integration testing](https://github.com/pysal/pysal/wiki/GitHub-Standard-Operating-Procedures#automated-testing-w-travis-ci) testing or running `nosetests` on your changes?
2. [ ] This pull request is directed to the `pysal/dev` branch.
3. [ ] This pull introduces new functionality covered by
   [docstrings](https://en.wikipedia.org/wiki/Docstring#Python) and
   [unittests](https://docs.python.org/2/library/unittest.html)? **Do you want tests for warnings?**
4. [ ] You have [assigned a
   reviewer](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) and added relevant [labels](https://help.github.com/articles/applying-labels-to-issues-and-pull-requests/) **I don't have permissions for this**
5. [ ] The justification for this PR is: The Python standard library [provides a rich set of facilities for nonfatal warnings](https://docs.python.org/3/library/warnings.html), which allow downstream users to decide how they want to handle warnings as a distinct stream of messages.

