### PR TITLE
refactor: modernize dynamic imports with importlib and stdlib cached_property (fixes issue #1386)

### DIFF
--- a/pysal/base.py
+++ b/pysal/base.py
@@ -2,15 +2,23 @@
 Base information for pysal meta package
 """
 
+import importlib
+from functools import cached_property
 
 federation_hierarchy = {
-    'explore': ['esda', 'giddy', 'segregation',
-                'pointpats', 'inequality',
-                 'spaghetti', 'access', 'momepy'],
-    'model': ['spreg', 'spglm', 'tobler', 'spint',
-              'mgwr', 'access', 'spopt'],
-    'viz': ['splot', 'mapclassify'],
-    'lib': ['libpysal']
+    "explore": [
+        "esda",
+        "giddy",
+        "segregation",
+        "pointpats",
+        "inequality",
+        "spaghetti",
+        "access",
+        "momepy",
+    ],
+    "model": ["spreg", "spglm", "tobler", "spint", "mgwr", "access", "spopt"],
+    "viz": ["splot", "mapclassify"],
+    "lib": ["libpysal"],
 }
 
 memberships = {}
@@ -19,44 +27,36 @@ for key in federation_hierarchy:
         memberships[package] = key
 
 
-
-class cached_property(object):
-    """ A property that is only computed once per instance and then replaces
-        itself with an ordinary attribute. Deleting the attribute resets the
-        property.
-
-        Source: https://github.com/bottlepy/bottle/commit/fa7733e075da0d790d809aa3d2f53071897e6f76
-        """
-
-    def __init__(self, func):
-        self.__doc__ = getattr(func, '__doc__')
-        self.func = func
-
-    def __get__(self, obj, cls):
-        if obj is None:
-            return self
-        value = obj.__dict__[self.func.__name__] = self.func(obj)
-        return value
-
 def _installed_version(package):
+    """Get the installed version of a package.
+
+    Parameters
+    ----------
+    package : str
+        Name of the package to check.
+
+    Returns
+    -------
+    str
+        Version string if available, 'NA' otherwise.
+    """
     try:
-        exec(f'import {package}')
-    except ModuleNotFoundError:
-        v = 'NA'
-    try:
-        v = eval(f'{package}.__version__')
-    except AttributeError:
-        v = 'NA'
-    return v
+        mod = importlib.import_module(package)
+        return getattr(mod, "__version__", "NA")
+    except (ModuleNotFoundError, ImportError):
+        return "NA"
+
 
 def _installed_versions():
     ver = {}
-    for package in memberships.keys():
+    for package in memberships:
         ver[package] = _installed_version(package)
     return ver
 
+
 def _released_versions():
     from .frozen import frozen_packages
+
     return frozen_packages
 
 
@@ -97,17 +97,16 @@ class Versions:
         installed = "Installed"
         released = "Released"
         match = "Match"
-        s = f'{package:>12} | {installed:>15} | {released:>15} | {match:>5}'
+        s = f"{package:>12} | {installed:>15} | {released:>15} | {match:>5}"
         table.append(s)
-        table.append("-"*len(s))
+        table.append("-" * len(s))
         for package in self.installed:
             installed = self.installed[package]
             released = self.released[package]
             match = installed == released
-            s = f'{package:>12} | {installed:>15} | {released:>15} | {match:>5}'
+            s = f"{package:>12} | {installed:>15} | {released:>15} | {match:>5}"
             table.append(s)
         print("\n".join(table))
 
 
 versions = Versions()
-

--- a/pysal/lib/common.py
+++ b/pysal/lib/common.py
@@ -1,24 +1,12 @@
 import copy
-import sys
-import time
-
-# external imports
-import numpy as np
-import numpy.linalg as la
-
-import scipy as sp
-import scipy.stats as stats
-from libpysal.cg.kdtree import KDTree
-from scipy.spatial.distance import pdist, cdist
-
-import pandas
+import importlib
 
 try:
     from patsy import PatsyError
 except ImportError:
     PatsyError = Exception
 
-RTOL = .00001
+RTOL = 0.00001
 ATOL = 1e-7
 MISSINGVALUE = None
 
@@ -29,26 +17,33 @@ MISSINGVALUE = None
 # import numba.jit OR create mimic decorator and set existence flag
 try:
     from numba import jit
+
     HAS_JIT = True
 except ImportError:
-    def jit(function=None, **kwargs):
-        """Mimic numba.jit() with synthetic wrapper
-        """
+
+    def jit(function=None, **kwargs):  # noqa: ARG001
+        """Mimic numba.jit() with synthetic wrapper"""
         if function is not None:
+
             def wrapped(*original_args, **original_kw):
                 """Case 1 - structure of a standard decorator
                 i.e., jit(function)(*args, **kwargs)
                 """
                 return function(*original_args, **original_kw)
+
             return wrapped
         else:
+
             def partial_inner(func):
                 """Case 2 - returns Case 1
                 i.e., jit()(function)(*args, **kwargs)
                 """
                 return jit(func)
+
             return partial_inner
+
     HAS_JIT = False
+
 
 def simport(modname):
     """
@@ -58,7 +53,7 @@ def simport(modname):
     -----------
     modname : str
               module name needed to import
-    
+
     Returns
     --------
     tuple of (True, Module) or (False, None) depending on whether the import
@@ -70,7 +65,6 @@ def simport(modname):
     allow the module to be used without necessarily attaching it permanently in
     the global namespace:
 
-    
         for t,mod in simport('pandas'):
             if t:
                 mod.DataFrame()
@@ -89,10 +83,11 @@ def simport(modname):
     The first idiom makes it work kind of a like a with statement.
     """
     try:
-        exec('import {}'.format(modname))
-        return True, eval(modname)
-    except:
+        mod = importlib.import_module(modname)
+        return True, mod
+    except (ModuleNotFoundError, ImportError):
         return False, None
+
 
 def requires(*args, **kwargs):
     """
@@ -110,19 +105,21 @@ def requires(*args, **kwargs):
     Original function is all arg in args are importable, otherwise returns a
     function that passes.
     """
-    v = kwargs.pop('verbose', True)
+    v = kwargs.pop("verbose", True)
     wanted = copy.deepcopy(args)
+
     def inner(function):
         available = [simport(arg)[0] for arg in args]
         if all(available):
             return function
         else:
-            def passer(*args,**kwargs):
+
+            def passer(*args, **kwargs):  # noqa: ARG001
                 if v:
                     missing = [arg for i, arg in enumerate(wanted) if not available[i]]
-                    print(('missing dependencies: {d}'.format(d=missing)))
-                    print(('not running {}'.format(function.__name__)))
-                else:
-                    pass
+                    print(f"missing dependencies: {missing}")
+                    print(f"not running {function.__name__}")
+
             return passer
+
     return inner


### PR DESCRIPTION
## Summary

The pysal/base.py and pysal/lib/common.py modules use outdated Python patterns that should be modernized for better security, maintainability, and to follow current best practices.

## Problems Identified

### 1. Custom `cached_property` implementation (pysal/base.py, lines 23-39)

PySAL defines its own `cached_property` class, but since PySAL requires Python >= 3.10 (per [pyproject.toml](cci:7://file:///D:/Projects2.0/Gsoc/NumFocus/pysal/pyproject.toml:0:0-0:0)), the standard library's `functools.cached_property` (available since Python 3.8) should be used instead.

### 2. Unsafe use of `exec()` and `eval()` (pysal/base.py, pysal/lib/common.py)

The codebase uses `exec()` and `eval()` for dynamic module imports:

```python
# In base.py
def _installed_version(package):
    try:
        exec(f'import {package}')
    except ModuleNotFoundError:
        v = 'NA'
    try:
        v = eval(f'{package}.__version__')
    except AttributeError:
        v = 'NA'
    return v