### PR TITLE
Fix for negative values of ebi_v in assancao_rate smoother function

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,6 @@ applications for spatial analysis.
 Counties 1990.*
 
 
-
 It is important to underscore what PySAL is, and is not, designed to do. First
 and foremost, PySAL is a library in the fullest sense of the word. Developers
 looking for a suite of spatial analytical methods that they can incorporate
@@ -37,17 +36,6 @@ who may be carrying out research projects requiring customized scripting,
 extensive simulation analysis, or those seeking to advance the state of the art
 in spatial analysis should also find PySAL to be a useful foundation for their
 work.
-
-End users looking for a user friendly graphical user interface for spatial
-analysis should not turn to PySAL directly. Instead, we would direct them to
-projects like  the GeoDaX_ suite of software products which wrap PySAL
-functionality in GUIs. At the same time, we expect that with developments such
-as the Python based plug-in architectures for QGIS, GRASS, and the toolbox
-extensions for ArcGIS, that end user access to PySAL functionality will be
-widening in the near future.
-
-.. _PySAL : https://github.com/pysal/pysal/
-.. _GeoDaX : https://geodacenter.asu.edu/software
 
 
 .. |build| image:: https://travis-ci.org/pysal/pysal.png

--- a/doc/source/users/tutorials/fileio.rst
+++ b/doc/source/users/tutorials/fileio.rst
@@ -37,7 +37,7 @@ Shapefiles
 .. doctest::
 
     >>> import pysal
-    >>> shp = pysal.open('../pysal/examples/10740/10740.shp')
+    >>> shp = pysal.open(pysal.examples.get_path('10740.shp'))
     >>> poly = shp.next()
     >>> type(poly)
     <class 'pysal.cg.shapes.Polygon'>
@@ -55,7 +55,7 @@ DBF Files
 .. doctest::
 
     >>> import pysal
-    >>> db = pysal.open('../pysal/examples/10740/10740.dbf','r')
+    >>> db = pysal.open(pysal.examples.get_path('10740.dbf'),'r')
     >>> db.header
     ['GIST_ID', 'FIPSSTCO', 'TRT2000', 'STFID', 'TRACTID']
     >>> db.field_spec

--- a/doc/source/users/tutorials/fileio.rst
+++ b/doc/source/users/tutorials/fileio.rst
@@ -37,7 +37,7 @@ Shapefiles
 .. doctest::
 
     >>> import pysal
-    >>> shp = pysal.open('../pysal/examples/10740.shp')
+    >>> shp = pysal.open('../pysal/examples/10740/10740.shp')
     >>> poly = shp.next()
     >>> type(poly)
     <class 'pysal.cg.shapes.Polygon'>
@@ -55,7 +55,7 @@ DBF Files
 .. doctest::
 
     >>> import pysal
-    >>> db = pysal.open('../pysal/examples/10740.dbf','r')
+    >>> db = pysal.open('../pysal/examples/10740/10740.dbf','r')
     >>> db.header
     ['GIST_ID', 'FIPSSTCO', 'TRT2000', 'STFID', 'TRACTID']
     >>> db.field_spec

--- a/pysal/esda/smoothing.py
+++ b/pysal/esda/smoothing.py
@@ -550,6 +550,8 @@ def assuncao_rate(e, b):
     s2 = sum(b * ((y - ebi_b) ** 2)) / b_sum
     ebi_a = s2 - ebi_b / (float(b_sum) / len(e))
     ebi_v = ebi_a + ebi_b / b
+    if (ebi_v < 0):
+      ebi_v = ebi_b / b
     return (y - ebi_b) / np.sqrt(ebi_v)
 
 class _Smoother(object):

--- a/pysal/esda/smoothing.py
+++ b/pysal/esda/smoothing.py
@@ -551,7 +551,7 @@ def assuncao_rate(e, b):
     ebi_a = s2 - ebi_b / (float(b_sum) / len(e))
     ebi_v = ebi_a + ebi_b / b
     if (ebi_v < 0):
-      ebi_v = ebi_b / b
+        ebi_v = ebi_b / b
     return (y - ebi_b) / np.sqrt(ebi_v)
 
 class _Smoother(object):

--- a/pysal/esda/smoothing.py
+++ b/pysal/esda/smoothing.py
@@ -549,9 +549,8 @@ def assuncao_rate(e, b):
     ebi_b = e_sum * 1.0 / b_sum
     s2 = sum(b * ((y - ebi_b) ** 2)) / b_sum
     ebi_a = s2 - ebi_b / (float(b_sum) / len(e))
-    ebi_v = ebi_a + ebi_b / b
-    if (ebi_v < 0):
-        ebi_v = ebi_b / b
+    ebi_v_raw = ebi_a + ebi_b / b
+    ebi_v = np.where(ebi_v_raw < 0, ebi_b / b, ebi_v_raw)
     return (y - ebi_b) / np.sqrt(ebi_v)
 
 class _Smoother(object):


### PR DESCRIPTION
Hello! Please make sure to check all these boxes before submitting a Pull Request
(PR). Once you have checked the boxes, feel free to remove all text except the
justification in point 5. 

1. [X] You have run tests on this submission, either by using [Travis Continuous Integration testing](https://github.com/pysal/pysal/wiki/GitHub-Standard-Operating-Procedures#automated-testing-w-travis-ci) testing or running `nosetests` on your changes?
2. [X] This pull request is directed to the `pysal/dev` branch.
3. [ ] This pull introduces new functionality covered by
   [docstrings](https://en.wikipedia.org/wiki/Docstring#Python) and
   [unittests](https://docs.python.org/2/library/unittest.html)? 
4. [ ] You have [assigned a
   reviewer](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) and added relevant [labels](https://help.github.com/articles/applying-labels-to-issues-and-pull-requests/)
5. [X] The justification for this PR is: According to #909, the Assuncao rate smoother function does not work correctly for negative values of ebi_v. This PR implements a fix suggested in the issue, by setting ebi_v = ebi_b / b for negative values of ebi_v instead of ebi_a + ebi_b/ b.
