### PR TITLE
resolve discrepancy of estimating Moran's I corrected for rates between GeoDa and pysal

### DIFF
--- a/doc/source/developers/release.rst
+++ b/doc/source/developers/release.rst
@@ -37,13 +37,13 @@ As of version 1.6, docs are automatically compiled and hosted_.
 Make a source dist and test locally (Python 3)
 ----------------------------------------------
 
-On each build machine::
+On each build machine
 
   $  git clone http://github.com/pysal/pysal.git
   $  cd pysal
   $  python setup.py sdist
-  $  cp dist/PySAL-1.14.2.tar.gz ../test/.
-  $  cd ../test
+  $  cp dist/PySAL-1.14.2.tar.gz ../junk/.
+  $  cd ../junk
   $  conda create -n pysaltest3 python=3 pip
   $  source activate pysaltest3
   $  pip install PySAL-1.14.2.tar.gz
@@ -60,11 +60,11 @@ Upload release to pypi
 
    $ python setup.py sdist upload
 
-- If not registered_, do so. Follow the prompts. You can save the
-  login credentials in a dot-file, .pypirc
+  - if not registered_, do so. Follow the prompts. You can save the
+      login credentials in a dot-file, .pypirc
 
 - Make and upload the Windows installer to SourceForge.
-- On a Windows box, build the installer as so::
+  - On a Windows box, build the installer as so:: 
 
     $ python setup.py bdist_wininst
 
@@ -84,8 +84,8 @@ Bump master version
 -------------------
 
 - Change MAJOR, MINOR version in setup script.
-- Change pysal/version.py
-- Change the docs version X.x by editing doc/source/conf.py in two places.
+- Change pysal/version.py to dev number
+- Change the docs version from X.x to X.xdev by editing doc/source/conf.py in two places.
 - Update the release schedule in doc/source/developers/guidelines.rst
 
 

--- a/doc/source/references.rst
+++ b/doc/source/references.rst
@@ -10,7 +10,7 @@ References
 .. [Anselin1997] Anselin, L. and Kelejian, H. H. (1997). Testing for spatial error autocorrelation in the presence of endogenous regressors. International Regional Science Review, 20(1-2):153–182.
 .. [Anselin2011] Anselin, L. (2011). GMM Estimation of Spatial Error Autocorrelation with and without Heteroskedasticity.
 .. [Arraiz2010] Arraiz, I., Drukker, D. M., Kelejian, H. H., and Prucha, I. R. (2010). A spatial Cliff-Ord-type model with heteroskedastic innovations: Small and large sample results. Journal of Regional Science, 50(2):592–614.
-.. [Assuncao1999] Assuncao, R. M. and Reis, E. A. (1999). A new proposal to adjust moran’s i for population density. Statistics in medicine, 18(16):2147–2162.
+.. [Assuncao1999] Assuncao, R. M. and Reis, E. A. (1999). A new proposal to adjust Moran’s I for population density. Statistics in medicine, 18(16):2147–2162.
 .. [Baker2004] Baker, R. D. (2004). Identifying space–time disease clusters. Acta tropica, 91(3):291–299.
 .. [Belsley1980] Belsley, D. A., Kuh, E., and Welsch, R. E. (1980). Regression diagnostics: Identifying influential data and sources of collinearity, volume 1.
 .. [Bickenbach2003] Bickenbach, F. and Bode, E. (2003). Evaluating the Markov property in studies of economic convergence. International Regional Science Review, 26(3):363–392.

--- a/pysal/esda/moran.py
+++ b/pysal/esda/moran.py
@@ -554,6 +554,7 @@ class Moran_Rate(Moran):
                       number of random permutations for calculation of pseudo
                       p_values
     geoda_rate      : boolean
+                      If adjusted=False, geoda_rate is ignored.
                       If adjusted=True and geoda_rate=True, rates are adjusted and
                       conform with Geoda implementation: if a<0, variance
                       estimator is v_i = b/x_i for any i; otherwise v_i = a+b/x_i.
@@ -1230,6 +1231,7 @@ class Moran_Local_Rate(Moran_Local):
                      If True use GeoDa scheme: HH=1, LL=2, LH=3, HL=4
                      If False use PySAL Scheme: HH=1, LH=2, LL=3, HL=4
     geoda_rate     : boolean
+                     If adjusted=False, geoda_rate is ignored.
                      If adjusted=True and geoda_rate=True, rates are adjusted and
                      conform with Geoda implementation: if a<0, variance
                      estimator is v_i = b/x_i for any i; otherwise v_i = a+b/x_i.

