### PR TITLE
HAC OLS documentation

### DIFF
--- a/pysal/spreg/ols.py
+++ b/pysal/spreg/ols.py
@@ -29,7 +29,7 @@ class BaseOLS(RegressionPropsY, RegressionPropsVM):
                    If 'white', then a White consistent estimator of the
                    variance-covariance matrix is given.  If 'hac', then a
                    HAC consistent estimator of the variance-covariance
-                   matrix is given. Default set to None. 
+                   matrix is given. Default set to None.
     gwk          : pysal W object
                    Kernel spatial weights needed for HAC estimation. Note:
                    matrix must have ones along the main diagonal.
@@ -141,7 +141,7 @@ class OLS(BaseOLS):
                    If 'white', then a White consistent estimator of the
                    variance-covariance matrix is given.  If 'hac', then a
                    HAC consistent estimator of the variance-covariance
-                   matrix is given. Default set to None. 
+                   matrix is given. Default set to None.
     gwk          : pysal W object
                    Kernel spatial weights needed for HAC estimation. Note:
                    matrix must have ones along the main diagonal.
@@ -218,11 +218,11 @@ class OLS(BaseOLS):
     logll        : float
                    Log likelihood
     aic          : float
-                   Akaike information criterion 
+                   Akaike information criterion
     schwarz      : float
-                   Schwarz information criterion     
+                   Schwarz information criterion
     std_err      : array
-                   1xk array of standard errors of the betas    
+                   1xk array of standard errors of the betas
     t_stat       : list of tuples
                    t statistic; each tuple contains the pair (statistic,
                    p-value), where each is a float
@@ -230,24 +230,24 @@ class OLS(BaseOLS):
                    Multicollinearity condition number
     jarque_bera  : dictionary
                    'jb': Jarque-Bera statistic (float); 'pvalue': p-value
-                   (float); 'df': degrees of freedom (int)  
+                   (float); 'df': degrees of freedom (int)
     breusch_pagan : dictionary
                     'bp': Breusch-Pagan statistic (float); 'pvalue': p-value
-                    (float); 'df': degrees of freedom (int)  
+                    (float); 'df': degrees of freedom (int)
     koenker_bassett : dictionary
                       'kb': Koenker-Bassett statistic (float); 'pvalue':
-                      p-value (float); 'df': degrees of freedom (int)  
+                      p-value (float); 'df': degrees of freedom (int)
     white         : dictionary
                     'wh': White statistic (float); 'pvalue': p-value (float);
-                    'df': degrees of freedom (int)  
+                    'df': degrees of freedom (int)
     lm_error      : tuple
                     Lagrange multiplier test for spatial error model; tuple
                     contains the pair (statistic, p-value), where each is a
-                    float 
+                    float
     lm_lag        : tuple
                     Lagrange multiplier test for spatial lag model; tuple
                     contains the pair (statistic, p-value), where each is a
-                    float 
+                    float
     rlm_error     : tuple
                     Robust lagrange multiplier test for spatial error model;
                     tuple contains the pair (statistic, p-value), where each
@@ -294,7 +294,7 @@ class OLS(BaseOLS):
     This is the DBF associated with the Columbus shapefile.  Note that
     pysal.open() also reads data in CSV format; also, the actual OLS class
     requires data to be passed in as numpy arrays so the user can read their
-    data in using any method.  
+    data in using any method.
 
     >>> db = pysal.open(pysal.examples.get_path('columbus.dbf'),'r')
 

--- a/pysal/spreg/ols.py
+++ b/pysal/spreg/ols.py
@@ -415,6 +415,28 @@ class OLS(BaseOLS):
     >>> print round(ols.moran_res[2],4)
     0.0095
 
+    If the optional parameter robust is passed to pysal.spreg.OLS, the
+    appropriate heteroskedasticity- and/or autocorrelation-robust
+    variance-covariance matrix will be calculated. The option robust='white'
+    requests White's heteroskedasticity-consistent standard errors. The option
+    robust='hac' requests heteroskedasticity- and autocorrelation-consistent
+    standard errors, using the formulation by Kelejian and Prucha. (These are
+    also called Conley standard errors.)
+    Below, we calculate kernel weights with a triangular kernel and a
+    bandwidth that  is the maximum of the distances to the second nearest
+    neighbor (the defaults).
+
+    >>> ols = OLS(y, X, robust=None)
+    >>> print round(ols.vm[1,1], 4)
+    0.2872
+    >>> ols = OLS(y, X, robust='white')
+    >>> print round(ols.vm[1,1], 4)
+    0.2585
+    >>> wk = pysal.weights.kernelW_from_shapefile(pysal.examples.get_path("columbus.shp"))
+    >>> ols = OLS(y, X, robust='hac', gwk=wk)
+    >>> print round(ols.vm[1,1], 4)
+    0.2603
+
     """
 
     def __init__(self, y, x,


### PR DESCRIPTION
The justification for this PR is: Adding to the documentation for HAC errors in spreg. 

Currently, there is no mention of Conley errors in the repo, but in #949, @lanselin provided more detail.  He wrote, "Conley errors are implemented in spreg as HAC standard errors, based on the formulation of Kelejian and Prucha".  I'd like to add this comment to the documentation for future users.  (I also added a small example, mostly copied from spreg/robust.py.)