### PR TITLE
Fixed incorrect file path in fileio.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,6 @@ applications for spatial analysis.
 Counties 1990.*
 
 
-
 It is important to underscore what PySAL is, and is not, designed to do. First
 and foremost, PySAL is a library in the fullest sense of the word. Developers
 looking for a suite of spatial analytical methods that they can incorporate
@@ -37,17 +36,6 @@ who may be carrying out research projects requiring customized scripting,
 extensive simulation analysis, or those seeking to advance the state of the art
 in spatial analysis should also find PySAL to be a useful foundation for their
 work.
-
-End users looking for a user friendly graphical user interface for spatial
-analysis should not turn to PySAL directly. Instead, we would direct them to
-projects like  the GeoDaX_ suite of software products which wrap PySAL
-functionality in GUIs. At the same time, we expect that with developments such
-as the Python based plug-in architectures for QGIS, GRASS, and the toolbox
-extensions for ArcGIS, that end user access to PySAL functionality will be
-widening in the near future.
-
-.. _PySAL : https://github.com/pysal/pysal/
-.. _GeoDaX : https://geodacenter.asu.edu/software
 
 
 .. |build| image:: https://travis-ci.org/pysal/pysal.png

--- a/doc/source/users/tutorials/fileio.rst
+++ b/doc/source/users/tutorials/fileio.rst
@@ -37,7 +37,7 @@ Shapefiles
 .. doctest::
 
     >>> import pysal
-    >>> shp = pysal.open('../pysal/examples/10740/10740.shp')
+    >>> shp = pysal.open(pysal.examples.get_path('10740.shp'))
     >>> poly = shp.next()
     >>> type(poly)
     <class 'pysal.cg.shapes.Polygon'>
@@ -55,7 +55,7 @@ DBF Files
 .. doctest::
 
     >>> import pysal
-    >>> db = pysal.open('../pysal/examples/10740/10740.dbf','r')
+    >>> db = pysal.open(pysal.examples.get_path('10740.dbf'),'r')
     >>> db.header
     ['GIST_ID', 'FIPSSTCO', 'TRT2000', 'STFID', 'TRACTID']
     >>> db.field_spec

--- a/doc/source/users/tutorials/fileio.rst
+++ b/doc/source/users/tutorials/fileio.rst
@@ -37,7 +37,7 @@ Shapefiles
 .. doctest::
 
     >>> import pysal
-    >>> shp = pysal.open('../pysal/examples/10740.shp')
+    >>> shp = pysal.open('../pysal/examples/10740/10740.shp')
     >>> poly = shp.next()
     >>> type(poly)
     <class 'pysal.cg.shapes.Polygon'>
@@ -55,7 +55,7 @@ DBF Files
 .. doctest::
 
     >>> import pysal
-    >>> db = pysal.open('../pysal/examples/10740.dbf','r')
+    >>> db = pysal.open('../pysal/examples/10740/10740.dbf','r')
     >>> db.header
     ['GIST_ID', 'FIPSSTCO', 'TRT2000', 'STFID', 'TRACTID']
     >>> db.field_spec


### PR DESCRIPTION
Previously, the doctests for the reading file examples were accessing
the 10740.shp and 10740.dbf files from an incorrect file path. Fixes #917 

1. [x] You have run tests on this submission, either by using [Travis Continuous Integration testing](https://github.com/pysal/pysal/wiki/GitHub-Standard-Operating-Procedures#automated-testing-w-travis-ci) testing or running `nosetests` on your changes?
2. [X] This pull request is directed to the `pysal/dev` branch.
3. [ ] This pull introduces new functionality covered by
   [docstrings](https://en.wikipedia.org/wiki/Docstring#Python) and
   [unittests](https://docs.python.org/2/library/unittest.html)? 
4. [ ] You have [assigned a
   reviewer](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) and added relevant [labels](https://help.github.com/articles/applying-labels-to-issues-and-pull-requests/)
5. [X] The justification for this PR is: 
This fixes a doctest in fileio.rst for shapefiles under the heading Reading files that tries to use an example shapefile with an incorrect file path. 