### PR TITLE
(docs) reflect mgwr api (kernels) change in the docs

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -800,12 +800,8 @@ Kernel Specification
 .. autosummary::
    :toctree: generated/
 
-    mgwr.kernels.fix_gauss
-    mgwr.kernels.adapt_gauss
-    mgwr.kernels.fix_bisquare
-    mgwr.kernels.adapt_bisquare
-    mgwr.kernels.fix_exp
-    mgwr.kernels.adapt_exp
+    mgwr.kernels.Kernel
+    mgwr.kernels.local_cdist
 
 Bandwidth Selection
 +++++++++++++++++++


### PR DESCRIPTION
[mgwr `kernels` API has undergone drastic changes](https://github.com/pysal/mgwr/commit/7459714b5c794bb1dff9f9d15ec938de0629001f#diff-1f3d7dec52d318c5f783e7ca914f6855R24), but these changes are not reflected in the docs. 
This PR is to accommodate the changes in the docs website.

follow https://github.com/pysal/mgwr/pull/55