### PR TITLE
explicit intel chip test for macOS

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,9 +33,9 @@
          ]
          include:
            - environment-file: ci/312-latest.yaml
-             os: macos-latest # Apple Silicon
-           - environment-file: ci/312-latest.yaml
              os: macos-13 # Intel
+           - environment-file: ci/312-latest.yaml
+             os: macos-14 # Apple Silicon
            - environment-file: ci/312-latest.yaml
              os: windows-latest
        fail-fast: false


### PR DESCRIPTION
This PR:
* explicitly tests macOS on the old Intel chip - [see here](https://github.com/pysal/pysal/issues/1298#issuecomment-2106348049)
* xref https://github.com/pysal/pysal/issues/1298