### PR TITLE
fix for #932 coordinates need to be (lon, lat) not (lat, lon)

### DIFF
--- a/pysal/cg/kdtree.py
+++ b/pysal/cg/kdtree.py
@@ -19,23 +19,23 @@ DISTANCE_METRICS = ['Euclidean', 'Arc']
 FLOAT_EPS = numpy.finfo(float).eps
 
 
-def KDTree(data, leafsize=10, distance_metric='Euclidean', 
+def KDTree(data, leafsize=10, distance_metric='Euclidean',
            radius=RADIUS_EARTH_KM):
     """
     kd-tree built on top of kd-tree functionality in scipy. If using scipy 0.12
     or greater uses the scipy.spatial.cKDTree, otherwise uses
     scipy.spatial.KDTree. Offers both Arc distance and Euclidean distance.
     Note that Arc distance is only appropriate when points in latitude and
-    longitude, and the radius set to meaningful value (see docs below). 
+    longitude, and the radius set to meaningful value (see docs below).
 
     Parameters
     ----------
     data            : array
-                      The data points to be indexed. This array is not copied, 
+                      The data points to be indexed. This array is not copied,
                       and so modifying this data will result in bogus results.
                       Typically nx2.
     leafsize        : int
-                      The number of points at which the algorithm switches over 
+                      The number of points at which the algorithm switches over
                       to brute-force. Has to be positive. Optional, default is 10.
     distance_metric : string
                       Options: "Euclidean" (default) and "Arc".
@@ -56,7 +56,7 @@ def KDTree(data, leafsize=10, distance_metric='Euclidean',
         return Arc_KDTree(data, leafsize, radius)
 
 
-# internal hack for the Arc_KDTree class inheritance 
+# internal hack for the Arc_KDTree class inheritance
 if int(scipy.version.version.split(".")[1]) < 12:
     temp_KDTree = scipy.spatial.KDTree
 else:
@@ -164,10 +164,16 @@ class Arc_KDTree(temp_KDTree):
             return sphere.linear2arcdist(d, r), i
         if dims == 1:
             #TODO: implement linear2arcdist on numpy arrays
-            d = [sphere.linear2arcdist(x, r) for x in d]
+            d1 = [sphere.linear2arcdist(dx, r) for dx in d]
         elif dims == 2:
-            d = [[sphere.linear2arcdist(x, r) for x in row] for row in d]
-        return numpy.array(d), i
+            d1 = [[sphere.linear2arcdist(dx, r) for dx in row] for row in d]
+        d = numpy.array(d1)
+        dinf = d == numpy.inf
+        if dinf.sum() > 0:
+            i = i.astype(float)
+            i[dinf] = numpy.nan
+
+        return d, i
 
     def query_ball_point(self, x, r, p=2, eps=0):
         """


### PR DESCRIPTION

```python
from pysal.cg.kdtree import Arc_KDTree
from pysal.cg.sphere import RADIUS_EARTH_KM
import numpy

coords = numpy.array([[47.64103, -122.32293],
    [47.6388, -122.32297],
    [47.63637, -122.32308],
    [47.63367, -122.32387],
    [47.63123, -122.32537]])

tree = Arc_KDTree(coords, leafsize=10, radius=RADIUS_EARTH_KM)
# get points from KDTree
toQuery = (coords[0])
d,i = tree.query(toQuery, k=5, distance_upper_bound=0.5)
```


```python
d
```




    array([ 0.        ,  0.13265903,  0.27756191,  0.44990361,         inf])




```python
i
```




    array([  0.,   1.,   2.,   3.,  nan])




```python
# Arc_KDTree takes coords in (lon, lat)
coords = coords[:, [1, 0]]
```


```python
tree = Arc_KDTree(coords, leafsize=10, radius=RADIUS_EARTH_KM)
```


```python
toQuery = (coords[0])
d,i = tree.query(toQuery, k=5, distance_upper_bound=0.5)
```


```python
d
```




    array([ 0.        ,  0.24798279,         inf,         inf,         inf])




```python
i # because the distance_upper_bound clips to only 2 nn, set nan
```




    array([  0.,   1.,  nan,  nan,  nan])




```python
toQuery = (coords[0])
d,i = tree.query(toQuery, k=5, distance_upper_bound=5.5)
```


```python
d
```




    array([ 0.        ,  0.24798279,  0.51829022,  0.82141962,  1.10494005])




```python
i # bumping up the distance_upper_bound gets us k=5 nn and back to ints
```




    array([0, 1, 2, 3, 4])




```python

```


```python

```