### PR TITLE
Weights, ordering, and from_dataframe

### DIFF
--- a/pysal/weights/util.py
+++ b/pysal/weights/util.py
@@ -521,14 +521,17 @@ def higher_order_sp(w, k=2, shortest_path=True, diagonal=False):
 
     """
 
-    tw = type(w)
     id_order = None
-    if tw == pysal.weights.weights.W:
-        id_order = w.id_order
-        w = w.sparse
-    elif tw != scipy.sparse.csr.csr_matrix:
-        print "Unsupported sparse argument."
-        return None
+    if issubclass(type(w), pysal.weights.W):
+        if np.unique(np.hstack(w.weights.values())) == np.array([1.0]):
+            id_order = w.id_order
+            w = w.sparse
+    elif scipy.sparse.isspmatrix_csr(w):
+        if not np.unique(w.data) == np.array([1.0]):
+            raise ValueError('Sparse weights matrix is not binary (0,1) weights matrix.')
+    else:
+        raise TypeError("Weights provided are neither a binary W object nor "
+                        "a scipy.sparse.csr_matrix")
 
     wk = w**k
     rk, ck = wk.nonzero()


### PR DESCRIPTION
The geotable API for Contiguity weights [was somewhat confusing](https://github.com/pysal/pysal/issues/813) to keep consistent with the preexisting file API. In doing so, I chose to use an indexing scheme matching the pre-existing `weights.util.queen_from_shapefile`, in that neither `ids` nor `idVariable` caused the resulting `W` to have any special ordering. 

Later, working with this stuff, I got surprised by some instability in the ordering of `W` when the indexing column is a string. Since we force `id_order` to be sorted, if `df` is **not** sorted, then `from_dataframe(df, idVariable='my_string_index')` will not be aligned. 

So, this PR does a few things. First, it breaks out the functionality for classmethods in `Contiguity` to live in a [mix-in](https://en.wikipedia.org/wiki/Mixin) class, `_ContiguityMixin`.  Then, the `from_dataframe` method is changed to ensure that the alignment of `W` matches `df` unless you explicitly ask for it not to be aligned with `id_order = False`. Unittests cover:
- `from_dataframe(df, idVariable='my_index')` is ordered by `my_index` when `my_index` is a `str`, `int`, or `float`
- `from_dataframe(df, ids=df.my_index.tolist())` is also ordered over `my_index` when `my_index` is a `str`, `int`, or `float` 
- an explicit `id_order=False` flag must be passed to construct a `W` that is out of alignment with the source data frame.
- Alignment can be assured after `df.sort_values('my_index')` for `str`, `int`, `float`.