### PR TITLE
Fix UnicodeDecodeError by changing UTF-8 character to ASCII.

### DIFF
--- a/pysal/examples/networks/README.md
+++ b/pysal/examples/networks/README.md
@@ -9,7 +9,7 @@ Datasets used for network testing
 * eberly_net.shx: spatial index.
 * eberly_net_pts_offnetwork.dbf: attribute data for points off network. (k=2)
 * eberly_net_pts_offnetwork.shp: Point shapefile. (n=100)
-* eberly_net_pts_offnetwork.shx: spatial index。
+* eberly_net_pts_offnetwork.shx: spatial index.
 * eberly_net_pts_onnetwork.dbf: attribute data for points on network. (k=1)
 * eberly_net_pts_onnetwork.shp: Point shapefile. (n=110)
 * eberly_net_pts_onnetwork.shx: spatial index.


### PR DESCRIPTION
Full error from the Debian package build:

```
======================================================================
ERROR: test_parser (pysal.examples.test_examples.Example_Tester)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/build/pysal-1.14.3/.pybuild/pythonX.Y_3.6/build/pysal/examples/test_examples.py", line 15, in test_parser
    self.extext = ex.explain(example)
  File "/build/pysal-1.14.3/.pybuild/pythonX.Y_3.6/build/pysal/examples/__init__.py", line 77, in explain
    return _read_example(fpath)
  File "/build/pysal-1.14.3/.pybuild/pythonX.Y_3.6/build/pysal/examples/__init__.py", line 55, in _read_example
    title = io.readline().strip('\n')
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe3 in position 384: ordinal not in range(128)
-------------------- >> begin captured stdout << ---------------------
```