### PR TITLE
test: add comprehensive test coverage for base and lib.common modules

### DIFF
--- a/pysal/tests/test_base.py
+++ b/pysal/tests/test_base.py
@@ -1,0 +1,149 @@
+"""
+Tests for pysal.base module functionality.
+
+This module provides test coverage for:
+- _installed_version() function
+- _installed_versions() function
+- Versions class and its methods
+- federation_hierarchy and memberships data structures
+"""
+
+from pysal.base import (
+    Versions,
+    _installed_version,
+    _installed_versions,
+    federation_hierarchy,
+    memberships,
+)
+
+
+class TestFederationHierarchy:
+    """Tests for the federation_hierarchy data structure."""
+
+    def test_federation_hierarchy_has_required_layers(self):
+        """Test that all expected layers exist in federation_hierarchy."""
+        expected_layers = {"explore", "model", "viz", "lib"}
+        assert set(federation_hierarchy.keys()) == expected_layers
+
+    def test_explore_layer_contains_expected_packages(self):
+        """Test that explore layer contains core packages."""
+        explore_packages = federation_hierarchy["explore"]
+        assert "esda" in explore_packages
+        assert "giddy" in explore_packages
+        assert "pointpats" in explore_packages
+
+    def test_model_layer_contains_expected_packages(self):
+        """Test that model layer contains core packages."""
+        model_packages = federation_hierarchy["model"]
+        assert "spreg" in model_packages
+        assert "mgwr" in model_packages
+
+    def test_viz_layer_contains_expected_packages(self):
+        """Test that viz layer contains core packages."""
+        viz_packages = federation_hierarchy["viz"]
+        assert "splot" in viz_packages
+        assert "mapclassify" in viz_packages
+
+    def test_lib_layer_contains_libpysal(self):
+        """Test that lib layer contains libpysal."""
+        assert "libpysal" in federation_hierarchy["lib"]
+
+
+class TestMemberships:
+    """Tests for the memberships mapping."""
+
+    def test_memberships_is_dict(self):
+        """Test that memberships is a dictionary."""
+        assert isinstance(memberships, dict)
+
+    def test_memberships_maps_packages_to_layers(self):
+        """Test that packages are correctly mapped to their layers."""
+        assert memberships.get("esda") == "explore"
+        assert memberships.get("spreg") == "model"
+        assert memberships.get("splot") == "viz"
+        assert memberships.get("libpysal") == "lib"
+
+    def test_all_hierarchy_packages_in_memberships(self):
+        """Test that all packages in hierarchy are in memberships."""
+        for layer, packages in federation_hierarchy.items():
+            for package in packages:
+                assert package in memberships
+                # Note: 'access' appears in both 'explore' and 'model' layers
+                # The last assignment wins, so 'access' maps to 'model'
+                if package == "access":
+                    assert memberships[package] in ("explore", "model")
+                else:
+                    assert memberships[package] == layer
+
+
+class TestInstalledVersion:
+    """Tests for the _installed_version function."""
+
+    def test_installed_version_returns_string(self):
+        """Test that _installed_version returns a string."""
+        result = _installed_version("libpysal")
+        assert isinstance(result, str)
+
+    def test_installed_version_for_installed_package(self):
+        """Test version detection for an installed package."""
+        version = _installed_version("libpysal")
+        assert version != "NA"
+        assert "." in version  # Version should contain dots (e.g., "4.13.0")
+
+    # Note: test for nonexistent package is omitted because the current
+    # implementation has a bug (NameError instead of returning 'NA').
+    # This will be fixed in a separate PR.
+
+    def test_installed_version_for_numpy(self):
+        """Test version detection for numpy (commonly installed)."""
+        version = _installed_version("numpy")
+        assert version != "NA"
+
+
+class TestInstalledVersions:
+    """Tests for the _installed_versions function."""
+
+    def test_installed_versions_returns_dict(self):
+        """Test that _installed_versions returns a dictionary."""
+        versions = _installed_versions()
+        assert isinstance(versions, dict)
+
+    def test_installed_versions_contains_all_packages(self):
+        """Test that all federation packages are in the result."""
+        versions = _installed_versions()
+        for package in memberships:
+            assert package in versions
+
+    def test_installed_versions_values_are_strings(self):
+        """Test that all version values are strings."""
+        versions = _installed_versions()
+        for _package, version in versions.items():
+            assert isinstance(version, str)
+
+
+class TestVersionsClass:
+    """Tests for the Versions class."""
+
+    def test_versions_instance_creation(self):
+        """Test that Versions can be instantiated."""
+        v = Versions()
+        assert v is not None
+
+    def test_versions_installed_property(self):
+        """Test that installed property returns a dictionary."""
+        v = Versions()
+        installed = v.installed
+        assert isinstance(installed, dict)
+        assert len(installed) > 0
+
+    def test_versions_installed_is_cached(self):
+        """Test that installed property is cached (same object on repeat access)."""
+        v = Versions()
+        installed1 = v.installed
+        installed2 = v.installed
+        assert installed1 is installed2
+
+    def test_versions_installed_contains_libpysal(self):
+        """Test that installed versions include libpysal."""
+        v = Versions()
+        assert "libpysal" in v.installed

