### PR TITLE
changing shp.next() to next(shp)

### DIFF
--- a/doc/source/users/tutorials/fileio.rst
+++ b/doc/source/users/tutorials/fileio.rst
@@ -38,7 +38,7 @@ Shapefiles
 
     >>> import pysal
     >>> shp = pysal.open('../pysal/examples/10740.shp')
-    >>> poly = shp.next()
+    >>> poly = next(shp)
     >>> type(poly)
     <class 'pysal.cg.shapes.Polygon'>
     >>> len(shp)


### PR DESCRIPTION
5. [x] The justification for this PR is: 

`shp.next( )` on python3 gives the error: 
`'PurePyShpWrapper' object has no attribute 'next'.` 
Changing it to `next(shp)` solves the issue.