--- a/pysal/esda/moran.py
+++ b/pysal/esda/moran.py
@@ -553,6 +553,15 @@ class Moran_Rate(Moran):
     permutations    : int
                       number of random permutations for calculation of pseudo
                       p_values
+    geoda_rate      : boolean
+                      If adjusted=True and geoda_rate=True, rates are adjusted and
+                      conform with Geoda implementation: if a<0, variance
+                      estimator is v_i = b/x_i for any i; otherwise v_i = a+b/x_i.
+                      If adjusted=True and geoda_rate=False, conform with
+                      Assuncao and Reis (1999) [Assuncao1999]_ :
+                      assign v_i = a+b/x_i and check individual v_i: if v_i<0,
+                      assign v_i = b/x_i.
+                      Default is True.
 
     Attributes
     ----------
@@ -628,11 +637,11 @@ class Moran_Rate(Moran):
     """
 
     def __init__(self, e, b, w, adjusted=True, transformation="r",
-                 permutations=PERMUTATIONS, two_tailed=True):
+                 permutations=PERMUTATIONS, two_tailed=True, geoda_rate=True):
         e = np.asarray(e).flatten()
         b = np.asarray(b).flatten()
         if adjusted:
-            y = assuncao_rate(e, b)
+            y = assuncao_rate(e, b, geoda=geoda_rate)
         else:
             y = e * 1.0 / b
         Moran.__init__(self, y, w, transformation=transformation,
@@ -1220,6 +1229,15 @@ class Moran_Local_Rate(Moran_Local):
                      (default=False)
                      If True use GeoDa scheme: HH=1, LL=2, LH=3, HL=4
                      If False use PySAL Scheme: HH=1, LH=2, LL=3, HL=4
+    geoda_rate     : boolean
+                     If adjusted=True and geoda_rate=True, rates are adjusted and
+                     conform with Geoda implementation: if a<0, variance
+                     estimator is v_i = b/x_i for any i; otherwise v_i = a+b/x_i.
+                     If adjusted=True and geoda_rate=False, conform with
+                     Assuncao and Reis (1999) [Assuncao1999]_ :
+                     assign v_i = a+b/x_i and check individual v_i: if v_i<0,
+                     assign v_i = b/x_i.
+                     Default is True.
     Attributes
     ----------
     y              : array
@@ -1293,11 +1311,11 @@ class Moran_Local_Rate(Moran_Local):
     """
 
     def __init__(self, e, b, w, adjusted=True, transformation="r",
-                 permutations=PERMUTATIONS, geoda_quads=False):
+                 permutations=PERMUTATIONS, geoda_quads=False, geoda_rate=True):
         e = np.asarray(e).flatten()
         b = np.asarray(b).flatten()
         if adjusted:
