### PR TITLE
Frozen

### DIFF
--- a/pysal/__init__.py
+++ b/pysal/__init__.py
@@ -4,44 +4,5 @@ from . import explore
 from . import viz
 from . import model
 
-from .base import memberships, federation_hierarchy
+from .base import memberships, federation_hierarchy, versions
 
-
-def installed_version(package):
-    exec(f'import {package}')
-    try:
-        v = eval(f'{package}.__version__')  ## FIX when spvcm is 0.3.0
-    except:
-        v = None
-    return v
-
-def installed_versions():
-    ver = {}
-    for package in memberships.keys():
-        ver[package] = installed_version(package)
-    return ver
-
-def released_versions():
-    from .frozen import frozen_packages
-    return frozen_packages
-
-def check_versions():
-    from .frozen import frozen_packages 
-    import warnings
-    frozen_packages.pop('spvcm')
-    current_packages = {}
-    for pkg in frozen_packages.keys():
-        exec(f'import {pkg}')
-        current_packages[pkg] = eval(f'{pkg}.__version__')
-    diffs = 0
-    for pkg in frozen_packages.keys():
-        if frozen_packages[pkg] != current_packages[pkg]:
-            diffs += 1
-            msg = (
-                f"The last meta package for PySAL included {pkg} "
-                f"at version {frozen_packages[pkg]}, but you have "
-                f"version {current_packages[pkg]}."
-                )
-            warnings.warn(msg)
-    if diffs == 0:
-        print(f'PySAL subpackages all pinned to meta release {__version__}.')

--- a/pysal/__init__.py
+++ b/pysal/__init__.py
@@ -4,9 +4,29 @@ from . import explore
 from . import viz
 from . import model
 
+from .base import memberships, federation_hierarchy
+
+
+def installed_version(package):
+    exec(f'import {package}')
+    try:
+        v = eval(f'{package}.__version__')  ## FIX when spvcm is 0.3.0
+    except:
+        v = None
+    return v
+
+def installed_versions():
+    ver = {}
+    for package in memberships.keys():
+        ver[package] = installed_version(package)
+    return ver
+
+def released_versions():
+    from .frozen import frozen_packages
+    return frozen_packages
 
 def check_versions():
-    from .base import frozen_packages
+    from .frozen import frozen_packages 
     import warnings
     frozen_packages.pop('spvcm')
     current_packages = {}

--- a/pysal/base.py
+++ b/pysal/base.py
@@ -2,19 +2,19 @@
 Frozen subpackages for meta release.
 """
 
-frozen_packages = {	"libpysal": "4.2.1",
-	"esda": "2.2.0",
-	"giddy": "2.3.0",
-	"inequality": "1.0.0",
-	"pointpats": "2.1.0",
-	"segregation": "1.1.1",
-	"spaghetti": "1.4.0",
-	"mgwr": "2.1.1",
-	"spglm": "1.0.7",
-	"spint": "1.0.6",
-	"spreg": "1.0.4",
-	"spvcm": "0.2.1.post1",
-	"tobler": "0.2.0",
-	"mapclassify": "2.2.0",
-	"splot": "1.1.2"
+frozen_packages = {    "libpysal": "4.2.2",
+    "esda": "2.2.1",
+    "giddy": "2.3.0",
+    "inequality": "1.0.0",
+    "pointpats": "2.1.0",
+    "segregation": "1.2.0",
+    "spaghetti": "1.4.1",
+    "mgwr": "2.1.1",
+    "spglm": "1.0.7",
+    "spint": "1.0.6",
+    "spreg": "1.0.4",
+    "spvcm": "0.2.1.post1",
+    "tobler": "0.2.0",
+    "mapclassify": "2.2.0",
+    "splot": "1.1.2"
 }

--- a/pysal/base.py
+++ b/pysal/base.py
@@ -28,3 +28,93 @@ memberships = {'libpysal': 'lib',
                'splot': 'viz',
                'mapclassify': 'viz'
 }
+
+
+class cached_property(object):
+    """ A property that is only computed once per instance and then replaces
+        itself with an ordinary attribute. Deleting the attribute resets the
+        property.
+
+        Source: https://github.com/bottlepy/bottle/commit/fa7733e075da0d790d809aa3d2f53071897e6f76
+        """
+
+    def __init__(self, func):
+        self.__doc__ = getattr(func, '__doc__')
+        self.func = func
+
+    def __get__(self, obj, cls):
+        if obj is None:
+            return self
+        value = obj.__dict__[self.func.__name__] = self.func(obj)
+        return value
+
+def _installed_version(package):
+    exec(f'import {package}')
+    try:
+        v = eval(f'{package}.__version__')  ## FIX when spvcm is 0.3.0
+    except:
+        v = 'NA'
+    return v
+
+def _installed_versions():
+    ver = {}
+    for package in memberships.keys():
+        ver[package] = _installed_version(package)
+    return ver
+
+def _released_versions():
+    from .frozen import frozen_packages
+    return frozen_packages
+
+
+class Versions:
+    @cached_property
+    def installed(self):
+        """
+        Inventory versions of pysal packages that are installed
+
+        Attributes
+        ----------
+        installed: dict
+                   key is package name, value is version string
+        """
+        return _installed_versions()
+
+    @cached_property
+    def released(self):
+        """
+        Inventory versions of pysal packages that are released in the meta
+        package.
+
+        Attributes
+        ----------
+        released: dict
+                   key is package name, value is version string
+        """
+
+        return _released_versions()
+
+    def check(self):
+        """
+        Print a tabular string that reports installed and released versions of
+        PySAL packages.
+        """
+        table = []
+        package = "Package"
+        installed = "Installed"
+        released = "Released"
+        match = "Match"
+        s = f'{package:>12} | {installed:>10} | {released:>13} | {match:>5}'
+        table.append(s)
+        table.append("-"*len(s))
+        for package in self.installed:
+            installed = self.installed[package]
+            released = self.released[package]
+            match = installed == released
+            s = f'{package:>12} | {installed:>10} | {released:>13} | {match:>5}'
+            table.append(s)
+        print("\n".join(table))
+
+
+versions = Versions()
+

--- a/pysal/base.py
+++ b/pysal/base.py
@@ -1,20 +1,30 @@
 """
