### PR TITLE
(docs) reference label style

### DIFF
--- a/doc/_static/pysal-styles.css
+++ b/doc/_static/pysal-styles.css
@@ -73,6 +73,10 @@
 .table-scrollable { margin: 0; padding: 0; }
 
 .label {
-    color: #222222;
-    font-size: 100%;
+    color: #ff0000;
+    /*font-size: 100%;*/
+}
+
+div.body {
+    max-width: 1080px;
 }


### PR DESCRIPTION
change reference label style to 
![image](https://user-images.githubusercontent.com/7359284/59960022-63078600-9476-11e9-85a3-b7a3b954e5f6.png)
follow https://github.com/pysal/giddy/pull/102
