### PR TITLE
Util.compute length

### DIFF
--- a/doc/source/users/tutorials/autocorrelation.rst
+++ b/doc/source/users/tutorials/autocorrelation.rst
@@ -676,7 +676,7 @@ PySAL implements local Moran's I as follows:
 
 .. math::
 
-        I_i =  \sum_j z_i w_{i,j} z_j / \sum_i z_i z_i
+        I_i =  \frac{(n-1) z_i \sum_j w_{i,j} z_j}{\sum_i z_i^2}
 
 which results in :math:`n` values of local spatial autocorrelation, 1 for each spatial unit. Continuing on with the St. Louis example, the LISA statistics are obtained with:
 

--- a/doc/source/users/tutorials/autocorrelation.rst
+++ b/doc/source/users/tutorials/autocorrelation.rst
@@ -676,7 +676,7 @@ PySAL implements local Moran's I as follows:
 
 .. math::
 
-        I_i =  \frac{(n-1) z_i \sum_j w_{i,j} z_j}{\sum_i z_i^2}
+        I_i =  \frac{(n-1) z_i \sum_j w_{i,j} z_j}{\sum_j z_j^2}
 
 which results in :math:`n` values of local spatial autocorrelation, 1 for each spatial unit. Continuing on with the St. Louis example, the LISA statistics are obtained with:
 

--- a/pysal/esda/mapclassify.py
+++ b/pysal/esda/mapclassify.py
@@ -392,7 +392,7 @@ class Map_Classifier(object):
 
     .. math::
 
-              C_j^l < y_i \le C_j^u \  \forall  i \in C_j
+              C_j^l < y_i \le C_j^u  \ \ \\forall  i \in C_j
 
     where :math:`C_j` denotes class :math:`j` which has lower bound
           :math:`C_j^l` and upper bound :math:`C_j^u`.

--- a/pysal/network/network.py
+++ b/pysal/network/network.py
@@ -709,9 +709,8 @@ class Network:
                 if set1 == set2: # same edge
                     x1,y1 = sourcepattern.snapped_coordinates[p1]
                     x2,y2 = destpattern.snapped_coordinates[p2]
-                    xd = x1-x2
-                    yd = y1-y2
-                    nearest[p1,p2] = np.sqrt(xd*xd + yd*yd)
+                    computed_length = util.compute_length((x1,y1),(x2,y2))
+                    nearest[p1,p2] = computed_length
 
                 else:
                     ddist1, ddist2 = dest_dist_to_node[p2].values()


### PR DESCRIPTION
This PR streamlines the use of `util.compute_length()` for its use within `network.py`. No actual functionality in changed. 