--- a/pysal/tests/test_common.py
+++ b/pysal/tests/test_common.py
@@ -1,0 +1,196 @@
+"""
+Tests for pysal.lib.common module functionality.
+
+This module provides test coverage for:
+- simport() function for safe module imports
+- requires() decorator for dependency checking
+- jit decorator fallback when numba is not available
+- Module-level constants
+"""
+
+from pysal.lib.common import (
+    ATOL,
+    HAS_JIT,
+    MISSINGVALUE,
+    RTOL,
+    PatsyError,
+    jit,
+    requires,
+    simport,
+)
+
+
+class TestConstants:
+    """Tests for module-level constants."""
+
+    def test_rtol_is_float(self):
+        """Test that RTOL is a float."""
+        assert isinstance(RTOL, float)
+        assert RTOL > 0
+
+    def test_atol_is_float(self):
+        """Test that ATOL is a float."""
+        assert isinstance(ATOL, float)
+        assert ATOL > 0
+
+    def test_missingvalue_is_none(self):
+        """Test that MISSINGVALUE is None."""
+        assert MISSINGVALUE is None
+
+    def test_has_jit_is_boolean(self):
+        """Test that HAS_JIT is a boolean."""
+        assert isinstance(HAS_JIT, bool)
+
+    def test_patsyerror_is_exception_type(self):
+        """Test that PatsyError is an exception type."""
+        assert issubclass(PatsyError, BaseException)
+
+
+class TestSimport:
+    """Tests for the simport function."""
+
+    def test_simport_returns_tuple(self):
+        """Test that simport returns a tuple."""
+        result = simport("os")
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+
+    def test_simport_success_for_stdlib_module(self):
+        """Test successful import of standard library module."""
+        success, module = simport("os")
+        assert success is True
+        assert module is not None
+        assert hasattr(module, "path")
+
+    def test_simport_success_for_numpy(self):
+        """Test successful import of numpy."""
+        success, module = simport("numpy")
+        assert success is True
+        assert module is not None
+        assert hasattr(module, "array")
+
+    def test_simport_failure_for_nonexistent_module(self):
+        """Test failed import of nonexistent module."""
+        success, module = simport("nonexistent_fake_module_xyz123")
+        assert success is False
+        assert module is None
+
+    def test_simport_success_for_submodule(self):
+        """Test successful import of submodule."""
+        success, module = simport("os.path")
+        assert success is True
+        assert module is not None
+
+    def test_simport_with_libpysal(self):
+        """Test import of libpysal."""
+        success, module = simport("libpysal")
+        assert success is True
+        assert module is not None
+
+
+class TestJitDecorator:
+    """Tests for the jit decorator (fallback when numba not available)."""
+
+    def test_jit_decorator_returns_callable(self):
+        """Test that jit decorator returns a callable."""
+
+        @jit
+        def sample_function(x):
+            return x * 2
+
+        assert callable(sample_function)
+
+    def test_jit_decorated_function_works(self):
+        """Test that jit-decorated function executes correctly."""
+
+        @jit
+        def add_numbers(a, b):
+            return a + b
+
+        result = add_numbers(2, 3)
+        assert result == 5
+
+    def test_jit_with_kwargs(self):
+        """Test jit decorator with keyword arguments (numba-style)."""
+
+        @jit(nopython=True, cache=True)
+        def multiply(x, y):
+            return x * y
+
+        assert callable(multiply)
+        assert multiply(3, 4) == 12
+
+    def test_jit_preserves_function_behavior(self):
+        """Test that jit doesn't alter function behavior."""
+
+        def original(x):
+            return x**2
+
+        decorated = jit(original)
+        for val in [0, 1, 2, 5, 10]:
+            assert decorated(val) == original(val)
+
+
+class TestRequiresDecorator:
+    """Tests for the requires decorator."""
+
+    def test_requires_with_available_module(self):
+        """Test requires decorator with available module."""
+
+        @requires("os")
+        def function_needing_os():
+            return "success"
+
+        result = function_needing_os()
+        assert result == "success"
+
+    def test_requires_with_multiple_available_modules(self):
+        """Test requires decorator with multiple available modules."""
+
+        @requires("os", "sys", "json")
+        def function_needing_multiple():
+            return "all available"
+
+        result = function_needing_multiple()
+        assert result == "all available"
+
+    def test_requires_with_unavailable_module(self, capsys):
+        """Test requires decorator with unavailable module."""
+
+        @requires("nonexistent_fake_module_xyz123", verbose=True)
+        def function_needing_fake():
+            return "should not reach here"
+
+        # Call the passer function
+        function_needing_fake()
+
+        # Check that warning was printed
+        captured = capsys.readouterr()
+        assert "missing dependencies" in captured.out
+        assert "nonexistent_fake_module_xyz123" in captured.out
+
+    def test_requires_with_verbose_false(self, capsys):
+        """Test requires decorator with verbose=False."""
+
+        @requires("nonexistent_fake_module_xyz123", verbose=False)
+        def silent_function():
+            return "should not reach here"
+
+        # Call the passer function
+        silent_function()
+
+        # Check that no warning was printed
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+    def test_requires_mixed_availability(self, capsys):
+        """Test requires with mix of available and unavailable modules."""
+
+        @requires("os", "nonexistent_fake_module_xyz123", verbose=True)
+        def mixed_function():
+            return "should not reach here"
+
+        mixed_function()
+
+        captured = capsys.readouterr()
+        assert "missing dependencies" in captured.out


### PR DESCRIPTION
## Summary

The [pysal/base.py] and [pysal/lib/common.py] modules have no dedicated test coverage. Currently, `pysal/tests/` only contains [test_imports.py] with a single test for package imports. (Fixes #1388)

## Current State

- [pysal/tests/test_imports.py] - 1 test (only tests that federation packages can be imported)
- No tests for utility functions in [base.py] and [lib/common.py]

## Missing Test Coverage

### pysal/base.py
- [federation_hierarchy] data structure
- [memberships] mapping
- [_installed_version()] function
- [_installed_versions()] function
- [Versions] class and its methods ([installed], [released], [check()]
- [cached_property] descriptor

### pysal/lib/common.py
- [simport()] safe import function
- [requires()] decorator for dependency checking
- [jit] decorator fallback (when numba is not available)
- Module constants (`RTOL`, `ATOL`, `MISSINGVALUE`, `HAS_JIT`, `PatsyError`)

## Proposed Solution

Add comprehensive test files:
- [pysal/tests/test_base.py] - ~19 tests
- [pysal/tests/test_common.py] - ~20 tests

This will significantly improve code coverage and help catch regressions.