### PR TITLE
MAINT: cleanup requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,8 +16,3 @@ tobler>=0.8.2
 mapclassify>=2.4.3
 splot>=1.1.4
 spopt>=0.2.1
-urllib3>=1.26
-python-dateutil<=2.8.0
-pytest
-pytest-cov
-coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-libpysal>=4.5.1.post2
+libpysal>=4.5.1
 access>=1.1.3
 esda>=2.4.1
 giddy>=2.3.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -13,3 +13,4 @@ wheel
 pytest
 pytest-mpl
 pytest-cov
+python-dateutil<=2.8.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,3 +14,4 @@ pytest
 pytest-mpl
 pytest-cov
 python-dateutil<=2.8.0
+urllib3>=1.26


### PR DESCRIPTION
Closes #1234 
Closes #1242 

I have moved `python-dateutil`and `urllib3` to `requirements-dev` and removed irrelevant packages from requirements.