### PR TITLE
Docs: Migrated contributing guidelines from Wiki to CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,2 +1,16 @@
-Thank you for your interest in contributing! We work primarily on Github. Please
-review the [contributing procedures](https://github.com/pysal/pysal/wiki/GitHub-Standard-Operating-Procedures) so that we can accept your contributions! Alternatively, contact someone in [PySAL's Discord channel](https://discord.gg/BxFTEPFFZn).
+# Contributing to PySAL
+
+PySAL moved to the Pull Request model at the 2013 SciPy Conference. Basically, this involves the following components:
+
+1. The organization GitHub account that has the master branch.
+2. Releases are made via tags out of master.
+
+A high-level overview of our model is as follows: All work will be submitted via pull requests. Developers will work on branches on their local machines, push these branches to their GitHub repos, and issue a pull request to the organization GitHub account. One of the other developers must review the Pull Request and merge it or, if there are issues, discuss them with the submitter. This ensures developers have a better understanding of the code base and we catch problems before they enter master.
+
+## Initial Setup
+
+1. If you don't have one yet, create your own account on GitHub.
+2. Fork `pysal/pysal` into your personal GitHub account.
+3. On a laptop/desktop client, clone master from your GitHub account:
+   ```bash
+   git clone [https://github.com/yourUsername/pysal.git](https://github.com/yourUsername/pysal.git)


### PR DESCRIPTION
## Justification
This PR addresses Issue #1333.

The current CONTRIBUTING.md was extremely brief and only linked to a Wiki page. I have migrated the relevant instructions from the Wiki into this file and formatted them into clean Markdown.

This makes the contributing guidelines more accessible and easier to maintain directly within the repo.