### PR TITLE
fromstring is deprecated in 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "2.7"
   - "3.4"
   - "3.5"
+  - "3.6"
 
 env:
   - PYSAL_PLUS=false

--- a/pysal/core/util/shapefile.py
+++ b/pysal/core/util/shapefile.py
@@ -149,7 +149,10 @@ def _unpackDict2(d, structure, fileObj):
     for name, dtype, order in structure:
         dtype, n = dtype
         result = array.array(dtype)
-        result.fromstring(fileObj.read(result.itemsize * n))
+        try:
+            result.frombytes(fileObj.read(result.itemsize * n))
+        except AttributeError:
+            result.fromstring(fileObj.read(result.itemsize * n))
         if order != SYS_BYTE_ORDER:
             result.byteswap()
         d[name] = result.tolist()


### PR DESCRIPTION
Hello,

1. [X] You have run tests on this submission, either by using [Travis Continuous Integration testing](https://github.com/pysal/pysal/wiki/GitHub-Standard-Operating-Procedures#automated-testing-w-travis-ci) testing or running `nosetests` on your changes?
2. [X] This pull request is directed to the `pysal/master` branch. **This is important, as any PRs submitted against any other branches will be delayed.**
3. [N/A] This pull introduces new functionality covered by
   [docstrings](https://en.wikipedia.org/wiki/Docstring#Python) and
   [unittests](https://docs.python.org/2/library/unittest.html)? 
4. [ ] You have [assigned a
   reviewer](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) and added relevant [labels](https://help.github.com/articles/applying-labels-to-issues-and-pull-requests/)
5. [X] The justification for this PR is: 

`array.fromstring` is [deprecated](https://docs.python.org/3/library/array.html#array.array.frombytes).

I think this is a quick way to maintain 2.7 compatibility while you get 3.6 ready. 

Let me know what you think. 
