### PR TITLE
DOC: fix formatting of a code block in the documentation

### DIFF
--- a/doc/source/developers/docs/index.rst
+++ b/doc/source/developers/docs/index.rst
@@ -47,11 +47,11 @@ If you're using Sphinx version 1.3 or newer, napoleon is included and should be 
 
 If you're using a version of Sphinx that does not ship with napoleon ( Sphinx < 1.3), you'll need napoleon version 0.2.4 or later and Sphinx version 1.0 or later to compile the documentation. 
 Both modules are available at the Python Package Index, and can be downloaded and installed
-from the command line using *pip* or *easy_install*.::
+from the command line using *pip* or *easy_install*::
 
        $ easy_install sphinx
        $ easy_install sphinxcontrib-napoleon
-or
+or::
 
        $ pip sphinx
        $ pip sphinxcontrib-napoleon


### PR DESCRIPTION
I found lines of code in the documentation which were formatted like normal text. After merging this PR Sphinx will render these lines correctly as code block.