### PR TITLE
resolve discrepancy of estimating Moran's I corrected for rates between GeoDa and pysal

### DIFF
--- a/doc/source/references.rst
+++ b/doc/source/references.rst
@@ -10,7 +10,7 @@ References
 .. [Anselin1997] Anselin, L. and Kelejian, H. H. (1997). Testing for spatial error autocorrelation in the presence of endogenous regressors. International Regional Science Review, 20(1-2):153–182.
 .. [Anselin2011] Anselin, L. (2011). GMM Estimation of Spatial Error Autocorrelation with and without Heteroskedasticity.
 .. [Arraiz2010] Arraiz, I., Drukker, D. M., Kelejian, H. H., and Prucha, I. R. (2010). A spatial Cliff-Ord-type model with heteroskedastic innovations: Small and large sample results. Journal of Regional Science, 50(2):592–614.
-.. [Assuncao1999] Assuncao, R. M. and Reis, E. A. (1999). A new proposal to adjust moran’s i for population density. Statistics in medicine, 18(16):2147–2162.
+.. [Assuncao1999] Assuncao, R. M. and Reis, E. A. (1999). A new proposal to adjust Moran’s I for population density. Statistics in medicine, 18(16):2147–2162.
 .. [Baker2004] Baker, R. D. (2004). Identifying space–time disease clusters. Acta tropica, 91(3):291–299.
 .. [Belsley1980] Belsley, D. A., Kuh, E., and Welsch, R. E. (1980). Regression diagnostics: Identifying influential data and sources of collinearity, volume 1.
 .. [Bickenbach2003] Bickenbach, F. and Bode, E. (2003). Evaluating the Markov property in studies of economic convergence. International Regional Science Review, 26(3):363–392.

--- a/pysal/esda/moran.py
+++ b/pysal/esda/moran.py
@@ -553,6 +553,15 @@ class Moran_Rate(Moran):
     permutations    : int
                       number of random permutations for calculation of pseudo
                       p_values
+    geoda_rate      : boolean
+                      If adjusted=True and geoda=True, rates are adjusted and
+                      conform with Geoda implementation: if a<0, variance
+                      estimator is v_i = b/x_i for any i; otherwise v_i = a+b/x_i.
+                      If adjusted=True and geoda=False, conform with
+                      Assuncao and Reis (1999) [Assuncao1999]_ :
+                      assign v_i = a+b/x_i and check individual v_i: if v_i<0,
+                      assign v_i = b/x_i.
+                      Default is True.
 
     Attributes
     ----------
@@ -628,11 +637,11 @@ class Moran_Rate(Moran):
     """
 
     def __init__(self, e, b, w, adjusted=True, transformation="r",
-                 permutations=PERMUTATIONS, two_tailed=True):
+                 permutations=PERMUTATIONS, two_tailed=True, geoda_rate=True):
         e = np.asarray(e).flatten()
         b = np.asarray(b).flatten()
         if adjusted:
-            y = assuncao_rate(e, b)
+            y = assuncao_rate(e, b, geoda=geoda_rate)
         else:
             y = e * 1.0 / b
         Moran.__init__(self, y, w, transformation=transformation,
@@ -1220,6 +1229,15 @@ class Moran_Local_Rate(Moran_Local):
                      (default=False)
                      If True use GeoDa scheme: HH=1, LL=2, LH=3, HL=4
                      If False use PySAL Scheme: HH=1, LH=2, LL=3, HL=4
+    geoda_rate     : boolean
+                     If adjusted=True and geoda=True, rates are adjusted and
+                     conform with Geoda implementation: if a<0, variance
+                     estimator is v_i = b/x_i for any i; otherwise v_i = a+b/x_i.
+                     If adjusted=True and geoda=False, conform with
+                     Assuncao and Reis (1999) [Assuncao1999]_ :
+                     assign v_i = a+b/x_i and check individual v_i: if v_i<0,
+                     assign v_i = b/x_i.
+                     Default is True.
     Attributes
     ----------
     y              : array
@@ -1293,11 +1311,11 @@ class Moran_Local_Rate(Moran_Local):
     """
 
     def __init__(self, e, b, w, adjusted=True, transformation="r",
-                 permutations=PERMUTATIONS, geoda_quads=False):
+                 permutations=PERMUTATIONS, geoda_quads=False, geoda_rate=True):
         e = np.asarray(e).flatten()
         b = np.asarray(b).flatten()
         if adjusted:
