### PR TITLE
DOC: make code snippet in documentation compatible to Python 3

### DIFF
--- a/doc/source/users/tutorials/region.rst
+++ b/doc/source/users/tutorials/region.rst
@@ -145,7 +145,7 @@ constraints.
     >>> import pysal
     >>> from pysal.region import Random_Region
     >>> nregs = 13
-    >>> cards = range(2,14) + [10]
+    >>> cards = list(range(2,14)) + [10]
     >>> w = pysal.lat2W(10,10,rook = False)
     >>> ids = w.id_order
     >>>


### PR DESCRIPTION
The documentation about regionalization contained Python2-specific code. I changed it so that it can be run under Python 3 too.