### PR TITLE
fix: remove access from explore tier in federation_hierarchy

### DIFF
--- a/pysal/base.py
+++ b/pysal/base.py
@@ -13,7 +13,6 @@ federation_hierarchy = {
         "pointpats",
         "inequality",
         "spaghetti",
-        "access",
         "momepy",
     ],
     "model": [

--- a/pysal/tests/test_base.py
+++ b/pysal/tests/test_base.py
@@ -86,6 +86,7 @@ class TestInstalledVersion:
         assert "." in version  # Version should contain dots (e.g., "4.13.0")
 
     def test_installed_version_for_nonexistent_package(self):
+        """Test version detection for a nonexistent package."""
         result = _installed_version("__nonexistent_package_xyz__")
         assert result == "NA"
 

--- a/pysal/tests/test_base.py
+++ b/pysal/tests/test_base.py
@@ -68,12 +68,7 @@ class TestMemberships:
         for layer, packages in federation_hierarchy.items():
             for package in packages:
                 assert package in memberships
-                # Note: 'access' appears in both 'explore' and 'model' layers
-                # The last assignment wins, so 'access' maps to 'model'
-                if package == "access":
-                    assert memberships[package] in ("explore", "model")
-                else:
-                    assert memberships[package] == layer
+                assert memberships[package] == layer
 
 
 class TestInstalledVersion:
@@ -90,9 +85,9 @@ class TestInstalledVersion:
         assert version != "NA"
         assert "." in version  # Version should contain dots (e.g., "4.13.0")
 
-    # Note: test for nonexistent package is omitted because the current
-    # implementation has a bug (NameError instead of returning 'NA').
-    # This will be fixed in a separate PR.
+    def test_installed_version_for_nonexistent_package(self):
+        result = _installed_version("__nonexistent_package_xyz__")
+        assert result == "NA"
 
     def test_installed_version_for_numpy(self):
         """Test version detection for numpy (commonly installed)."""


### PR DESCRIPTION
fixes #1424.

`access` was listed in both `explore` and `model` tiers of `federation_hierarchy`, causing Python's dict assignment to silently discard the `explore` entry so `memberships["access"]` always resolved to `"model"` regardless of iteration order. The duplicate `explore` entry is removed, aligning the data structure with the `__init__.py` docstring and pysal.org which place `access` exclusively under `model`.
