### PR TITLE
fix inplace overwrite issue

### DIFF
--- a/pysal/contrib/geotable/tests/test_utils.py
+++ b/pysal/contrib/geotable/tests/test_utils.py
@@ -1,13 +1,66 @@
 from .. import utils
-from ...pdio import read_files as rf
+from ...pdio import read_files
+import pysal as ps
 import unittest as ut
+try:
+    import geopandas as gpd
+except ImportError:
+    gpd = None
 
+MISSING_GEOPANDAS = gpd is None 
+
+@ut.skipIf(MISSING_GEOPANDAS, 'geopandas is missing...')
 class Test_Utils(ut.TestCase):
+    def setUp(self):
+        self.df = read_files(ps.examples.get_path('columbus.shp'))
+        self.gdf = gpd.read_file(ps.examples.get_path('columbus.shp'))
+
     
     def test_converters(self):
-        ## make a round trip to geodataframe and back
-        raise
+        import shapely.geometry as shgeom
+        import pandas as pd
+
+        from_df = utils.to_gdf(self.df)
+        from_gdf = utils.to_df(self.gdf)
+
+        self.assertIsInstance(from_df, type(self.gdf))
+        self.assertIsInstance(from_gdf, type(self.df))
+
+        self.assertIsInstance(from_gdf.iloc[0].geometry,
+                              ps.cg.Polygon)
+        self.assertIsInstance(from_df.iloc[0].geometry,
+                              shgeom.base.BaseGeometry)
+
+        self.assertIsInstance(self.df, pd.DataFrame)
+        self.assertIsInstance(self.gdf,gpd.GeoDataFrame)
+
+        self.assertIsInstance(self.df.iloc[0].geometry,
+                              ps.cg.Polygon)
+        self.assertIsInstance(self.gdf.iloc[0].geometry,
+                              shgeom.base.BaseGeometry)
+
     def test_insert_metadata(self):
         ## add an attribute to a dataframe and see 
         ## if it is pervasive over copies
-        raise
+        W = ps.weights.Queen.from_dataframe(self.gdf)
+        new = utils.insert_metadata(self.df, W, 'W', inplace=False)
+        utils.insert_metadata(self.gdf, W, 'W', inplace=True)
+        assert hasattr(new, 'W')
+        self.assertIsInstance(new.W, ps.weights.W)
+
+        assert hasattr(new.copy(), 'W') 
+
+        assert hasattr(new.copy(deep=True), 'W')
+        
+        assert hasattr(self.gdf, 'W')
+        
+        try:
+            utils.insert_metadata(self.gdf, W, 'W', 
+                                  inplace=True, overwrite=False)
+            raise UserWarning('Did not raise an exception when'
+                              'overwriting and overwrite=False')
+        except Exception:
+            pass
+
+if __name__ == "__main__":
+    ut.main()


### PR DESCRIPTION
Hello! Please make sure to check all these boxes before submitting a Pull Request
(PR). Once you have checked the boxes, feel free to remove all text except the
justification in point 5. 

1. [x] You have run tests on this submission, either by using [Travis Continuous Integration testing](https://github.com/pysal/pysal/wiki/GitHub-Standard-Operating-Procedures#automated-testing-w-travis-ci) testing or running `nosetests` on your changes?
2. [x] This pull request is directed to the `pysal/dev` branch.
3. [x] This pull introduces new functionality covered by
   [docstrings](https://en.wikipedia.org/wiki/Docstring#Python) and
   [unittests](https://docs.python.org/2/library/unittest.html)? 
4. [x] You have [assigned a
   reviewer](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) and added relevant [labels](https://help.github.com/articles/applying-labels-to-issues-and-pull-requests/)
5. [x] The justification for this PR is: 

Earlier versions of the `to_df` and `to_gdf` functions in `contrib.geotables` were intended to be inplace functions. But, there's a critical issue with this. While you can change the geometries in the geometry column, you can't force the type of the frame that contains them to change in place.

This resulted in an ambiguous/surprising API, where a call to `to_df` converts the input's geometry column from `shapely` to `pysal`, but leaves the frame itself as a `GeoDataFrame`. A similar problem occurs in the other direction. 

This fix forces a copy always to ensure that this no longer surprisingly updates in place. In addition, I've added unittests to the utils module to test that the type changes work. 