### PR TITLE
SUR output does not show the value of the rho estimate

### DIFF
--- a/pysal/model/spreg/summary_output.py
+++ b/pysal/model/spreg/summary_output.py
@@ -1050,7 +1050,7 @@ def summary_coefs_sur(reg, lambd=False, regimes=False):
                 fixed_rho = 0
                 if k == range(regK)[-1] and (len(reg.name_bigyend[eq])/regK)*regK<len(reg.name_bigyend[eq]):
                     fixed_rho += 1
-                for j in range(len(reg.name_bigyend[eq]))[k*regkend:(k+1)*regkend+fixed_rho]:
+                for j in range(len(reg.name_bigyend[eq]))[int(k*regkend):int((k+1)*regkend+fixed_rho)]:
                     strSummary += "%20s    %12.7f    %12.7f    %12.7f    %12.7f\n"   \
                         % (reg.name_bigyend[eq][j], betas[eq][h+j][0], inf[eq][h+j][0],\
                              inf[eq][h+j][1], inf[eq][h+j][2])


### PR DESCRIPTION
5. [YES ] The justification for this PR is: 

Bug fix for SUR output does not show the value of the rho estimate (See example below)

The bug is in pysal.model.spreg.summary_output.py line 1053: [k*regkend:(k+1)*regkend+fixed_rho]
This part doesn’t work and will throw an exception “slice indices must be integers” instead of prining the value of rho estimate. This part should be: [int(k*regk):int((k+1)*regkend+fixed_rho)].

E.g.
```python
import pysal

db = pysal.lib.io.open("natregimes.dbf")
w = pysal.lib.weights.Queen.from_shapefile("natregimes.shp")
w.transform = 'r'

y_var = ['HR80', 'HR90']
x_var = [['PS80', 'UE80'], ['PS90','UE90']]

bigy, bigX, bigyvars, bigXvars = pysal.model.spreg.sur_dictxy(db, y_var, x_var)

reg = pysal.model.spreg.SURlagIV(bigy, bigX, w=w, name_bigy=bigyvars, name_bigX=bigXvars,
                                 name_ds='nat', name_w='nat_queen', nonspat_diag=True, spat_diag=True)

print(reg.summary)
```

Before fix:
```
SUMMARY OF EQUATION 1
---------------------
Dependent Variable  :        HR80                Number of Variables   :           4
Mean dependent var  :      6.9276                Degrees of Freedom    :        3081
S.D. dependent var  :      6.8251

------------------------------------------------------------------------------------
            Variable     Coefficient       Std.Error     z-Statistic     Probability
------------------------------------------------------------------------------------
          Constant_1       4.7976664       4.5582400       1.0525261       0.2925583
                PS80       0.6690071       0.3547444       1.8858845       0.0593105
                UE80       0.4543072       0.0779072       5.8313889       0.0000000
------------------------------------------------------------------------------------
Instrumented: W_HR80
Instruments: W_PS80, W_UE80

SUMMARY OF EQUATION 2
---------------------
Dependent Variable  :        HR90                Number of Variables   :           4
Mean dependent var  :      6.1829                Degrees of Freedom    :        3081
S.D. dependent var  :      6.6403

------------------------------------------------------------------------------------
            Variable     Coefficient       Std.Error     z-Statistic     Probability
------------------------------------------------------------------------------------
          Constant_2       2.2797256       0.3903511       5.8401928       0.0000000
                PS90       0.9925229       0.1216741       8.1572255       0.0000000
                UE90       0.5228057       0.0447687      11.6779288       0.0000000
------------------------------------------------------------------------------------
Instrumented: W_HR90
Instruments: W_PS90, W_UE90


REGRESSION DIAGNOSTICS
                                     TEST         DF       VALUE           PROB
                 Joint significance (rho)         2        1.028           0.5980

OTHER DIAGNOSTICS - CHOW TEST BETWEEN EQUATIONS
                                VARIABLES         DF       VALUE           PROB
                   Constant_1, Constant_2         1        0.318           0.5729
                               PS80, PS90         1        1.026           0.3111
                               UE80, UE90         1        1.026           0.3111
                           W_HR80, W_HR90         1        0.769           0.3807

ERROR CORRELATION MATRIX
  EQUATION 1  EQUATION 2
    1.000000    0.525751
    0.525751    1.000000
================================ END OF REPORT =====================================
```

After fix:
```
REGRESSION
----------
SUMMARY OF OUTPUT: SEEMINGLY UNRELATED REGRESSIONS (SUR) - SPATIAL LAG MODEL
----------------------------------------------------------------------------
Data set            :         nat
Weights matrix      :   nat_queen
Number of Equations :           2                Number of Observations:        3085
----------

SUMMARY OF EQUATION 1
---------------------
Dependent Variable  :        HR80                Number of Variables   :           4
Mean dependent var  :      6.9276                Degrees of Freedom    :        3081
S.D. dependent var  :      6.8251

------------------------------------------------------------------------------------
            Variable     Coefficient       Std.Error     z-Statistic     Probability
------------------------------------------------------------------------------------
          Constant_1       4.7976664       4.5582400       1.0525261       0.2925583
                PS80       0.6690071       0.3547444       1.8858845       0.0593105
                UE80       0.4543072       0.0779072       5.8313889       0.0000000
              W_HR80      -0.1366547       0.6743189      -0.2026558       0.8394040
------------------------------------------------------------------------------------
Instrumented: W_HR80
Instruments: W_PS80, W_UE80

SUMMARY OF EQUATION 2
---------------------
Dependent Variable  :        HR90                Number of Variables   :           4
Mean dependent var  :      6.1829                Degrees of Freedom    :        3081
S.D. dependent var  :      6.6403

------------------------------------------------------------------------------------
            Variable     Coefficient       Std.Error     z-Statistic     Probability
------------------------------------------------------------------------------------
          Constant_2       2.2797256       0.3903511       5.8401928       0.0000000
                PS90       0.9925229       0.1216741       8.1572255       0.0000000
                UE90       0.5228057       0.0447687      11.6779288       0.0000000
              W_HR90       0.0690947       0.0799641       0.8640716       0.3875486
------------------------------------------------------------------------------------
Instrumented: W_HR90
Instruments: W_PS90, W_UE90


REGRESSION DIAGNOSTICS
                                     TEST         DF       VALUE           PROB
                 Joint significance (rho)         2        1.028           0.5980

OTHER DIAGNOSTICS - CHOW TEST BETWEEN EQUATIONS
                                VARIABLES         DF       VALUE           PROB
                   Constant_1, Constant_2         1        0.318           0.5729
                               PS80, PS90         1        1.026           0.3111
                               UE80, UE90         1        1.026           0.3111
                           W_HR80, W_HR90         1        0.769           0.3807

ERROR CORRELATION MATRIX
  EQUATION 1  EQUATION 2
    1.000000    0.525751
    0.525751    1.000000
================================ END OF REPORT =====================================
```