### PR TITLE
Improve code and documentation of viz.plot.mplot

### DIFF
--- a/pysal/contrib/viz/plot.py
+++ b/pysal/contrib/viz/plot.py
@@ -14,33 +14,51 @@ __all__ = ['mplot']
 
 
 def mplot(m, xlabel='', ylabel='', title='', custom=(7,7)):
-    '''
+    """
     Produce basic Moran Plot 
-    ...
+
     Parameters
-    ---------
-    m            : array
-                   values of Moran's I 
-    xlabel       : str
-                   label for x axis
-    ylabel       : str
-                   label for y axis                
-    title        : str
-                   title of plot
-    custom       : tuple
-                   dimensions of figure size
+    ----------
+    m : pysal.Moran instance
+        values of Moran's I Global Autocorrelation Statistic
+    xlabel : str
+        label for x axis
+    ylabel : str
+        label for y axis
+    title : str
+        title of plot
+    custom : tuple
+        dimensions of figure size
 
     Returns
-    ---------
-    plot         : png 
-                    image file showing plot
+    -------
+    fig : Matplotlib Figure instance
+        Moran scatterplot figure
+
+    Examples
+    --------
+    >>> import matplotlib.pyplot as plt
+    >>> import pysal as ps
+    >>> from pysal.contrib.pdio import read_files
+    >>> from pysal.contrib.viz.plot import mplot
+
+    >>> link = ps.examples.get_path('columbus.shp')
+    >>> db = read_files(link)
+    >>> y = db['HOVAL'].values
+    >>> w = ps.queen_from_shapefile(link)
+    >>> w.transform = 'R'
+
+    >>> m = ps.Moran(y, w)
+    >>> mplot(m, xlabel='Response', ylabel='Spatial Lag',
+    ...       title='Moran Scatterplot', custom=(7,7))
+
+    >>> plt.show()
             
-    '''
-    
+    """
     lag = ps.lag_spatial(m.w, m.z)
     fit = ps.spreg.OLS(m.z[:, None], lag[:,None])
 
-    ## Customize plot
+    # Customize plot
     fig = plt.figure(figsize=custom)
     ax = fig.add_subplot(111)
 
@@ -54,4 +72,4 @@ def mplot(m, xlabel='', ylabel='', title='', custom=(7,7)):
     ax.axvline(0, alpha=0.5)
     ax.axhline(0, alpha=0.5)
 
-    return None
+    return fig

--- a/pysal/contrib/viz/plot.py
+++ b/pysal/contrib/viz/plot.py
@@ -9,6 +9,10 @@ import numpy as np
 import pysal as ps
 import matplotlib.pyplot as plt
 
+
+__all__ = ['mplot']
+
+
 def mplot(m, xlabel='', ylabel='', title='', custom=(7,7)):
     '''
     Produce basic Moran Plot 
@@ -38,15 +42,16 @@ def mplot(m, xlabel='', ylabel='', title='', custom=(7,7)):
 
     ## Customize plot
     fig = plt.figure(figsize=custom)
-    plt.xlabel(xlabel)
-    plt.ylabel(ylabel)
-    plt.suptitle(title)
+    ax = fig.add_subplot(111)
 
-    plt.scatter(m.z, lag, s=60, color='k', alpha=.6)
-    plt.plot(lag, fit.predy, color='r')
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel(ylabel)
+    fig.suptitle(title)
 
-    plt.axvline(0, alpha=0.5)
-    plt.axhline(0, alpha=0.5)
-    plt.show()
+    ax.scatter(m.z, lag, s=60, color='k', alpha=.6)
+    ax.plot(lag, fit.predy, color='r')
+
+    ax.axvline(0, alpha=0.5)
+    ax.axhline(0, alpha=0.5)
 
     return None

--- a/pysal/contrib/viz/tests/test_plot.py
+++ b/pysal/contrib/viz/tests/test_plot.py
@@ -1,0 +1,19 @@
+import matplotlib.pyplot as plt
+import pysal as ps
+from pysal.contrib.pdio import read_files
+from pysal.contrib.viz.plot import mplot
+
+
+def test_mplot():
+    link = ps.examples.get_path('columbus.shp')
+
+    db = read_files(link)
+    y = db['HOVAL'].values
+    w = ps.queen_from_shapefile(link)
+    w.transform = 'R'
+
+    m = ps.Moran(y, w)
+
+    fig = mplot(m, xlabel='Response', ylabel='Spatial Lag',
+                title='Moran Scatterplot', custom=(7,7))
+    plt.close(fig)


### PR DESCRIPTION
Code changes:
- changed to matplotlib OO API: use of pyplot rather than the object-oriented matplotlib API (from https://matplotlib.org/faq/usage_faq.html: "For non-interactive plotting it is suggested to use pyplot to create the figures and then the OO interface for plotting.")
- removed `plt.show` call: `show` does not belong in a library, user may just want to save and close the figure
- added `__all__` dict

Documentation changes:
- added example
- fixed type descriptors,
- changed fuction to return figure instance,
- made docstring conform to numpydoc standard