-            y = assuncao_rate(e, b)
+            y = assuncao_rate(e, b, geoda=geoda_rate)
         else:
             y = e * 1.0 / b
         Moran_Local.__init__(self, y, w,

--- a/pysal/esda/moran.py
+++ b/pysal/esda/moran.py
@@ -554,10 +554,10 @@ class Moran_Rate(Moran):
                       number of random permutations for calculation of pseudo
                       p_values
     geoda_rate      : boolean
-                      If adjusted=True and geoda=True, rates are adjusted and
+                      If adjusted=True and geoda_rate=True, rates are adjusted and
                       conform with Geoda implementation: if a<0, variance
                       estimator is v_i = b/x_i for any i; otherwise v_i = a+b/x_i.
-                      If adjusted=True and geoda=False, conform with
+                      If adjusted=True and geoda_rate=False, conform with
                       Assuncao and Reis (1999) [Assuncao1999]_ :
                       assign v_i = a+b/x_i and check individual v_i: if v_i<0,
                       assign v_i = b/x_i.
@@ -1230,10 +1230,10 @@ class Moran_Local_Rate(Moran_Local):
                      If True use GeoDa scheme: HH=1, LL=2, LH=3, HL=4
                      If False use PySAL Scheme: HH=1, LH=2, LL=3, HL=4
     geoda_rate     : boolean
-                     If adjusted=True and geoda=True, rates are adjusted and
+                     If adjusted=True and geoda_rate=True, rates are adjusted and
                      conform with Geoda implementation: if a<0, variance
                      estimator is v_i = b/x_i for any i; otherwise v_i = a+b/x_i.
-                     If adjusted=True and geoda=False, conform with
+                     If adjusted=True and geoda_rate=False, conform with
                      Assuncao and Reis (1999) [Assuncao1999]_ :
                      assign v_i = a+b/x_i and check individual v_i: if v_i<0,
                      assign v_i = b/x_i.

--- a/pysal/esda/smoothing.py
+++ b/pysal/esda/smoothing.py
@@ -512,7 +512,7 @@ def assuncao_rate(e, b, geoda=True):
                  (n, 1), event variable measured at n spatial units
     b          : array
                  (n, 1), population at risk variable measured at n spatial units
-    geoda      : bool
+    geoda      : boolean
                  If True, conform with Geoda implementation: if a<0, variance
                  estimator is v_i = b/x_i for any i; otherwise v_i = a+b/x_i.
                  If False, conform with Assuncao and Reis (1999) [Assuncao1999]_ :

--- a/pysal/esda/tests/test_smoothing.py
+++ b/pysal/esda/tests/test_smoothing.py
@@ -487,8 +487,7 @@ class TestUtils(unittest.TestCase):
     def test_assuncao_rate(self):
         e = np.array([30, 25, 25, 15, 33, 21, 30, 20])
         b = np.array([100, 100, 110, 90, 100, 90, 110, 90])
-        exp_assuncao = np.array([1.03843594, -0.04099089, -0.56250375,
-            -1.73061861])
+        exp_assuncao = np.array([ 0.95839273, -0.03783129, -0.51460896, -1.61105841])
         np.testing.assert_array_almost_equal(
             exp_assuncao, sm.assuncao_rate(e, b)[:4])
 

--- a/pysal/esda/tests/test_smoothing.py
+++ b/pysal/esda/tests/test_smoothing.py
@@ -487,9 +487,14 @@ class TestUtils(unittest.TestCase):
     def test_assuncao_rate(self):
         e = np.array([30, 25, 25, 15, 33, 21, 30, 20])
         b = np.array([100, 100, 110, 90, 100, 90, 110, 90])
-        exp_assuncao = np.array([ 0.95839273, -0.03783129, -0.51460896, -1.61105841])
+
+        exp_assuncao_geoda = np.array([ 0.95839273, -0.03783129, -0.51460896, -1.61105841])
         np.testing.assert_array_almost_equal(
-            exp_assuncao, sm.assuncao_rate(e, b)[:4])
+            exp_assuncao_geoda, sm.assuncao_rate(e, b)[:4])
+
+        exp_assuncao = np.array([1.03843594, -0.04099089, -0.56250375, -1.73061861])
+        np.testing.assert_array_almost_equal(
+            exp_assuncao, sm.assuncao_rate(e, b, geoda=False)[:4])
 
 
 suite = unittest.TestSuite()


### PR DESCRIPTION
This PR is to resolve the discrepancy in estimating EBI (Moran's I corrected for rates) between GeoDa and pysal as pointed out in #987. Now users could choose to conform with Geoda by setting parameter `geoda_rate=True` :
```python
pysal.esda.moran.Moran_Local(e, b, w, adjusted=True, transformation = "r", geoda_rate=True)
pysal.esda.moran.Moran_Local_Rate(e, b, w, adjusted=True, transformation = "r", geoda_rate=True)
```
or to use the original implementation of correcting rates in pysal which conform with the Assunção's paper by setting parameter `geoda_rate=False":

```python
pysal.esda.moran.Moran_Local(e, b, w, adjusted=True, transformation = "r", geoda_rate=False)
pysal.esda.moran.Moran_Local_Rate(e, b, w, adjusted=True, transformation = "r", geoda_rate=False)
```

