### PR TITLE
[WIP] fix bug #944

### DIFF
--- a/pysal/weights/util.py
+++ b/pysal/weights/util.py
@@ -521,14 +521,17 @@ def higher_order_sp(w, k=2, shortest_path=True, diagonal=False):
 
     """
 
-    tw = type(w)
     id_order = None
-    if tw == pysal.weights.weights.W:
-        id_order = w.id_order
-        w = w.sparse
-    elif tw != scipy.sparse.csr.csr_matrix:
-        print "Unsupported sparse argument."
-        return None
+    if issubclass(type(w), pysal.weights.W):
+        if np.unique(np.hstack(w.weights.values())) == np.array([1.0]):
+            id_order = w.id_order
+            w = w.sparse
+    elif scipy.sparse.isspmatrix_csr(w):
+        if not np.unique(w.data) == np.array([1.0]):
+            raise ValueError('Sparse weights matrix is not binary (0,1) weights matrix.')
+    else:
+        raise TypeError("Weights provided are neither a binary W object nor "
+                        "a scipy.sparse.csr_matrix")
 
     wk = w**k
     rk, ck = wk.nonzero()


### PR DESCRIPTION
This adds "correct" typedispatching for the `higher_order` function.

It should work for any weights subclass of `W` that's binary, or on binary sparse matrices.

It requires unittests to ensure all the W-types complete for it. 