### PR TITLE
test: add edge case tests for simport (empty string, None)

### DIFF
--- a/pysal/tests/test_imports.py
+++ b/pysal/tests/test_imports.py
@@ -10,3 +10,14 @@ def test_imports():
         packages = federation_hierarchy[layer]
         for package in packages:
             assert module_exists(package), f"{package} not installed." 
+
+import pytest
+from pysal.lib.common import simport
+
+def test_simport_empty_string():
+    with pytest.raises(Exception):
+        simport("")
+
+def test_simport_none():
+    with pytest.raises(Exception):
+        simport(None)


### PR DESCRIPTION
Hello! Please make sure to check all these boxes before submitting a Pull Request
(PR). Once you have checked the boxes, feel free to remove all text except the
justification in point 6. 

1. [x] You have run tests on this submission locally with [`pytest`](https://docs.pytest.org/en/8.2.x/) (see example command in [`.github/workflows/testing.yml`](https://github.com/pysal/pysal/blob/12ae3c1a59b02e3142d9f9e083c211e8b2fdc314/.github/workflows/testing.yml#L74-L82)).
2. [x] This submission is [formatted](https://docs.astral.sh/ruff/formatter/) and [linted](https://docs.astral.sh/ruff/linter/) with [`ruff`](https://docs.astral.sh/ruff/). Formatting & linting are done automatically if you have [installed](https://pre-commit.com/#3-install-the-git-hook-scripts) the [`.pre-commit-config.yaml`](https://github.com/pysal/pysal/blob/main/.pre-commit-config.yaml) properly in a local environment.
3. [x] If this PR adds or updates the codebase, appropriate adjustments are made to corresponding [docstrings](https://numpydoc.readthedocs.io/en/latest/format.html#overview) and changes are covered (see (1.) above).
4. [x] This pull request is directed to the `pysal/main` branch. **This is important, as any PRs submitted against any other branches will be delayed.**
5. [x] You have [assigned a
   reviewer](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) and added relevant [labels](https://help.github.com/articles/applying-labels-to-issues-and-pull-requests/) (if possible)
6. [x] The justification for this PR is: 
   This PR adds test coverage for the `simport` function to handle edge
      cases such as empty string and None inputs, improving robustness and
      preventing regressions.
