### PR TITLE
Fix unusual interpreter path.

### DIFF
--- a/pysal/contrib/network/klincs.py
+++ b/pysal/contrib/network/klincs.py
@@ -1,4 +1,4 @@
-#!/usr/env python
+#!/usr/bin/env python
 
 """
 A library for computing local K function for network-constrained data


### PR DESCRIPTION
Most, if not all, distributions will have the `env` executable in `/usr/bin` instead of `/bin`.
