### PR TITLE
Passing p_thres in plot_lisa_cluster. This fixes #971

### DIFF
--- a/pysal/contrib/viz/mapping.py
+++ b/pysal/contrib/viz/mapping.py
@@ -1097,7 +1097,7 @@ def plot_lisa_cluster(shp_link, lisa, p_thres=0.01, shp_type='poly',
     shp = ps.open(shp_link)
     # Lisa layer
     lisa_obj = map_poly_shp(shp)
-    lisa_obj = base_lisa_cluster(lisa_obj, lisa)
+    lisa_obj = base_lisa_cluster(lisa_obj, lisa, p_thres=p_thres)
     lisa_obj.set_alpha(alpha)
     # Figure
     fig = plt.figure(figsize=figsize)


### PR DESCRIPTION
Minor patch to make sure `p_thres` is passed on `plot_lisa_cluster`. Note this API is on its way out as it does not depend on `geotable` structures, but it is anyway good to have it properly working.