### PR TITLE
Fix minor bugs in tests

### DIFF
--- a/pysal/cg/tests/test_sphere.py
+++ b/pysal/cg/tests/test_sphere.py
@@ -3,7 +3,7 @@ import pysal
 import math
 import unittest
 import numpy as np
-
+from pysal.common import (RTOL, ATOL)
 
 class Sphere(unittest.TestCase):
 
@@ -71,9 +71,7 @@ class Sphere(unittest.TestCase):
         pup = (42.023768, -87.946389)    # Arlington Heights IL
         pdown = (41.644415, -87.524102)  # Hammond, IN
         grid1 = sphere.geogrid(pup, pdown, 3, lonx=False)
-        # Use assertTrue instead of np.testing.assert_all_close so unittest
-        # can know what's going on.
-        self.assertTrue(np.allclose(grid, grid1))
+        np.testing.assert_allclose(grid, grid1, rtol=RTOL, atol=ATOL)
 
     def test_toXYZ(self):
         w2 = {0: [2, 5, 6, 10], 1: [4, 7, 9, 14], 2: [6, 0, 3, 8],

--- a/pysal/cg/tests/test_sphere.py
+++ b/pysal/cg/tests/test_sphere.py
@@ -2,6 +2,7 @@ from pysal.cg import sphere
 import pysal
 import math
 import unittest
+import numpy as np
 
 
 class Sphere(unittest.TestCase):
@@ -70,7 +71,9 @@ class Sphere(unittest.TestCase):
         pup = (42.023768, -87.946389)    # Arlington Heights IL
         pdown = (41.644415, -87.524102)  # Hammond, IN
         grid1 = sphere.geogrid(pup, pdown, 3, lonx=False)
-        self.assertAlmostEqual(grid, grid1)
+        # Use assertTrue instead of np.testing.assert_all_close so unittest
+        # can know what's going on.
+        self.assertTrue(np.allclose(grid, grid1))
 
     def test_toXYZ(self):
         w2 = {0: [2, 5, 6, 10], 1: [4, 7, 9, 14], 2: [6, 0, 3, 8],

--- a/pysal/examples/test_examples.py
+++ b/pysal/examples/test_examples.py
@@ -1,12 +1,13 @@
 import unittest
 import pysal.examples as ex
+import os
 
 
 class Example_Tester(unittest.TestCase):
     def test_get_path(self):
-        pathparts = ex.get_path('').split('/')
-        self.localpath = '/'.join(pathparts[-3:])
-        self.assertEquals(self.localpath, 'pysal/examples/')
+        pathparts = os.path.normpath(ex.get_path('')).split(os.path.sep)
+        self.localpath = os.path.join(*pathparts[-2:])
+        self.assertEquals(self.localpath, os.path.normpath('pysal/examples/'))
 
     def test_parser(self):
         for example in ex.available():


### PR DESCRIPTION
- test_sphere.py:
Existing code was trying to compare lists of floats with `assertAlmostEqual` instead of the numpy equivalent. 

- test_examples.py:
Existing code assumed a "/" path separator, so failed on Windows.
The change from `pathparts[-3:]` to `pathparts[-2:]` is because `os.path.normpath` strips out the trailing slash.
