### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/release_and_publish.yml
+++ b/.github/workflows/release_and_publish.yml
@@ -15,8 +15,13 @@
      tags:
        - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
  
+ permissions:
+   contents: read
+
  jobs:
    build:
+     permissions:
+       contents: write  # for softprops/action-gh-release to create GitHub release
      name: Create release & publish to PyPI
      runs-on: ubuntu-latest
      steps:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
