### PR TITLE
Resolve issue of "False" "id_order_set" when building contiguity weights from shapefile even if `idVariable` is given in initialization

### DIFF
--- a/doc/source/users/tutorials/smoothing.rst
+++ b/doc/source/users/tutorials/smoothing.rst
@@ -141,7 +141,7 @@ and total population (the 13th column):
 .. doctest:: 
 
     >>> import pysal
-    >>> stl = pysal.open('../pysal/examples/stl_hom.csv', 'r')
+    >>> stl = pysal.open(pysal.examples.get_path('stl_hom.csv'), 'r')
     >>> e, b = np.array(stl[:,10]), np.array(stl[:,13])
 
 We then read the spatial weights file defining neighborhood relationships among the counties 
@@ -149,7 +149,7 @@ and ensure that the :ref:`order <id_order>` of observations in the weights objec
 
 .. doctest:: 
 
-    >>> w = pysal.open('../pysal/examples/stl.gal', 'r').read()
+    >>> w = pysal.open(pysal.examples.get_path("stl.gal"),"r").read()
     >>> if not w.id_order_set: w.id_order = range(1,len(stl) + 1)
 
 Now we calculate locally weighted averages of the homicide rates.

--- a/pysal/esda/moran.py
+++ b/pysal/esda/moran.py
@@ -726,10 +726,10 @@ class Moran_Local(object):
 
     Parameters
     ----------
-    y : array
-        (n,1), attribute array
-    w : W
-        weight instance assumed to be aligned with y
+    y              : array
+                     (n,1), attribute array
+    w              : W
+                     weight instance assumed to be aligned with y
     transformation : {'R', 'B', 'D', 'U', 'V'}
                      weights transformation,  default is row-standardized "r".
                      Other options include
@@ -952,12 +952,12 @@ class Moran_Local_BV(object):
 
     Parameters
     ----------
-    x : array
-        x-axis variable
-    y : array
-        (n,1), wy will be on y axis
-    w : W
-        weight instance assumed to be aligned with y
+    x              : array
+                     x-axis variable
+    y              : array
+                     (n,1), wy will be on y axis
+    w              : W
+                     weight instance assumed to be aligned with y
     transformation : {'R', 'B', 'D', 'U', 'V'}
                      weights transformation,  default is row-standardized "r".
                      Other options include
@@ -1197,15 +1197,15 @@ class Moran_Local_Rate(Moran_Local):
 
     Parameters
     ----------
-    e : array
-        (n,1), an event variable across n spatial units
-    b : array
-        (n,1), a population-at-risk variable across n spatial units
-    w : W
-        weight instance assumed to be aligned with y
-    adjusted : boolean
-              whether or not local Moran statistics need to be adjusted for
-              rate variable
+    e              : array
+                     (n,1), an event variable across n spatial units
+    b              : array
+                     (n,1), a population-at-risk variable across n spatial units
+    w              : W
+                     weight instance assumed to be aligned with y
+    adjusted       : boolean
+                     whether or not local Moran statistics need to be adjusted for
+                     rate variable
     transformation : {'R', 'B', 'D', 'U', 'V'}
                      weights transformation,  default is row-standardized "r".
                      Other options include
@@ -1222,47 +1222,47 @@ class Moran_Local_Rate(Moran_Local):
                      If False use PySAL Scheme: HH=1, LH=2, LL=3, HL=4
     Attributes
     ----------
-    y            : array
-                   rate variables computed from parameters e and b
-                   if adjusted is True, y is standardized rates
-                   otherwise, y is raw rates
-    w            : W
-                   original w object
-    permutations : int
-                   number of random permutations for calculation of pseudo
-                   p_values
-    I            : float
-                   value of Moran's I
-    q            : array
-                   (if permutations>0)
-                   values indicate quandrant location 1 HH,  2 LH,  3 LL,  4 HL
-    sim          : array
-                   (if permutations>0)
-                   vector of I values for permuted samples
-    p_sim        : array
-                   (if permutations>0)
-                   p-value based on permutations (one-sided)
-                   null: spatial randomness
-                   alternative: the observed Ii is further away or extreme
-                   from the median of simulated Iis. It is either extremely
-                   high or extremely low in the distribution of simulated Is
-    EI_sim       : float
-                   (if permutations>0)
-                   average value of I from permutations
-    VI_sim       : float
-                   (if permutations>0)
-                   variance of I from permutations
-    seI_sim      : float
-                   (if permutations>0)
-                   standard deviation of I under permutations.
-    z_sim        : float
-                   (if permutations>0)
-                   standardized I based on permutations
-    p_z_sim      : float
-                   (if permutations>0)
-                   p-value based on standard normal approximation from
-                   permutations (one-sided)
-                   for two-sided tests, these values should be multiplied by 2
+    y              : array
+                     rate variables computed from parameters e and b
+                     if adjusted is True, y is standardized rates
+                     otherwise, y is raw rates
+    w              : W
+                     original w object
+    permutations   : int
+                     number of random permutations for calculation of pseudo
+                     p_values
+    Is             : float
+                     local Moran's I values for rates or Empirical Bayes Index
+    q              : array
+                     (if permutations>0)
+                     values indicate quandrant location 1 HH,  2 LH,  3 LL,  4 HL
+    sim            : array
+                     (if permutations>0)
+                     vector of I values for permuted samples
+    p_sim          : array
+                     (if permutations>0)
+                     p-values based on permutations (one-sided)
+                     null: spatial randomness
+                     alternative: the observed Ii is further away or extreme
+                     from the median of simulated values. It is either extremelyi
+                     high or extremely low in the distribution of simulated Is.
+    EI_sim         : array
+                     (if permutations>0)
+                     average values of local Is from permutations
+    VI_sim         : array
+                     (if permutations>0)
+                     variance of Is from permutations
+    seI_sim        : array
+                     (if permutations>0)
+                     standard deviations of Is under permutations.
+    z_sim          : arrray
+                     (if permutations>0)
+                     standardized Is based on permutations
+    p_z_sim        : array
+                     (if permutations>0)
+                     p-values based on standard normal approximation from
+                     permutations (one-sided)
+                     for two-sided tests, these values should be multiplied by 2
 
     Examples
     --------