-            y = assuncao_rate(e, b)
+            y = assuncao_rate(e, b, geoda=geoda_rate)
         else:
             y = e * 1.0 / b
         Moran_Local.__init__(self, y, w,

--- a/pysal/esda/smoothing.py
+++ b/pysal/esda/smoothing.py
@@ -502,11 +502,9 @@ def choynowski(e, b, n, threshold=None):
     return np.array(p)
 
 
-def assuncao_rate(e, b):
-    """The standardized rates where the mean and stadard deviation used for
-    the standardization are those of Empirical Bayes rate estimates
-    The standardized rates resulting from this function are used to compute
-    Moran's I corrected for rate variables [Choynowski1959]_ .
+def assuncao_rate(e, b, geoda=True):
+    """Standardized rates used for computing Moran's I corrected for rate
+    variables.
 
     Parameters
     ----------
@@ -514,25 +512,33 @@ def assuncao_rate(e, b):
                  (n, 1), event variable measured at n spatial units
     b          : array
                  (n, 1), population at risk variable measured at n spatial units
+    geoda      : boolean
+                 If True, conform with Geoda implementation: if a<0, variance
+                 estimator is v_i = b/x_i for any i; otherwise v_i = a+b/x_i.
+                 If False, conform with Assuncao and Reis (1999) [Assuncao1999]_ :
+                 assign v_i = a+b/x_i and check individual v_i: if v_i<0,
+                 assign v_i = b/x_i.
+                 Default is True.
 
     Notes
     -----
-    e and b are arranged in the same order
+    The mean and standard deviation used for standardizing rates are those
+    of Empirical Bayes rate estimates.
+    Based on Assuncao and Reis (1999) [Assuncao1999]_ .
 
     Returns
     -------
                : array
-                 (n,1)
+                 (n, 1)
 
     Examples
     --------
-
-    Creating an array of an event variable (e.g., the number of cancer patients)
+    Create an array of an event variable (e.g., the number of cancer patients)
     for 8 regions.
 
     >>> e = np.array([30, 25, 25, 15, 33, 21, 30, 20])
 
-    Creating another array of a population-at-risk variable (e.g., total population)
+    Create another array of a population-at-risk variable (e.g., total population)
     for the same 8 regions.
     The order for entering values is the same as the case of e.
 
@@ -540,19 +546,34 @@ def assuncao_rate(e, b):
 
     Computing the rates
 
-    >>> print assuncao_rate(e, b)[:4]
-    [ 1.03843594 -0.04099089 -0.56250375 -1.73061861]
+    >>> print(assuncao_rate(e, b)[:4])
+    [ 0.95839273 -0.03783129 -0.51460896 -1.61105841]
+
+    >>> import pysal
+    >>> w = pysal.open(pysal.examples.get_path("sids2.gal")).read()
+    >>> f = pysal.open(pysal.examples.get_path("sids2.dbf"))
+    >>> e = np.array(f.by_col('SID79'))
+    >>> b = np.array(f.by_col('BIR79'))
+    >>> print(assuncao_rate(e, b)[:4])
+    [-1.48875691  1.78507268 -0.34422806  0.26190802]
 
     """
 
-    y = e * 1.0 / b
+    e = np.array(e).astype(float)
+    b = np.array(b).astype(float)
+    y = e / b
     e_sum, b_sum = sum(e), sum(b)
-    ebi_b = e_sum * 1.0 / b_sum
-    s2 = sum(b * ((y - ebi_b) ** 2)) / b_sum
-    ebi_a = s2 - ebi_b / (float(b_sum) / len(e))
-    ebi_v_raw = ebi_a + ebi_b / b
-    ebi_v = np.where(ebi_v_raw < 0, ebi_b / b, ebi_v_raw)
+    ebi_b = e_sum / b_sum
+    s2 = sum(b * (((y - ebi_b) ** 2)/ b_sum))
+    ebi_a = s2 - (ebi_b / (b_sum / len(e)))
+    ebi_v = ebi_a + ebi_b / b
+    if geoda:
+        if ebi_a < 0:
+            ebi_v = ebi_b / b
+    else:
+        ebi_v = np.where(ebi_v < 0, ebi_b / b, ebi_v)
     return (y - ebi_b) / np.sqrt(ebi_v)
+
 
 class _Smoother(object):
     """

--- a/pysal/esda/tests/test_smoothing.py
+++ b/pysal/esda/tests/test_smoothing.py
@@ -487,10 +487,14 @@ class TestUtils(unittest.TestCase):
     def test_assuncao_rate(self):
         e = np.array([30, 25, 25, 15, 33, 21, 30, 20])
         b = np.array([100, 100, 110, 90, 100, 90, 110, 90])
-        exp_assuncao = np.array([1.03843594, -0.04099089, -0.56250375,
-            -1.73061861])
+
+        exp_assuncao_geoda = np.array([ 0.95839273, -0.03783129, -0.51460896, -1.61105841])
         np.testing.assert_array_almost_equal(
-            exp_assuncao, sm.assuncao_rate(e, b)[:4])
+            exp_assuncao_geoda, sm.assuncao_rate(e, b)[:4])
+
+        exp_assuncao = np.array([1.03843594, -0.04099089, -0.56250375, -1.73061861])
+        np.testing.assert_array_almost_equal(
+            exp_assuncao, sm.assuncao_rate(e, b, geoda=False)[:4])
 
 
 suite = unittest.TestSuite()


### PR DESCRIPTION
This PR is to reopen PR #989 which was unmerged but closed because of some complication I made. It is to resolve the discrepancy in estimating EBI (Moran's I corrected for rates) between GeoDa and pysal as pointed out in issue #987. Now users could choose to conform with Geoda by setting parameter `geoda_rate=True` :
```python
pysal.esda.moran.Moran_Local(e, b, w, adjusted=True, transformation = "r", geoda_rate=True)
pysal.esda.moran.Moran_Local_Rate(e, b, w, adjusted=True, transformation = "r", geoda_rate=True)
```
or to use the original implementation of correcting rates in pysal which conform with the Assunção's paper by setting parameter `geoda_rate=False`:

```python
pysal.esda.moran.Moran_Local(e, b, w, adjusted=True, transformation = "r", geoda_rate=False)
pysal.esda.moran.Moran_Local_Rate(e, b, w, adjusted=True, transformation = "r", geoda_rate=False)
```
