### PR TITLE
allow non-binary weights to propagate in w_subset

### DIFF
--- a/pysal/weights/Wsets.py
+++ b/pysal/weights/Wsets.py
@@ -394,15 +394,20 @@ def w_subset(w1, ids, silent_island_warning=False):
     """ 
 
     neighbors = {}
+    weights = {}
     ids_set = set(list(ids))
     for i in ids:
         if i in w1.neighbors:
             neigh_add = ids_set.intersection(set(w1.neighbors[i]))
+            weights_add = [w1.weights[i][list(w1.neighbors[i]).index(neigh)] 
+                           for neigh in neigh_add]
             neighbors[i] = list(neigh_add)
+            weights[i] = list(weights_add)
         else:
             neighbors[i] = []
+            weights[i] = [] 
 
-    return pysal.W(neighbors, id_order=list(ids), silent_island_warning=silent_island_warning)
+    return pysal.W(neighbors, weights=weights, id_order=list(ids), silent_island_warning=silent_island_warning)
 
 
 def w_clip(w1, w2, outSP=True, silent_island_warning=False):


### PR DESCRIPTION
this addresses #891, in that non-binary weights are generated using w-subset. 

this will reduce the speed of the function, since it's doing both a list coercion and a lookup in each iteration of the subset search. But, the current behavior is somewhat of a gotcha, I think. 

This should probably get a specific unittest as well. 