### PR TITLE
DOC: fix a broken link (HTTP 404) in documentation

### DIFF
--- a/doc/source/developers/guidelines.rst
+++ b/doc/source/developers/guidelines.rst
@@ -9,7 +9,7 @@ PySAL is adopting many of the conventions in the larger scientific computing
 in Python community and we ask that anyone interested in joining the project
 please review the following documents:
 
- * `Documentation standards <http://projects.scipy.org/numpy/wiki/CodingStyleGuidelines>`_
+ * :doc:`Documentation standards <docs/index>`
  * `Coding guidelines <http://www.python.org/dev/peps/pep-0008/>`_
  * :doc:`Testing guidelines <testing>`
 

--- a/doc/source/developers/guidelines.rst
+++ b/doc/source/developers/guidelines.rst
@@ -9,7 +9,7 @@ PySAL is adopting many of the conventions in the larger scientific computing
 in Python community and we ask that anyone interested in joining the project
 please review the following documents:
 
- * :doc:`Documentation standards <docs/index>`
+ * `Documentation standards <https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt>`_
  * `Coding guidelines <http://www.python.org/dev/peps/pep-0008/>`_
  * :doc:`Testing guidelines <testing>`
 


### PR DESCRIPTION
A link in PySAL's documentation was broken (404 Not Found). With this PR it will point to an existing document again.