--- a/pysal/esda/smoothing.py
+++ b/pysal/esda/smoothing.py
@@ -510,10 +510,10 @@ def assuncao_rate(e, b):
 
     Parameters
     ----------
-    e          : array(n, 1)
-                 event variable measured at n spatial units
-    b          : array(n, 1)
-                 population at risk variable measured at n spatial units
+    e          : array
+                 (n, 1), event variable measured at n spatial units
+    b          : array
+                 (n, 1), population at risk variable measured at n spatial units
 
     Notes
     -----
@@ -521,7 +521,8 @@ def assuncao_rate(e, b):
 
     Returns
     -------
-               : array (nx1)
+               : array
+                 (n,1)
 
     Examples
     --------
@@ -540,7 +541,7 @@ def assuncao_rate(e, b):
     Computing the rates
 
     >>> print assuncao_rate(e, b)[:4]
-    [ 1.04319254 -0.04117865 -0.56539054 -1.73762547]
+    [ 1.03843594 -0.04099089 -0.56250375 -1.73061861]
 
     """
 
@@ -667,15 +668,15 @@ class Empirical_Bayes(_Smoother):
 
     Parameters
     ----------
-    e           : array (n, 1)
-                  event variable measured across n spatial units
-    b           : array (n, 1)
-                  population at risk variable measured across n spatial units
+    e           : array
+                  (n, 1), event variable measured across n spatial units
+    b           : array
+                  (n, 1), population at risk variable measured across n spatial units
 
     Attributes
     ----------
-    r           : array (n, 1)
-                  rate values from Empirical Bayes Smoothing
+    r           : array
+                  (n, 1), rate values from Empirical Bayes Smoothing
 
     Examples
     --------

--- a/pysal/weights/Contiguity.py
+++ b/pysal/weights/Contiguity.py
@@ -79,11 +79,13 @@ class Rook(W):
         """
         sparse = kwargs.pop('sparse', False)
         if idVariable is not None:
-            ids = get_ids(filepath, idVariable) 
+            ids = get_ids(filepath, idVariable)
+            id_order = ids
         else:
             ids = None
+            id_order = None
         iterable = FileIO(filepath)
-        w = cls(FileIO(filepath), ids=ids, **kwargs)
+        w = cls(iterable, ids=ids, id_order=id_order, **kwargs)
         w.set_shapefile(filepath, idVariable=idVariable, full=full)
         if sparse:
             w = w.to_WSP()
@@ -243,11 +245,14 @@ class Queen(W):
         """
         sparse = kwargs.pop('sparse', False)
         if idVariable is not None:
-            ids = get_ids(filepath, idVariable) 
+            ids = get_ids(filepath, idVariable)
+            id_order = ids
         else:
             ids = None
+            id_order = None
+
         iterable = FileIO(filepath)
-        w = cls(FileIO(filepath), ids=ids, **kwargs)
+        w = cls(iterable, ids=ids, id_order=id_order, **kwargs)
         w.set_shapefile(filepath, idVariable=idVariable, full=full)
         if sparse:
             w = w.to_WSP()


### PR DESCRIPTION
Resolve issue of `id_order_set` being "False" when building contiguity weights from shapefile even if `idVariable` is given in initialization:
![image](https://user-images.githubusercontent.com/7359284/31255302-1539a13c-a9e1-11e7-9866-7a81ca586aaf.png)
This is not true for functions building knn weights (`idVariable=True`):
![image](https://user-images.githubusercontent.com/7359284/31255335-3eb5e66a-a9e1-11e7-8b73-c87749d77230.png)
False `id_order_set` causes errors when spatial weight is a parameter in some pysal functions such as `Spatial_Empirical_Bayes` which requires a "True" `id_order_set`:
![image](https://user-images.githubusercontent.com/7359284/31255391-718bde32-a9e1-11e7-84e2-84bb94030d6f.png)
The changes in [smoothing.py](https://github.com/weikang9009/pysal/blob/master/pysal/esda/smoothing.py) deals with this issue by setting `id_order_set` as "True" when `idVariable` is assigned a value in building contiguity weights (rook and queen) from shapefile.
