### PR TITLE
Add test for _installed_version with non-existent package

### DIFF
--- a/pysal/tests/test_base.py
+++ b/pysal/tests/test_base.py
@@ -90,9 +90,10 @@ class TestInstalledVersion:
         assert version != "NA"
         assert "." in version  # Version should contain dots (e.g., "4.13.0")
 
-    # Note: test for nonexistent package is omitted because the current
-    # implementation has a bug (NameError instead of returning 'NA').
-    # This will be fixed in a separate PR.
+    def test_installed_version_for_nonexistent_package(self):
+        """Test that _installed_version returns 'NA' for non-existent packages."""
+        version = _installed_version("this_package_does_not_exist")
+        assert version == "NA"
 
     def test_installed_version_for_numpy(self):
         """Test version detection for numpy (commonly installed)."""
@@ -147,3 +148,4 @@ class TestVersionsClass:
         """Test that installed versions include libpysal."""
         v = Versions()
         assert "libpysal" in v.installed
+


### PR DESCRIPTION
This PR adds missing test coverage for _installed_version() when a non-existent
package name is provided, asserting that the function correctly returns "NA".

The function already behaves as expected; this change only adds a test and
removes outdated assumptions about a previously mentioned bug.

