### PR TITLE
Order enforce

### DIFF
--- a/pysal/weights/Distance.py
+++ b/pysal/weights/Distance.py
@@ -859,6 +859,8 @@ class DistanceBand(W):
             ids = df.index.tolist()
         elif isinstance(ids, str):
             ids = df[ids].tolist()
+        else:
+            ids = df.index.tolist()
         return cls(pts, threshold, ids=ids, **kwargs)
 
     def _band(self):

--- a/pysal/weights/tests/test_Contiguity.py
+++ b/pysal/weights/tests/test_Contiguity.py
@@ -92,6 +92,13 @@ class Contiguity_Mixin(object):
         w = self.cls.from_dataframe(df, geom_col='the_geom', idVariable=self.idVariable)
         self.assertEqual(w[self.known_name], self.known_namedw)
 
+        # order preserving
+        permute = df.sample(frac=1)
+        w = self.cls.from_dataframe(permute, geom_col='the_geom')
+        with self.assertRaises(AssertionError):
+            assert w.id_order == df.index.tolist()
+        self.assertEqual(w.id_order, permute.index.tolist())
+
 class Test_Queen(ut.TestCase, Contiguity_Mixin):
     def setUp(self):
         Contiguity_Mixin.setUp(self)

--- a/pysal/weights/tests/test_Distance.py
+++ b/pysal/weights/tests/test_Distance.py
@@ -86,6 +86,12 @@ class Test_KNN(ut.TestCase, Distance_Mixin):
         w = d.KNN.from_dataframe(df, k=4)
         self.assertEqual(w.neighbors[self.known_wi0], self.known_w0)
         self.assertEqual(w.neighbors[self.known_wi1], self.known_w1)
+        perm = df.sample(frac=1)
+        w = d.KNN.from_dataframe(perm, k=4)
+        with self.assertRaises(AssertionError):
+            assert w.id_order == df.index.tolist()
+        self.assertEqual(perm.index.tolist(), w.id_order)
+
 
     def test_from_array(self):
         w = d.KNN.from_array(self.poly_centroids, k=4)
@@ -146,6 +152,11 @@ class Test_DistanceBand(ut.TestCase, Distance_Mixin):
         w = d.DistanceBand.from_dataframe(df, 1)
         for k,v in w:
             self.assertEquals(v, self.grid_rook_w[k])
+        perm = df.sample(frac=1)
+        w =  d.DistanceBand.from_dataframe(perm, 1)
+        with self.assertRaises(AssertionError):
+            assert w.id_order == df.index.tolist()
+        self.assertEqual(w.id_order, perm.index.tolist())
 
     ##########################
     # Function/User tests    #
@@ -252,7 +263,12 @@ class Test_Kernel(ut.TestCase, Distance_Mixin):
         w = d.Kernel.from_dataframe(df)
         for k,v in w[self.known_wi5-1].items():
             np.testing.assert_allclose(v, self.known_w5[k+1], rtol=RTOL)
-    
+        perm = df.sample(frac=1)
+        w = d.Kernel.from_dataframe(perm)
+        with self.assertRaises(AssertionError):
+            assert w.id_order == df.index.tolist()
+        self.assertEqual(w.id_order, perm.index.tolist())
+
     ##########################
     # Function/User tests    # 
     ##########################

--- a/pysal/weights/weights.py
+++ b/pysal/weights/weights.py
@@ -426,6 +426,7 @@ class W(object):
         """Number of neighbors for each observation.
 
         """
+        print(self.neighbors)
         if 'cardinalities' not in self._cache:
             c = {}
             for i in self._id_order:


### PR DESCRIPTION
This revives #922, ensuring that anytime, regardless of the index or index-column type, the weights constructed from the dataframe match the input dataframe order. 