-Frozen subpackages for meta release.
+Base information for pysal meta package
 """
 
-frozen_packages = {    "libpysal": "4.2.2",
-    "esda": "2.2.1",
-    "giddy": "2.3.0",
-    "inequality": "1.0.0",
-    "pointpats": "2.1.0",
-    "segregation": "1.2.0",
-    "spaghetti": "1.4.1",
-    "mgwr": "2.1.1",
-    "spglm": "1.0.7",
-    "spint": "1.0.6",
-    "spreg": "1.0.4",
-    "spvcm": "0.2.1.post1",
-    "tobler": "0.2.0",
-    "mapclassify": "2.2.0",
-    "splot": "1.1.2"
+
+federation_hierarchy = {
+    'explore': ['esda', 'giddy', 'segregation',
+                'pointpats', 'inequality',
+                'segregation', 'spaghetti'],
+    'model': ['spreg', 'spglm', 'tobler', 'spint',
+              'mgwr', 'spvcm'],
+    'viz': ['splot', 'mapclassify'],
+    'lib': ['libpysal']
+}
+
+memberships = {'libpysal': 'lib',
+               'esda': 'explore',
+               'giddy': 'explore',
+               'segregation': 'explore',
+               'pointpats': 'explore',
+               'inequality': 'explore',
+               'spaghetti': 'explore',
+               'spreg': 'model',
+               'spglm': 'model',
+               'spint': 'model',
+               'tobler': 'model',
+               'spvcm': 'model',
+               'splot': 'viz',
+               'mapclassify': 'viz'
 }

--- a/pysal/base.py
+++ b/pysal/base.py
@@ -49,10 +49,13 @@ class cached_property(object):
         return value
 
 def _installed_version(package):
-    exec(f'import {package}')
     try:
-        v = eval(f'{package}.__version__')  ## FIX when spvcm is 0.3.0
-    except:
+        exec(f'import {package}')
+    except ModuleNotFoundError:
+        v = 'NA'
+    try:
+        v = eval(f'{package}.__version__')
+    except AttributeError:
         v = 'NA'
     return v
 

--- a/pysal/frozen.py
+++ b/pysal/frozen.py
@@ -1,0 +1,20 @@
+"""
+Frozen subpackages for meta release.
+"""
+
+frozen_packages = {    "libpysal": "4.2.2",
+    "esda": "2.2.1",
+    "giddy": "2.3.0",
+    "inequality": "1.0.0",
+    "pointpats": "2.1.0",
+    "segregation": "1.2.0",
+    "spaghetti": "1.4.1",
+    "mgwr": "2.1.1",
+    "spglm": "1.0.7",
+    "spint": "1.0.6",
+    "spreg": "1.0.4",
+    "spvcm": "0.2.1.post1",
+    "tobler": "0.2.0",
+    "mapclassify": "2.2.0",
+    "splot": "1.1.2"
+}

--- a/tools/build.py
+++ b/tools/build.py
@@ -50,8 +50,8 @@ def _get_pysal_sub_versions():
 
 def get_frozen():
     from os import path
-    if not path.exists(PACKAGE_FILE):
-        _get_pysal_sub_versions()
+
+    _get_pysal_sub_versions()
     with open(PACKAGE_FILE, 'r') as version_file:
         frozen = dict([line.strip().split()
                        for line in version_file.readlines()])
@@ -93,3 +93,10 @@ def build_requirements():
 
     with open('requirements.txt', 'w') as req:
         req.write("\n".join(lines))
+
+def main():
+    build_requirements()
+    build_base()
+
+if __name__ == '__main__':
+    main()

--- a/tools/build.py
+++ b/tools/build.py
@@ -58,8 +58,8 @@ def get_frozen():
     return frozen
 
 
-def build_base():
-    base = os.path.join(os.pardir, 'pysal', 'base.py')
+def build_frozen():
+    base = os.path.join(os.pardir, 'pysal', 'frozen.py')
     content = f'"""\nFrozen subpackages for meta release.\n"""\n\n'
 
     with open(base, 'w') as target_file:
@@ -70,8 +70,11 @@ def build_base():
         for package, version in frozen.items():
             lines.append(f'    "{package}": "{version}"')
         lines = ",\n".join(lines)
+
         target_file.write(lines)
         target_file.write("\n}")
+
+
 
 def build_requirements():
     """
