### PR TITLE
manual option for publish action

### DIFF
--- a/.github/workflows/release_and_publish.yml
+++ b/.github/workflows/release_and_publish.yml
@@ -9,7 +9,7 @@ on:
     inputs:
       version:
         description: Manual Unittest Run
-        default: test
+        default: release+publish
         required: false
 
 permissions:

--- a/.github/workflows/release_and_publish.yml
+++ b/.github/workflows/release_and_publish.yml
@@ -5,6 +5,7 @@ on:
     # Sequence of patterns matched against refs/tags
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+  workflow_dispatch:  # Enables manual triggering from GH UI
 
 permissions:
   contents: read

--- a/.github/workflows/release_and_publish.yml
+++ b/.github/workflows/release_and_publish.yml
@@ -6,6 +6,11 @@ on:
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
   workflow_dispatch:  # Enables manual triggering from GH UI
+    inputs:
+      version:
+        description: Manual Unittest Run
+        default: test
+        required: false
 
 permissions:
   contents: read

--- a/.github/workflows/release_and_publish.yml
+++ b/.github/workflows/release_and_publish.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:  # Enables manual triggering from GH UI
     inputs:
       version:
-        description: Manual Unittest Run
+        description: Manual Release & Publish
         default: release+publish
         required: false
 


### PR DESCRIPTION
Given the complexity of the meta release, it would be nice to have the manual option available if things go sideways in a build.