### PR TITLE
0. Fixed docstring that was causing latex error

### DIFF
--- a/pysal/esda/mapclassify.py
+++ b/pysal/esda/mapclassify.py
@@ -392,7 +392,7 @@ class Map_Classifier(object):
 
     .. math::
 
-              C_j^l < y_i \le C_j^u \  \forall  i \in C_j
+              C_j^l < y_i \le C_j^u  \ \ \\forall  i \in C_j
 
     where :math:`C_j` denotes class :math:`j` which has lower bound
           :math:`C_j^l` and upper bound :math:`C_j^u`.


### PR DESCRIPTION
The docstring for pysal.esda.mapclassify.Map_Classifier has a small error, see http://pysal.readthedocs.io/en/latest/library/esda/mapclassify.html

This is a small fix. Please let me know if I should open an issue or target dev with this pull request instead.

Thanks!