@@ -94,9 +97,11 @@ def build_requirements():
     with open('requirements.txt', 'w') as req:
         req.write("\n".join(lines))
 
+
+
 def main():
     build_requirements()
-    build_base()
+    build_frozen()
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Helper class and methods to introspect package versions in the meta release. Addresses #1153.

```
In [2]: pysal.versions.installed
Out[2]: 
{'libpysal': '4.2.2',
 'esda': '2.2.1',
 'giddy': '2.3.0',
 'segregation': '1.2.0',
 'pointpats': '2.1.0',
 'inequality': '1.0.0',
 'spaghetti': '1.4.1',
 'spreg': '1.0.4',
 'spglm': '1.0.7',
 'spint': '1.0.6',
 'tobler': '0.2.0',
 'spvcm': 'NA',
 'splot': '1.1.2',
 'mapclassify': '2.2.0'}

In [3]: pysal.versions.released
Out[3]: 
{'libpysal': '4.2.2',
 'esda': '2.2.1',
 'giddy': '2.3.0',
 'inequality': '1.0.0',
 'pointpats': '2.1.0',
 'segregation': '1.2.0',
 'spaghetti': '1.4.1',
 'mgwr': '2.1.1',
 'spglm': '1.0.7',
 'spint': '1.0.6',
 'spreg': '1.0.4',
 'spvcm': '0.2.1.post1',
 'tobler': '0.2.0',
 'mapclassify': '2.2.0',
 'splot': '1.1.2'}

In [4]: pysal.versions.check()
     Package |  Installed |      Released | Match
-------------------------------------------------
    libpysal |      4.2.2 |         4.2.2 |     1
        esda |      2.2.1 |         2.2.1 |     1
       giddy |      2.3.0 |         2.3.0 |     1
 segregation |      1.2.0 |         1.2.0 |     1
   pointpats |      2.1.0 |         2.1.0 |     1
  inequality |      1.0.0 |         1.0.0 |     1
   spaghetti |      1.4.1 |         1.4.1 |     1
       spreg |      1.0.4 |         1.0.4 |     1
       spglm |      1.0.7 |         1.0.7 |     1
       spint |      1.0.6 |         1.0.6 |     1
      tobler |      0.2.0 |         0.2.0 |     1
       spvcm |         NA |   0.2.1.post1 |     0
       splot |      1.1.2 |         1.1.2 |     1
 mapclassify |      2.2.0 |         2.2.0 |     1



```