### PR TITLE
remove erroneous debug print

### DIFF
--- a/pysal/weights/weights.py
+++ b/pysal/weights/weights.py
@@ -426,7 +426,6 @@ class W(object):
         """Number of neighbors for each observation.
 
         """
-        print(self.neighbors)
         if 'cardinalities' not in self._cache:
             c = {}
             for i in self._id_order:


### PR DESCRIPTION
This erroneous print statement was accidentally retained in #946. 

It's noticeable though, since it causes the neighbor dictionary to be printed on access to `weights.cardinalities`. 

It was not retained in the `libpysal` addressing of the issue, [libpysal/#21](https://github.com/pysal/libpysal/pull/21)

If this is merged, I can take care of incrementing the releases on PyPI and github. 

