### PR TITLE
addressing DeprecationWarning: fromstring()

### DIFF
--- a/pysal/lib/io/util/shapefile.py
+++ b/pysal/lib/io/util/shapefile.py
@@ -152,7 +152,7 @@ def _unpackDict2(d, structure, fileObj):
     for name, dtype, order in structure:
         dtype, n = dtype
         result = array.array(dtype)
-        result.fromstring(fileObj.read(result.itemsize * n))
+        result.frombytes(fileObj.read(result.itemsize * n))
         if order != SYS_BYTE_ORDER:
             result.byteswap()
         d[name] = result.tolist()

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,5 @@
 nose
 nose-progressive
-nose-exclude
 coverage
 sphinx>=1.4.3
 sphinxcontrib-napoleon


### PR DESCRIPTION
The justification for this PR is:

Addressing a `DeprecationWarning` ([reported here](https://github.com/pysal/pysal/issues/1072#issuecomment-456149651)) thrown within [`pysal/lib/io/util/shapefile.py`](https://github.com/pysal/pysal/blob/006a01a00fb146b5587497ccd675d43a42f331eb/pysal/lib/io/util/shapefile.py#L155) whereby `fromstring()` is now deprecated in favor of `frombytes()`.